### PR TITLE
Add secret file config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/moonbridge"
 cp config.example.yml "${XDG_CONFIG_HOME:-$HOME/.config}/moonbridge/config.yml"
 ```
 
-编辑 `config.yml`，至少填入一个上游 Provider 的 `base_url` 和 `api_key`。
+编辑 `config.yml`，至少填入一个上游 Provider 的 `base_url` 和 `api_key`。密钥也可以用同名 `*_file` 字段从文件读取，例如 Docker Secret 路径 `/run/secrets/provider_api_key`；同一个密钥的 inline 字段和 `*_file` 不能同时配置。
 
 最小的可工作配置：
 
@@ -69,6 +69,7 @@ providers:
   my-provider:
     base_url: "https://api.example.com"
     api_key: "sk-..."
+    # api_key_file: "/run/secrets/provider_api_key"
     # 协议：默认 "anthropic"，设为 "openai-response" 可直通 OpenAI Responses API
     # protocol: "anthropic"
     offers:
@@ -154,12 +155,14 @@ providers:
   deepseek:
     base_url: "https://api.deepseek.com/anthropic"
     api_key: "replace-with-deepseek-api-key"
+    # api_key_file: "/run/secrets/provider_api_key"
     version: "2023-06-01"
     offers:
       - model: deepseek-v4-pro
   openai:
     base_url: "https://api.openai.com"
     api_key: "replace-with-openai-api-key"
+    # api_key_file: "/run/secrets/provider_api_key"
     protocol: "openai-response"
     offers:
       - model: gpt-image-1.5
@@ -394,6 +397,7 @@ proxy:
     model: "gpt-5.5"
     base_url: "https://api.openai.com"
     api_key: "sk-..."
+    # api_key_file: "/run/secrets/provider_api_key"
 ```
 
 ### CaptureAnthropic
@@ -416,6 +420,7 @@ proxy:
     model: "claude-sonnet-4-6"
     base_url: "https://api.anthropic.com"
     api_key: "sk-ant-..."
+    # api_key_file: "/run/secrets/provider_api_key"
     version: "2023-06-01"
 ```
 
@@ -478,13 +483,16 @@ web_search:
   support: "auto"          # 全局默认，可选 auto/enabled/disabled/injected
   max_uses: 8
   tavily_api_key: "tvly-..."
+  # tavily_api_key_file: "/run/secrets/tavily_api_key"
   firecrawl_api_key: "fc-..."
+  # firecrawl_api_key_file: "/run/secrets/firecrawl_api_key"
   search_max_rounds: 5
 
 providers:
   anthropic:
     base_url: "https://api.anthropic.com"
     api_key: "sk-ant-..."
+    # api_key_file: "/run/secrets/provider_api_key"
     web_search:
       support: "enabled"   # 提供商级覆盖
 ```

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,6 +12,7 @@ server:
   # Set a Bearer token for API authentication. When non-empty, all requests
   # must include an Authorization: Bearer <token> header. If empty, auth is disabled.
   # auth_token: "replace-with-your-secret-token"
+  # auth_token_file: "/run/secrets/server_auth_token"
 
 persistence:
   active_provider: db_sqlite
@@ -72,14 +73,26 @@ defaults:
   max_tokens: 65536
 trace:
   enabled: false
+
+# web_search:
+#   support: "disabled" # auto / enabled / disabled / injected
+#   max_uses: 8
+#   tavily_api_key: "replace-with-tavily-api-key"
+#   tavily_api_key_file: "/run/secrets/tavily_api_key"
+#   firecrawl_api_key: "replace-with-firecrawl-api-key"
+#   firecrawl_api_key_file: "/run/secrets/firecrawl_api_key"
+#   search_max_rounds: 5
+
 proxy:
   response:
     base_url: "https://api.openai.com"
     api_key: "replace-with-real-openai-responses-api-key"
+    # api_key_file: "/run/secrets/provider_api_key"
     model: "gpt-5.4"
   anthropic:
     base_url: "https://provider.example.com"
     api_key: "replace-with-real-anthropic-compatible-api-key"
+    # api_key_file: "/run/secrets/provider_api_key"
     version: "2023-06-01"
 models:
   deepseek-v4-pro:
@@ -148,6 +161,7 @@ providers:
   deepseek:
     base_url: "https://api.deepseek.com/anthropic"
     api_key: "replace-with-deepseek-api-key"
+    # api_key_file: "/run/secrets/provider_api_key"
     version: "2023-06-01"
     user_agent: "moonbridge/1.0"
     web_search:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,6 +18,11 @@ services:
       - ./data:/app/data
       - ./logs:/app/logs
       - ./trace:/app/trace
+    # To use providers.<name>.api_key_file: "/run/secrets/provider_api_key",
+    # create ./secrets/provider_api_key and uncomment this block plus the
+    # top-level secrets block below.
+    # secrets:
+    #   - provider_api_key
     healthcheck:
       test:
         - CMD
@@ -31,3 +36,7 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+# secrets:
+#   provider_api_key:
+#     file: ./secrets/provider_api_key

--- a/internal/foundation/config/config_loader.go
+++ b/internal/foundation/config/config_loader.go
@@ -88,8 +88,9 @@ type TraceFileConfig struct {
 }
 
 type ServerFileConfig struct {
-	Addr      string `yaml:"addr" json:"addr,omitempty"`
-	AuthToken string `yaml:"auth_token" json:"auth_token,omitempty"`
+	Addr          string `yaml:"addr" json:"addr,omitempty"`
+	AuthToken     string `yaml:"auth_token" json:"auth_token,omitempty"`
+	AuthTokenFile string `yaml:"auth_token_file" json:"auth_token_file,omitempty"`
 }
 
 type LogFileConfig struct {
@@ -120,33 +121,34 @@ type ModelDefFileConfig struct {
 }
 
 type OfferFileConfig struct {
-	Model        string                  `yaml:"model" json:"model"`
-	UpstreamName string                  `yaml:"upstream_name,omitempty" json:"upstream_name,omitempty"`
-	Priority     int                     `yaml:"priority,omitempty" json:"priority,omitempty"`
-	Pricing      ModelPricingFileConfig  `yaml:"pricing,omitempty" json:"pricing,omitempty"`
-	Overrides    *ModelDefFileConfig     `yaml:"overrides,omitempty" json:"overrides,omitempty"`
+	Model        string                 `yaml:"model" json:"model"`
+	UpstreamName string                 `yaml:"upstream_name,omitempty" json:"upstream_name,omitempty"`
+	Priority     int                    `yaml:"priority,omitempty" json:"priority,omitempty"`
+	Pricing      ModelPricingFileConfig `yaml:"pricing,omitempty" json:"pricing,omitempty"`
+	Overrides    *ModelDefFileConfig    `yaml:"overrides,omitempty" json:"overrides,omitempty"`
 }
 
 type ProviderDefFileConfig struct {
-	BaseURL    string                           `yaml:"base_url" json:"base_url"`
-	APIKey     string                           `yaml:"api_key" json:"api_key"`
-	Version    string                           `yaml:"version,omitempty" json:"version,omitempty"`
-	UserAgent  string                           `yaml:"user_agent,omitempty" json:"user_agent,omitempty"`
-	Protocol   string                           `yaml:"protocol,omitempty" json:"protocol,omitempty"`
-	WebSearch  WebSearchFileConfig              `yaml:"web_search,omitempty" json:"web_search,omitempty"`
-	Extensions map[string]ExtensionFileConfig   `yaml:"extensions,omitempty" json:"extensions,omitempty"`
-	Offers     []OfferFileConfig                `yaml:"offers,omitempty" json:"offers,omitempty"`
+	BaseURL    string                         `yaml:"base_url" json:"base_url"`
+	APIKey     string                         `yaml:"api_key" json:"api_key"`
+	APIKeyFile string                         `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
+	Version    string                         `yaml:"version,omitempty" json:"version,omitempty"`
+	UserAgent  string                         `yaml:"user_agent,omitempty" json:"user_agent,omitempty"`
+	Protocol   string                         `yaml:"protocol,omitempty" json:"protocol,omitempty"`
+	WebSearch  WebSearchFileConfig            `yaml:"web_search,omitempty" json:"web_search,omitempty"`
+	Extensions map[string]ExtensionFileConfig `yaml:"extensions,omitempty" json:"extensions,omitempty"`
+	Offers     []OfferFileConfig              `yaml:"offers,omitempty" json:"offers,omitempty"`
 }
 
 type RouteFileConfig struct {
-	To            string                           `yaml:"to,omitempty" json:"to,omitempty"` // backward compat "provider/model"
-	Model         string                           `yaml:"model,omitempty" json:"model,omitempty"`
-	Provider      string                           `yaml:"provider,omitempty" json:"provider,omitempty"`
-	DisplayName   string                           `yaml:"display_name,omitempty" json:"display_name,omitempty"`
-	Description   string                           `yaml:"description,omitempty" json:"description,omitempty"`
-	ContextWindow int                              `yaml:"context_window,omitempty" json:"context_window,omitempty"`
-	WebSearch     WebSearchFileConfig              `yaml:"web_search,omitempty" json:"web_search,omitempty"`
-	Extensions    map[string]ExtensionFileConfig   `yaml:"extensions,omitempty" json:"extensions,omitempty"`
+	To            string                         `yaml:"to,omitempty" json:"to,omitempty"` // backward compat "provider/model"
+	Model         string                         `yaml:"model,omitempty" json:"model,omitempty"`
+	Provider      string                         `yaml:"provider,omitempty" json:"provider,omitempty"`
+	DisplayName   string                         `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description   string                         `yaml:"description,omitempty" json:"description,omitempty"`
+	ContextWindow int                            `yaml:"context_window,omitempty" json:"context_window,omitempty"`
+	WebSearch     WebSearchFileConfig            `yaml:"web_search,omitempty" json:"web_search,omitempty"`
+	Extensions    map[string]ExtensionFileConfig `yaml:"extensions,omitempty" json:"extensions,omitempty"`
 }
 
 func (cfg *RouteFileConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -187,11 +189,13 @@ type ReasoningLevelPresetFileConfig struct {
 }
 
 type WebSearchFileConfig struct {
-	Support         string `yaml:"support" json:"support,omitempty"`
-	MaxUses         int    `yaml:"max_uses" json:"max_uses,omitempty"`
-	TavilyAPIKey    string `yaml:"tavily_api_key" json:"tavily_api_key,omitempty"`
-	FirecrawlAPIKey string `yaml:"firecrawl_api_key" json:"firecrawl_api_key,omitempty"`
-	SearchMaxRounds int    `yaml:"search_max_rounds" json:"search_max_rounds,omitempty"`
+	Support             string `yaml:"support" json:"support,omitempty"`
+	MaxUses             int    `yaml:"max_uses" json:"max_uses,omitempty"`
+	TavilyAPIKey        string `yaml:"tavily_api_key" json:"tavily_api_key,omitempty"`
+	TavilyAPIKeyFile    string `yaml:"tavily_api_key_file" json:"tavily_api_key_file,omitempty"`
+	FirecrawlAPIKey     string `yaml:"firecrawl_api_key" json:"firecrawl_api_key,omitempty"`
+	FirecrawlAPIKeyFile string `yaml:"firecrawl_api_key_file" json:"firecrawl_api_key_file,omitempty"`
+	SearchMaxRounds     int    `yaml:"search_max_rounds" json:"search_max_rounds,omitempty"`
 }
 
 type PersistenceFileConfig struct {
@@ -218,10 +222,11 @@ type ProxyFileConfig struct {
 }
 
 type ProxyTargetFileConfig struct {
-	BaseURL string `yaml:"base_url" json:"base_url"`
-	APIKey  string `yaml:"api_key" json:"api_key"`
-	Model   string `yaml:"model,omitempty" json:"model,omitempty"`
-	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+	BaseURL    string `yaml:"base_url" json:"base_url"`
+	APIKey     string `yaml:"api_key" json:"api_key"`
+	APIKeyFile string `yaml:"api_key_file,omitempty" json:"api_key_file,omitempty"`
+	Model      string `yaml:"model,omitempty" json:"model,omitempty"`
+	Version    string `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
 // ---- Loading functions ----
@@ -235,6 +240,7 @@ func LoadFromFileWithOptions(path string, opts LoadOptions) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("read config %s: %w", path, err)
 	}
+	opts.ConfigDir = filepath.Dir(path)
 	fileConfig, err := decodeFileConfig(data)
 	if err != nil {
 		return Config{}, err
@@ -293,6 +299,9 @@ func FromFileConfig(fileConfig FileConfig) (Config, error) {
 }
 
 func FromFileConfigWithOptions(fileConfig FileConfig, opts LoadOptions) (Config, error) {
+	if err := resolveSecretFiles(&fileConfig, opts); err != nil {
+		return Config{}, err
+	}
 	specs, err := newExtensionSpecIndex(opts.ExtensionSpecs)
 	if err != nil {
 		return Config{}, err
@@ -377,6 +386,107 @@ func FromFileConfigWithOptions(fileConfig FileConfig, opts LoadOptions) (Config,
 		return Config{}, err
 	}
 	return cfg, nil
+}
+
+func resolveSecretFiles(fileConfig *FileConfig, opts LoadOptions) error {
+	var err error
+	if fileConfig.Server.AuthToken, err = secretValue(fileConfig.Server.AuthToken, fileConfig.Server.AuthTokenFile, "server.auth_token", "server.auth_token_file", opts); err != nil {
+		return err
+	}
+	if err := resolveWebSearchSecretFiles(&fileConfig.WebSearch, "web_search", opts); err != nil {
+		return err
+	}
+	for modelName, model := range fileConfig.Models {
+		path := "models." + modelName
+		if err := resolveWebSearchSecretFiles(&model.WebSearch, path+".web_search", opts); err != nil {
+			return err
+		}
+		fileConfig.Models[modelName] = model
+	}
+	for providerName, def := range fileConfig.Providers {
+		path := "providers." + providerName
+		if def.APIKey, err = secretValue(def.APIKey, def.APIKeyFile, path+".api_key", path+".api_key_file", opts); err != nil {
+			return err
+		}
+		if err := resolveWebSearchSecretFiles(&def.WebSearch, path+".web_search", opts); err != nil {
+			return err
+		}
+		for i, offer := range def.Offers {
+			if offer.Overrides != nil {
+				offerPath := fmt.Sprintf("%s.offers[%d].overrides.web_search", path, i)
+				if err := resolveWebSearchSecretFiles(&offer.Overrides.WebSearch, offerPath, opts); err != nil {
+					return err
+				}
+				def.Offers[i] = offer
+			}
+		}
+		fileConfig.Providers[providerName] = def
+	}
+	for routeName, route := range fileConfig.Routes {
+		path := "routes." + routeName
+		if err := resolveWebSearchSecretFiles(&route.WebSearch, path+".web_search", opts); err != nil {
+			return err
+		}
+		fileConfig.Routes[routeName] = route
+	}
+	if fileConfig.Proxy.Response.APIKey, err = secretValue(
+		fileConfig.Proxy.Response.APIKey,
+		fileConfig.Proxy.Response.APIKeyFile,
+		"proxy.response.api_key",
+		"proxy.response.api_key_file",
+		opts,
+	); err != nil {
+		return err
+	}
+	if fileConfig.Proxy.Anthropic.APIKey, err = secretValue(
+		fileConfig.Proxy.Anthropic.APIKey,
+		fileConfig.Proxy.Anthropic.APIKeyFile,
+		"proxy.anthropic.api_key",
+		"proxy.anthropic.api_key_file",
+		opts,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveWebSearchSecretFiles(ws *WebSearchFileConfig, path string, opts LoadOptions) error {
+	var err error
+	if ws.TavilyAPIKey, err = secretValue(ws.TavilyAPIKey, ws.TavilyAPIKeyFile, path+".tavily_api_key", path+".tavily_api_key_file", opts); err != nil {
+		return err
+	}
+	if ws.FirecrawlAPIKey, err = secretValue(ws.FirecrawlAPIKey, ws.FirecrawlAPIKeyFile, path+".firecrawl_api_key", path+".firecrawl_api_key_file", opts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func secretValue(inlineValue, fileValue, inlinePath, filePath string, opts LoadOptions) (string, error) {
+	inline := strings.TrimSpace(inlineValue)
+	secretPath := strings.TrimSpace(fileValue)
+	if inline != "" && secretPath != "" {
+		return "", fmt.Errorf("%s and %s are mutually exclusive", inlinePath, filePath)
+	}
+	if secretPath == "" {
+		return inline, nil
+	}
+	resolvedPath := secretPath
+	if !filepath.IsAbs(resolvedPath) {
+		configDir := strings.TrimSpace(opts.ConfigDir)
+		if configDir == "" {
+			return "", fmt.Errorf("%s requires LoadOptions.ConfigDir when using a relative path", filePath)
+		}
+		resolvedPath = filepath.Join(configDir, resolvedPath)
+	}
+	data, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s %s: %w", filePath, resolvedPath, err)
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		return "", fmt.Errorf("%s %s is empty", filePath, resolvedPath)
+	}
+	return value, nil
 }
 
 // ---- Conversion helpers ----

--- a/internal/foundation/config/config_test.go
+++ b/internal/foundation/config/config_test.go
@@ -130,6 +130,277 @@ func TestXDGDefaultConfigPathFallsBackToHome(t *testing.T) {
 	}
 }
 
+func writeSecretFile(t *testing.T, dir, name, value string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(value), 0600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+	return path
+}
+
+func TestLoadFromFileResolvesServerAuthTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	writeSecretFile(t, dir, "server-token", "  file-token\n")
+	configPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(configPath, []byte(`
+mode: CaptureResponse
+server:
+  auth_token_file: server-token
+proxy:
+  response:
+    model: gpt-capture
+    base_url: https://api.openai.example.test
+    api_key: upstream-openai-key
+`), 0644); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+
+	cfg, err := config.LoadFromFile(configPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
+	if cfg.AuthToken != "file-token" {
+		t.Fatalf("AuthToken = %q, want file-token", cfg.AuthToken)
+	}
+}
+
+func TestLoadFromYAMLResolvesProviderAPIKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeSecretFile(t, dir, "main-key", "\nmain-key\n")
+
+	cfg, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: Transform
+models:
+  claude-test: {}
+providers:
+  main:
+    base_url: https://provider.example.test
+    api_key_file: `+keyPath+`
+    offers:
+      - model: claude-test
+routes:
+  moonbridge:
+    model: claude-test
+    provider: main
+`), config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadFromYAMLWithOptions() error = %v", err)
+	}
+	if cfg.ProviderDefs["main"].APIKey != "main-key" {
+		t.Fatalf("ProviderDefs[main].APIKey = %q, want main-key", cfg.ProviderDefs["main"].APIKey)
+	}
+}
+
+func TestLoadFromYAMLResolvesCaptureProxyAPIKeyFiles(t *testing.T) {
+	dir := t.TempDir()
+	responseKeyPath := writeSecretFile(t, dir, "response-key", "response-key")
+	anthropicKeyPath := writeSecretFile(t, dir, "anthropic-key", "anthropic-key")
+
+	responseCfg, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: CaptureResponse
+proxy:
+  response:
+    model: gpt-capture
+    base_url: https://api.openai.example.test
+    api_key_file: `+responseKeyPath+`
+`), config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadFromYAMLWithOptions(response) error = %v", err)
+	}
+	if responseCfg.ResponseProxy.ProviderAPIKey != "response-key" {
+		t.Fatalf("ResponseProxy.ProviderAPIKey = %q, want response-key", responseCfg.ResponseProxy.ProviderAPIKey)
+	}
+
+	anthropicCfg, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: CaptureAnthropic
+proxy:
+  anthropic:
+    model: claude-test
+    base_url: https://provider.example.test
+    api_key_file: `+anthropicKeyPath+`
+`), config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadFromYAMLWithOptions(anthropic) error = %v", err)
+	}
+	if anthropicCfg.AnthropicProxy.ProviderAPIKey != "anthropic-key" {
+		t.Fatalf("AnthropicProxy.ProviderAPIKey = %q, want anthropic-key", anthropicCfg.AnthropicProxy.ProviderAPIKey)
+	}
+}
+
+func TestLoadFromYAMLResolvesWebSearchAPIKeyFiles(t *testing.T) {
+	dir := t.TempDir()
+	globalTavily := writeSecretFile(t, dir, "global-tavily", "global-tavily")
+	globalFirecrawl := writeSecretFile(t, dir, "global-firecrawl", "global-firecrawl")
+	providerTavily := writeSecretFile(t, dir, "provider-tavily", "provider-tavily")
+	providerFirecrawl := writeSecretFile(t, dir, "provider-firecrawl", "provider-firecrawl")
+	modelTavily := writeSecretFile(t, dir, "model-tavily", "model-tavily")
+	modelFirecrawl := writeSecretFile(t, dir, "model-firecrawl", "model-firecrawl")
+	routeTavily := writeSecretFile(t, dir, "route-tavily", "route-tavily")
+	routeFirecrawl := writeSecretFile(t, dir, "route-firecrawl", "route-firecrawl")
+
+	cfg, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: Transform
+web_search:
+  support: auto
+  tavily_api_key_file: `+globalTavily+`
+  firecrawl_api_key_file: `+globalFirecrawl+`
+models:
+  claude-test:
+    web_search:
+      support: injected
+      tavily_api_key_file: `+modelTavily+`
+      firecrawl_api_key_file: `+modelFirecrawl+`
+providers:
+  main:
+    base_url: https://provider.example.test
+    api_key: upstream-key
+    web_search:
+      support: auto
+      tavily_api_key_file: `+providerTavily+`
+      firecrawl_api_key_file: `+providerFirecrawl+`
+    offers:
+      - model: claude-test
+routes:
+  moonbridge:
+    model: claude-test
+    provider: main
+  route-search:
+    model: claude-test
+    provider: main
+    web_search:
+      support: injected
+      tavily_api_key_file: `+routeTavily+`
+      firecrawl_api_key_file: `+routeFirecrawl+`
+`), config.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadFromYAMLWithOptions() error = %v", err)
+	}
+	if cfg.TavilyAPIKey != "global-tavily" || cfg.FirecrawlAPIKey != "global-firecrawl" {
+		t.Fatalf("global web search keys = %q/%q", cfg.TavilyAPIKey, cfg.FirecrawlAPIKey)
+	}
+	if got := cfg.WebSearchTavilyKeyForProvider("main"); got != "provider-tavily" {
+		t.Fatalf("WebSearchTavilyKeyForProvider(main) = %q", got)
+	}
+	if got := cfg.WebSearchFirecrawlKeyForProvider("main"); got != "provider-firecrawl" {
+		t.Fatalf("WebSearchFirecrawlKeyForProvider(main) = %q", got)
+	}
+	if got := cfg.WebSearchTavilyKeyForModel("moonbridge"); got != "model-tavily" {
+		t.Fatalf("WebSearchTavilyKeyForModel(moonbridge) = %q", got)
+	}
+	if got := cfg.WebSearchFirecrawlKeyForModel("moonbridge"); got != "model-firecrawl" {
+		t.Fatalf("WebSearchFirecrawlKeyForModel(moonbridge) = %q", got)
+	}
+	if got := cfg.WebSearchTavilyKeyForModel("route-search"); got != "route-tavily" {
+		t.Fatalf("WebSearchTavilyKeyForModel(route-search) = %q", got)
+	}
+	if got := cfg.WebSearchFirecrawlKeyForModel("route-search"); got != "route-firecrawl" {
+		t.Fatalf("WebSearchFirecrawlKeyForModel(route-search) = %q", got)
+	}
+}
+
+func TestLoadFromYAMLRejectsInlineAndFileSecretConflict(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeSecretFile(t, dir, "provider-key", "provider-key")
+
+	_, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: Transform
+models:
+  claude-test: {}
+providers:
+  main:
+    base_url: https://provider.example.test
+    api_key: inline-key
+    api_key_file: `+keyPath+`
+    offers:
+      - model: claude-test
+routes:
+  moonbridge:
+    model: claude-test
+    provider: main
+`), config.LoadOptions{})
+	if err == nil {
+		t.Fatal("LoadFromYAMLWithOptions() error = nil, want inline/file conflict")
+	}
+	if !strings.Contains(err.Error(), "providers.main.api_key") || !strings.Contains(err.Error(), "providers.main.api_key_file") {
+		t.Fatalf("LoadFromYAMLWithOptions() error = %v, want field paths", err)
+	}
+}
+
+func TestLoadFromYAMLRejectsMissingSecretFile(t *testing.T) {
+	_, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: CaptureResponse
+proxy:
+  response:
+    model: gpt-capture
+    base_url: https://api.openai.example.test
+    api_key_file: /no/such/provider-key
+`), config.LoadOptions{})
+	if err == nil {
+		t.Fatal("LoadFromYAMLWithOptions() error = nil, want missing file error")
+	}
+	if !strings.Contains(err.Error(), "proxy.response.api_key_file") {
+		t.Fatalf("LoadFromYAMLWithOptions() error = %v, want field path", err)
+	}
+}
+
+func TestLoadFromYAMLRejectsEmptySecretFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := writeSecretFile(t, dir, "empty-key", " \n\t")
+
+	_, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: CaptureAnthropic
+proxy:
+  anthropic:
+    model: claude-test
+    base_url: https://provider.example.test
+    api_key_file: `+keyPath+`
+`), config.LoadOptions{})
+	if err == nil {
+		t.Fatal("LoadFromYAMLWithOptions() error = nil, want empty file error")
+	}
+	if !strings.Contains(err.Error(), "proxy.anthropic.api_key_file") {
+		t.Fatalf("LoadFromYAMLWithOptions() error = %v, want field path", err)
+	}
+}
+
+func TestLoadFromYAMLRejectsRelativeSecretFileWithoutConfigDir(t *testing.T) {
+	_, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: CaptureResponse
+proxy:
+  response:
+    model: gpt-capture
+    base_url: https://api.openai.example.test
+    api_key_file: provider-key
+`), config.LoadOptions{})
+	if err == nil {
+		t.Fatal("LoadFromYAMLWithOptions() error = nil, want relative path error")
+	}
+	if !strings.Contains(err.Error(), "proxy.response.api_key_file") || !strings.Contains(err.Error(), "ConfigDir") {
+		t.Fatalf("LoadFromYAMLWithOptions() error = %v, want ConfigDir field path error", err)
+	}
+}
+
+func TestLoadFromYAMLResolvesRelativeSecretFileWithConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	writeSecretFile(t, dir, "provider-key", "relative-key")
+
+	cfg, err := config.LoadFromYAMLWithOptions([]byte(`
+mode: CaptureResponse
+proxy:
+  response:
+    model: gpt-capture
+    base_url: https://api.openai.example.test
+    api_key_file: provider-key
+`), config.LoadOptions{ConfigDir: dir})
+	if err != nil {
+		t.Fatalf("LoadFromYAMLWithOptions() error = %v", err)
+	}
+	if cfg.ResponseProxy.ProviderAPIKey != "relative-key" {
+		t.Fatalf("ResponseProxy.ProviderAPIKey = %q, want relative-key", cfg.ResponseProxy.ProviderAPIKey)
+	}
+}
+
 func TestLoadFromYAMLCanDisableWebSearch(t *testing.T) {
 	cfg, err := config.LoadFromYAML([]byte(`
 mode: Transform

--- a/internal/foundation/config/extension_config.go
+++ b/internal/foundation/config/extension_config.go
@@ -26,6 +26,7 @@ type ExtensionConfigSpec struct {
 
 type LoadOptions struct {
 	ExtensionSpecs []ExtensionConfigSpec
+	ConfigDir      string
 }
 
 type ExtensionFileConfig struct {


### PR DESCRIPTION
## Summary
- add *_file config fields for server auth, provider keys, web search keys, and proxy keys on the v5 config schema
- resolve relative secret paths from the config file directory or LoadOptions.ConfigDir
- reject inline/file conflicts, missing files, and empty secret files
- document Docker secret usage

## Conflict resolution
- rebased codex/tokenfile onto latest origin/dev
- migrated the original implementation from the old provider/developer.proxy schema to the current top-level providers/models/routes/proxy schema

## Tests
- go test -count=1 ./internal/foundation/config ./internal/service/app ./internal/service/server ./internal/extension/codex