### PR TITLE
🐛 fix: 修复 websearch/visual 编排器 EOF 检测不兼容导致流式传输失败

### DIFF
--- a/internal/extension/websearch/orchestrator.go
+++ b/internal/extension/websearch/orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"moonbridge/internal/foundation/logger"
@@ -396,7 +397,7 @@ func collectStream(stream anthropic.Stream) ([]anthropic.StreamEvent, error) {
 	for {
 		event, err := stream.Next()
 		if err != nil {
-			if err.Error() == "EOF" {
+			if err == io.EOF {
 				break
 			}
 			return events, err
@@ -557,7 +558,7 @@ type staticStream struct {
 
 func (s *staticStream) Next() (anthropic.StreamEvent, error) {
 	if s.pos >= len(s.events) {
-		return anthropic.StreamEvent{}, fmt.Errorf("EOF")
+		return anthropic.StreamEvent{}, io.EOF
 	}
 	event := s.events[s.pos]
 	s.pos++


### PR DESCRIPTION
@
## Summary
- `websearch` 编排器的 `staticStream.Next()` 使用 `fmt.Errorf("EOF")` 返回流结束哨兵，但 `visual` 编排器的 `collectStream` 使用 `err == io.EOF` 指针比较。当 visual 包裹 websearch 时，流结束的 EOF 无法被正确识别，导致流式传输失败（status_code=500 error=EOF）。

## Root Cause
两个编排器对 EOF 检测方式不一致：
- websearch: `staticStream.Next()` 返回 `fmt.Errorf("EOF")`，`collectStream` 用 `err.Error() == "EOF"` 字符串比较
- visual: `stdinStream.Next()` 返回 `io.EOF`，`collectStream` 用 `err == io.EOF` 指针比较

当 visual 调用 websearch 返回的 `staticStream` 时，visual 的 `collectStream` 无法识别 websearch 的 `fmt.Errorf("EOF")`，导致流被中断。

## Changes
- `websearch/orchestrator.go`: `staticStream.Next()` 改为返回标准 `io.EOF`
- `websearch/orchestrator.go`: `collectStream` 改为 `err == io.EOF` 检测
- 添加 `"io"` import

## Test Plan
- [x] `go build ./...` 编译通过
- [x] `go test ./internal/extension/websearch/ ./internal/extension/visual/` 全部通过
- [ ] 重启 moonbridge 后在 Codex CLI 中对话验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@