### PR TITLE
fix: 修复 /v1/responses 假流式输出问题

### DIFF
--- a/internal/protocol/bridge/stream.go
+++ b/internal/protocol/bridge/stream.go
@@ -17,32 +17,54 @@ type StreamOptions struct {
 }
 
 func (bridge *Bridge) ConvertStreamEventsWithContext(events []anthropic.StreamEvent, model string, context codex.ConversionContext, extData map[string]any, opts ...StreamOptions) []openai.StreamEvent {
+	converter := NewStreamConverter(bridge, model, context, opts...)
+	var converted []openai.StreamEvent
+	for _, event := range events {
+		converted = append(converted, converter.ProcessEvent(event)...)
+	}
+	converter.Finalize(extData)
+	return converted
+}
+
+// StreamConverter processes Anthropic stream events incrementally so callers
+// can flush OpenAI response SSE events as soon as they are produced.
+type StreamConverter struct {
+	c *streamConverter
+}
+
+// NewStreamConverter creates a StreamConverter for the given model and context.
+func NewStreamConverter(bridge *Bridge, model string, context codex.ConversionContext, opts ...StreamOptions) *StreamConverter {
 	var opt StreamOptions
 	if len(opts) > 0 {
 		opt = opts[0]
 	}
-	converter := streamConverter{
-		bridge:               bridge,
-		model:                model,
-		persistTextReasoning: opt.PersistFinalTextReasoning,
-		contentText:          map[int]string{},
-		toolArguments:        map[int]string{},
-		itemIDs:              map[int]string{},
-		outputIndexes:        map[int]int{},
-		extStreamStates:      bridge.hooks.NewStreamStates(model),
-		codexStream:          codex.NewStreamAdapter(context),
+	return &StreamConverter{
+		c: &streamConverter{
+			bridge:               bridge,
+			model:                model,
+			persistTextReasoning: opt.PersistFinalTextReasoning,
+			contentText:          map[int]string{},
+			toolArguments:        map[int]string{},
+			itemIDs:              map[int]string{},
+			outputIndexes:        map[int]int{},
+			extStreamStates:      bridge.hooks.NewStreamStates(model),
+			codexStream:          codex.NewStreamAdapter(context),
+		},
 	}
-	var converted []openai.StreamEvent
-	for _, event := range events {
-		converted = append(converted, converter.convert(event)...)
-	}
+}
 
-	// Let extensions persist stream state back to the session.
+// ProcessEvent converts a single Anthropic stream event into zero or more
+// OpenAI Response stream events.
+func (sc *StreamConverter) ProcessEvent(event anthropic.StreamEvent) []openai.StreamEvent {
+	return sc.c.convert(event)
+}
+
+// Finalize persists extension stream state after all events have been
+// processed.
+func (sc *StreamConverter) Finalize(extData map[string]any) {
 	if extData != nil {
-		bridge.hooks.OnStreamComplete(model, converter.extStreamStates, converter.response.OutputText, extData)
+		sc.c.bridge.hooks.OnStreamComplete(sc.c.model, sc.c.extStreamStates, sc.c.response.OutputText, extData)
 	}
-
-	return converted
 }
 
 type streamConverter struct {

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -520,32 +520,46 @@ func (server *Server) handleStream(writer http.ResponseWriter, request *http.Req
 	writer.WriteHeader(http.StatusOK)
 
 	var events []anthropic.StreamEvent
+	var openAIEvents []openai.StreamEvent
 	var streamErr string
+	converter := bridge.NewStreamConverter(
+		server.bridge,
+		responsesRequest.Model,
+		context,
+		bridge.StreamOptions{
+			PersistFinalTextReasoning: hasToolHistory(anthropicRequest.Messages),
+		},
+	)
 	for {
 		event, err := stream.Next()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			events = append(events, anthropic.StreamEvent{Type: "error", Error: &anthropic.ErrorObject{Type: "provider_stream_error", Message: err.Error()}})
+			errEvent := anthropic.StreamEvent{Type: "error", Error: &anthropic.ErrorObject{Type: "provider_stream_error", Message: err.Error()}}
+			events = append(events, errEvent)
 			record.Error = traceError("provider_stream_next", err)
 			log.Error("流式读取错误", "error", err)
 			streamErr = err.Error()
+			result := converter.ProcessEvent(errEvent)
+			openAIEvents = append(openAIEvents, result...)
+			for _, oe := range result {
+				writeSSE(writer, oe)
+			}
 			break
 		}
 		events = append(events, event)
+		result := converter.ProcessEvent(event)
+		openAIEvents = append(openAIEvents, result...)
+		for _, oe := range result {
+			writeSSE(writer, oe)
+		}
 	}
 
-	openAIEvents := server.bridge.ConvertStreamEventsWithContext(events, responsesRequest.Model, context, sess.ExtensionData, bridge.StreamOptions{
-		PersistFinalTextReasoning: hasToolHistory(anthropicRequest.Messages),
-	})
+	converter.Finalize(sess.ExtensionData)
 	record.AnthropicStreamEvents = events
 	record.OpenAIStreamEvents = openAIEvents
 	server.writeTrace(record)
-
-	for _, event := range openAIEvents {
-		writeSSE(writer, event)
-	}
 	usage, billingUsage, inputIncludesCache := anthropicUsageFromStreamEvents(events)
 	if server.stats != nil {
 		server.stats.RecordBilling(responsesRequest.Model, anthropicRequest.Model, billingUsage)


### PR DESCRIPTION
## 说明

修复 `/v1/responses` 在 `stream: true` 下的假流式问题。

在修复前，接口虽然返回的是 `text/event-stream`，但实际处理流程是：

1. 先完整读取上游 stream
2. 再统一转换为 OpenAI Responses SSE event
3. 最后一次性写给客户端

这会导致客户端长时间收不到任何 `data:`，然后在请求接近结束时短时间内刷出全部事件，用户体感上等同于“非实时流式”。

关联 issue：
Closes #20 

---

## 修复内容

这次改动保持为最小修复，只做了两件事：

1. 在 `internal/protocol/bridge/stream.go` 中新增逐事件处理能力
   - 增加 `StreamConverter`
   - 支持按单个上游 event 增量转换为 OpenAI Responses stream events

2. 在 `internal/service/server/server.go` 中调整 `/v1/responses` 的流式处理路径
   - 从“先收集、后转换、再统一写出”
   - 改为“边读、边转、边写、边 flush”

---

## 修复前后的行为对比

### 修复前

```text
first_data_delay=20.118s
stream_duration=0.460s
data_events=513
```

表现为：

- 前 20 秒几乎没有任何输出
- 最后不到 0.5 秒内一次性刷出 513 个 SSE event

### 修复后

```text
first_data_delay=0.405s
stream_duration=9.610s
data_events=535
```

表现为：

- 首包很快返回
- 后续内容持续流式输出
- 行为符合真实流式传输预期

---

## 根因

根因是 `/v1/responses` 的下游 SSE 写出时机过晚。

虽然返回格式本身是合法 SSE，但写出策略不是实时流式，而是请求接近结束后再统一 flush，因此看起来像“假流式”。

---

## 验证

已验证：

```bash
go build ./...
go test ./internal/protocol/bridge ./internal/service/server
```

同时也通过实际 `curl -N` 测试确认修复前后行为差异明显。

---

## 影响范围

这次改动仅针对 `/v1/responses` 的流式写出路径，不包含其他额外行为修改，尽量保持修复范围最小。