### PR TITLE
fix: 修复 start_codex_with_moonbridge.ps1 无法启动的问题

### DIFF
--- a/scripts/start_codex_with_moonbridge.ps1
+++ b/scripts/start_codex_with_moonbridge.ps1
@@ -1,11 +1,3 @@
-Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
-
-if ($MyInvocation.InvocationName -eq ".") {
-    Write-Error "Do not dot-source this script; run it as .\scripts\start_codex_with_moonbridge.ps1 to avoid polluting your shell."
-    return
-}
-
 param(
     [Parameter(Mandatory = $true)]
     [string]$ProjectDirectory,
@@ -13,6 +5,14 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$CodexHome = $(if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME ".codex" })
 )
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($MyInvocation.InvocationName -eq ".") {
+    Write-Error "Do not dot-source this script; run it as .\scripts\start_codex_with_moonbridge.ps1 to avoid polluting your shell."
+    return
+}
 
 $RootDir = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $ConfigFile = if ($env:MOONBRIDGE_CONFIG) { $env:MOONBRIDGE_CONFIG } else { Join-Path $RootDir "config.yml" }
@@ -493,7 +493,7 @@ Write-Log "Press Ctrl+C in this terminal to stop Moon Bridge and the launched Co
 Push-Location $RootDir
 $MoonBridgeStatus = 0
 try {
-    & $ServerBin $ServerBin --config $ConfigFile
+    & $ServerBin --config $ConfigFile
     $MoonBridgeStatus = $LASTEXITCODE
 } finally {
     Stop-CodexTerminal


### PR DESCRIPTION
## 修复内容

修复 `scripts/start_codex_with_moonbridge.ps1` 的两个 bug：

### 1. `param()` 位置错误
PowerShell 要求 `param()` 必须是脚本第一个可执行语句。原脚本将 `Set-StrictMode`、`$ErrorActionPreference` 和 dot-source 检查放在 `param()` 之前，导致报错：
```
param : 无法将"param"项识别为 cmdlet、函数、脚本文件或可运行程序的名称。
```
**修复**：将 `param()` 移至文件最前面。

### 2. 启动命令中 `$ServerBin` 重复
原代码：
```powershell
& $ServerBin $ServerBin --config $ConfigFile
```
第二个 `$ServerBin` 被 Go `flag` 包当作非 flag 参数，导致 flag 解析提前停止，`--config` 实际未生效，最终因 Windows 缺少 `HOME` 环境变量而报错 `HOME is not set and XDG_CONFIG_HOME is empty`。

**修复**：移除重复的 `$ServerBin`。

## 测试
已在 Windows 上实际运行验证，脚本能正常启动 Moon Bridge 和 Codex。