### PR TITLE
修复 Codex 自定义工具调用的协议适配与流程控制问题

### DIFF
--- a/internal/extension/codextool/customtool.go
+++ b/internal/extension/codextool/customtool.go
@@ -86,10 +86,16 @@ func BuildToolMapFromCore(original []format.CoreTool) ToolMap {
 		if kind == "" {
 			continue
 		}
-		m[t.Name] = ToolSpec{
+		spec := ToolSpec{
 			Kind:       ToolKind(kind),
 			OpenAIName: openaiName,
 			Namespace:  ns,
+		}
+		m[t.Name] = spec
+		// Register original name as alias so the model can call either
+		// the proxy name (apply_patch_add_file) or the original (apply_patch).
+		if openaiName != "" && openaiName != t.Name {
+			m[openaiName] = spec
 		}
 	}
 	return m
@@ -110,10 +116,8 @@ func OutputItemFromBlock(
 	switch spec.Kind {
 	case ToolLocalShell:
 		return "local_shell_call", "", "", "", true, toolInput
-	case ToolApplyPatch:
-		return "custom_tool_call", spec.OpenAIName, "", RebuildApplyPatchGrammar(blockName, toolInput), false, nil
-	case ToolExec:
-		return "custom_tool_call", spec.OpenAIName, "", RebuildExecGrammar(toolInput), false, nil
+	case ToolApplyPatch, ToolExec:
+		return "custom_tool_call", spec.OpenAIName, "", RebuildGrammar(blockName, toolInput), false, nil
 	case ToolRaw:
 		return "custom_tool_call", spec.OpenAIName, "", InputFromRaw(toolInput), false, nil
 	case ToolFunction:
@@ -466,10 +470,19 @@ func RebuildExecGrammar(input json.RawMessage) string {
 // RebuildGrammar auto-detects the tool type from the proxy tool name and
 // reconstructs the raw grammar input for custom_tool_call from structured arguments.
 func RebuildGrammar(proxyName string, input json.RawMessage) string {
-	if strings.HasPrefix(proxyName, "apply_patch") {
+	// If the model calls the proxy-expanded name (e.g. apply_patch_add_file),
+	// reconstruct grammar from structured params. If calling the original name
+	// (apply_patch), input is already raw grammar — extract via InputFromRaw.
+	if strings.HasPrefix(proxyName, "apply_patch_") {
 		return RebuildApplyPatchGrammar(proxyName, input)
 	}
-	if proxyName == "exec" || strings.HasPrefix(proxyName, "exec_") {
+	if proxyName == "apply_patch" {
+		return InputFromRaw(input)
+	}
+	if proxyName == "exec" {
+		return InputFromRaw(input)
+	}
+	if strings.HasPrefix(proxyName, "exec_") {
 		return RebuildExecGrammar(input)
 	}
 	return string(input)

--- a/internal/extension/codextool/customtool.go
+++ b/internal/extension/codextool/customtool.go
@@ -1,0 +1,368 @@
+package codextool
+
+import (
+	"encoding/json"
+	"strings"
+
+	"moonbridge/internal/format"
+)
+
+// Grammar helpers
+
+// CustomToolGrammar extracts the grammar definition from a custom tool's Format field.
+func CustomToolGrammar(formatMap map[string]any) string {
+	if formatMap == nil {
+		return ""
+	}
+	d, _ := formatMap["definition"].(string)
+	return strings.TrimSpace(d)
+}
+
+// IsApplyPatchGrammar checks if a grammar definition is for the apply_patch tool.
+func IsApplyPatchGrammar(definition string) bool {
+	return strings.Contains(definition, `begin_patch: "*** Begin Patch"`) &&
+		strings.Contains(definition, `end_patch: "*** End Patch"`) &&
+		strings.Contains(definition, `add_hunk: "*** Add File: "`)
+}
+
+// IsExecGrammar checks if a grammar definition is for the exec tool.
+func IsExecGrammar(definition string) bool {
+	return strings.Contains(definition, "@exec") ||
+		(strings.Contains(definition, "pragma_source") && strings.Contains(definition, "plain_source"))
+}
+
+// NamespacedToolName joins namespace and name with underscore.
+func NamespacedToolName(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
+	if name == "" {
+		return namespace
+	}
+	return namespace + "_" + name
+}
+
+// Simple tool input reading
+
+// InputFromRaw extracts the raw input string from a tool input JSON.
+// It tries {"input":"..."} first, then falls back to parsing the whole message.
+func InputFromRaw(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		if val, ok := obj["input"]; ok {
+			var s string
+			if err := json.Unmarshal(val, &s); err == nil {
+				return s
+			}
+			return string(val)
+		}
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}
+
+// ToolMap building from format.CoreTool
+
+// BuildToolMapFromCore builds a ToolMap from a slice of format.CoreTool.
+// This is called by the adapter after flattening openai.Tools to CoreTools.
+// coreTools must be the flattened list; original is the pre-flattening list
+// used to recover namespace/function info.
+func BuildToolMapFromCore(original []format.CoreTool) ToolMap {
+	m := make(ToolMap)
+	for _, t := range original {
+		if t.Extensions == nil {
+			continue
+		}
+		kind, _ := t.Extensions["codex_tool_kind"].(string)
+		openaiName, _ := t.Extensions["codex_openai_name"].(string)
+		ns, _ := t.Extensions["codex_namespace"].(string)
+		if kind == "" {
+			continue
+		}
+		m[t.Name] = ToolSpec{
+			Kind:       ToolKind(kind),
+			OpenAIName: openaiName,
+			Namespace:  ns,
+		}
+	}
+	return m
+}
+
+// OutputItemFromBlock constructs an output item from a tool_use block using tool metadata.
+// Returns the item type ("function_call", "custom_tool_call", "local_shell_call"),
+// name, namespace, input/arguments string, and action pointer.
+func OutputItemFromBlock(
+	blockName string,
+	toolInput json.RawMessage,
+	toolMap ToolMap,
+) (itemType, itemName, itemNamespace, toolInputStr string, isLocalShell bool, actionJSON json.RawMessage) {
+	spec, ok := toolMap.Lookup(blockName)
+	if !ok {
+		return "function_call", blockName, "", string(toolInput), false, nil
+	}
+	switch spec.Kind {
+	case ToolLocalShell:
+		return "local_shell_call", "", "", "", true, toolInput
+	case ToolApplyPatch, ToolRaw, ToolExec:
+		return "custom_tool_call", spec.OpenAIName, "", InputFromRaw(toolInput), false, nil
+	case ToolFunction:
+		return "function_call", spec.OpenAIName, spec.Namespace, string(toolInput), false, nil
+	default:
+		return "function_call", blockName, "", string(toolInput), false, nil
+	}
+}
+
+// Proxy schema builders (return map[string]any for format.CoreTool.InputSchema)
+
+func ApplyPatchToolActions() []string {
+	return []string{"add_file", "delete_file", "update_file", "replace_file", "batch"}
+}
+
+func ApplyPatchToolName(base, action string) string {
+	if action == "" {
+		return base
+	}
+	return base + "_" + action
+}
+
+func ApplyPatchToolNames(name string) []string {
+	return []string{
+		ApplyPatchToolName(name, "add_file"),
+		ApplyPatchToolName(name, "delete_file"),
+		ApplyPatchToolName(name, "update_file"),
+		ApplyPatchToolName(name, "replace_file"),
+		ApplyPatchToolName(name, "batch"),
+	}
+}
+
+func ApplyPatchProxyCoreTools(name string) []format.CoreTool {
+	return []format.CoreTool{
+		{
+			Name:        ApplyPatchToolName(name, "add_file"),
+			Description: "Create one new file. Moon Bridge reconstructs the raw Codex apply_patch grammar from the result.",
+			InputSchema: ApplyPatchSingleOpSchema("add_file"),
+		},
+		{
+			Name:        ApplyPatchToolName(name, "delete_file"),
+			Description: "Delete one file. Moon Bridge reconstructs the raw Codex apply_patch grammar from the result.",
+			InputSchema: ApplyPatchSingleOpSchema("delete_file"),
+		},
+		{
+			Name:        ApplyPatchToolName(name, "update_file"),
+			Description: "Edit one existing file with structured hunks.",
+			InputSchema: ApplyPatchSingleOpSchema("update_file"),
+		},
+		{
+			Name:        ApplyPatchToolName(name, "replace_file"),
+			Description: "Replace one file entirely.",
+			InputSchema: ApplyPatchSingleOpSchema("replace_file"),
+		},
+		{
+			Name:        ApplyPatchToolName(name, "batch"),
+			Description: "Edit files by providing structured JSON patch operations. Moon Bridge reconstructs the raw Codex apply_patch grammar from the result.",
+			InputSchema: ApplyPatchProxySchema(),
+		},
+	}
+}
+
+func ApplyPatchSingleOpSchema(action string) map[string]any {
+	properties := map[string]any{
+		"path": map[string]any{"type": "string", "description": "Target file path."},
+	}
+	required := []string{"path"}
+	switch action {
+	case "add_file", "replace_file":
+		properties["content"] = map[string]any{"type": "string", "description": "Full file content."}
+		required = append(required, "content")
+	case "update_file":
+		properties["move_to"] = map[string]any{"type": "string", "description": "Optional destination for moves."}
+		properties["hunks"] = ApplyPatchHunksSchema()
+		required = append(required, "hunks")
+	}
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties":           properties,
+		"required":             required,
+	}
+}
+
+func ApplyPatchProxySchema() map[string]any {
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"operations": map[string]any{
+				"type":        "array",
+				"description": "Structured patch operations.",
+				"minItems":    1,
+				"items": map[string]any{
+					"type":                 "object",
+					"additionalProperties": false,
+					"properties": map[string]any{
+						"type":    map[string]any{"type": "string", "enum": []string{"add_file", "delete_file", "update_file", "replace_file"}, "description": "Operation type."},
+						"path":    map[string]any{"type": "string", "description": "Target file path."},
+						"move_to": map[string]any{"type": "string", "description": "Optional destination for moves."},
+						"content": map[string]any{"type": "string", "description": "File content."},
+						"hunks":   ApplyPatchHunksSchema(),
+					},
+					"required": []string{"type", "path"},
+				},
+			},
+		},
+		"required": []string{"operations"},
+	}
+}
+
+func ApplyPatchHunksSchema() map[string]any {
+	return map[string]any{
+		"type":        "array",
+		"description": "Structured update hunks.",
+		"minItems":    1,
+		"items": map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"context": map[string]any{"type": "string", "description": "Context header text."},
+				"lines": map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"type":                 "object",
+						"additionalProperties": false,
+						"properties": map[string]any{
+							"op":   map[string]any{"type": "string", "enum": []string{"context", "add", "remove"}},
+							"text": map[string]any{"type": "string"},
+						},
+						"required": []string{"op", "text"},
+					},
+				},
+			},
+			"required": []string{"lines"},
+		},
+	}
+}
+
+func ExecProxySchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"source": map[string]any{
+				"type":        "string",
+				"description": "JavaScript source code, including any // @exec pragmas if needed.",
+			},
+		},
+		"required": []string{"source"},
+	}
+}
+
+func ExecProxyDescription() string {
+	return "Run the Codex Code Mode exec custom tool by providing structured JSON with a source string."
+}
+
+func LocalShellSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"command": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Command and arguments to execute",
+			},
+			"working_directory": map[string]any{"type": "string", "description": "Working directory"},
+			"timeout_ms":        map[string]any{"type": "integer", "description": "Timeout in milliseconds"},
+			"env": map[string]any{
+				"type":                 "object",
+				"additionalProperties": map[string]any{"type": "string"},
+				"description":          "Environment variables",
+			},
+		},
+		"required": []string{"command"},
+	}
+}
+
+func CustomToolInputSchema(grammar string) map[string]any {
+	description := "Raw freeform input for this custom tool."
+	if grammar != "" {
+		description += "\n\nGrammar:\n" + grammar
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"input": map[string]any{
+				"type":        "string",
+				"description": description,
+			},
+		},
+		"required": []string{"input"},
+	}
+}
+
+// InputSchemaWithFallback returns a schema for known Codex tool names.
+func InputSchemaWithFallback(params map[string]any, toolName string) map[string]any {
+	if len(params) > 0 {
+		return params
+	}
+	switch toolName {
+	case "apply_patch", "patch":
+		return map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"input": map[string]any{"type": "string", "description": "The patch content or operation to apply"},
+			},
+			"required": []string{"input"},
+		}
+	case "exec", "exec_command", "local_shell", "shell":
+		return map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"command": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Command and arguments to execute",
+				},
+				"description": map[string]any{"type": "string"},
+			},
+			"required": []string{"command"},
+		}
+	case "read", "view", "view_image":
+		return map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"file_path": map[string]any{"type": "string"},
+			},
+			"required": []string{"file_path"},
+		}
+	default:
+		return map[string]any{"type": "object"}
+	}
+}
+
+// ToolKindForGrammar returns the ToolKind for a custom tool grammar definition.
+func ToolKindForGrammar(grammar string, toolName string) (ToolKind, bool) {
+	if toolName == "local_shell" {
+		return ToolLocalShell, true
+	}
+	if IsApplyPatchGrammar(grammar) {
+		return ToolApplyPatch, true
+	}
+	if IsExecGrammar(grammar) {
+		return ToolExec, true
+	}
+	return ToolRaw, true
+}
+
+// AnnotateCoreTool sets codex metadata extensions on a CoreTool for reverse mapping.
+func AnnotateCoreTool(t *format.CoreTool, kind ToolKind, openAIName, namespace string) {
+	if t.Extensions == nil {
+		t.Extensions = make(map[string]any)
+	}
+	t.Extensions["codex_tool_kind"] = string(kind)
+	t.Extensions["codex_openai_name"] = openAIName
+	t.Extensions["codex_namespace"] = namespace
+}

--- a/internal/extension/codextool/customtool.go
+++ b/internal/extension/codextool/customtool.go
@@ -86,16 +86,10 @@ func BuildToolMapFromCore(original []format.CoreTool) ToolMap {
 		if kind == "" {
 			continue
 		}
-		spec := ToolSpec{
+		m[t.Name] = ToolSpec{
 			Kind:       ToolKind(kind),
 			OpenAIName: openaiName,
 			Namespace:  ns,
-		}
-		m[t.Name] = spec
-		// Register original name as alias so the model can call either
-		// the proxy name (apply_patch_add_file) or the original (apply_patch).
-		if openaiName != "" && openaiName != t.Name {
-			m[openaiName] = spec
 		}
 	}
 	return m

--- a/internal/extension/codextool/customtool.go
+++ b/internal/extension/codextool/customtool.go
@@ -463,3 +463,14 @@ func RebuildExecGrammar(input json.RawMessage) string {
 	}
 	return p.Source
 }
+// RebuildGrammar auto-detects the tool type from the proxy tool name and
+// reconstructs the raw grammar input for custom_tool_call from structured arguments.
+func RebuildGrammar(proxyName string, input json.RawMessage) string {
+	if strings.HasPrefix(proxyName, "apply_patch") {
+		return RebuildApplyPatchGrammar(proxyName, input)
+	}
+	if proxyName == "exec" || strings.HasPrefix(proxyName, "exec_") {
+		return RebuildExecGrammar(input)
+	}
+	return string(input)
+}

--- a/internal/extension/codextool/customtool.go
+++ b/internal/extension/codextool/customtool.go
@@ -2,6 +2,7 @@ package codextool
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"moonbridge/internal/format"
@@ -109,10 +110,12 @@ func OutputItemFromBlock(
 	switch spec.Kind {
 	case ToolLocalShell:
 		return "local_shell_call", "", "", "", true, toolInput
+	case ToolApplyPatch:
+		return "custom_tool_call", spec.OpenAIName, "", RebuildApplyPatchGrammar(blockName, toolInput), false, nil
+	case ToolExec:
+		return "custom_tool_call", spec.OpenAIName, "", RebuildExecGrammar(toolInput), false, nil
 	case ToolRaw:
 		return "custom_tool_call", spec.OpenAIName, "", InputFromRaw(toolInput), false, nil
-	case ToolApplyPatch, ToolExec:
-		return "function_call", spec.OpenAIName, "", string(toolInput), false, nil
 	case ToolFunction:
 		return "function_call", spec.OpenAIName, spec.Namespace, string(toolInput), false, nil
 	default:
@@ -367,4 +370,96 @@ func AnnotateCoreTool(t *format.CoreTool, kind ToolKind, openAIName, namespace s
 	t.Extensions["codex_tool_kind"] = string(kind)
 	t.Extensions["codex_openai_name"] = openAIName
 	t.Extensions["codex_namespace"] = namespace
+}
+// RebuildApplyPatchGrammar reconstructs the raw apply_patch grammar from
+// a proxy tool name and its structured input, for use as custom_tool_call.input.
+func RebuildApplyPatchGrammar(proxyName string, input json.RawMessage) string {
+	action := strings.TrimPrefix(proxyName, "apply_patch_")
+	if action == proxyName {
+		action = "batch"
+	}
+	switch action {
+	case "add_file", "replace_file":
+		var p struct {
+			Path    string `json:"path"`
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(input, &p); err != nil || p.Path == "" {
+			return string(input)
+		}
+		return fmt.Sprintf("*** Add File: %s\n%s\n*** End Patch", p.Path, p.Content)
+	case "delete_file":
+		var p struct{ Path string `json:"path"` }
+		if err := json.Unmarshal(input, &p); err != nil || p.Path == "" {
+			return string(input)
+		}
+		return fmt.Sprintf("*** Delete File: %s\n*** End Patch", p.Path)
+	case "update_file":
+		var p struct {
+			Path   string `json:"path"`
+			Hunks []map[string]any `json:"hunks"`
+		}
+		if err := json.Unmarshal(input, &p); err != nil || p.Path == "" {
+			return string(input)
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "*** Update File: %s\n", p.Path)
+		for _, hunk := range p.Hunks {
+			ctx, _ := hunk["context"].(string)
+			if ctx != "" {
+				fmt.Fprintf(&b, "*** Context: %s\n", ctx)
+			}
+			if lines, ok := hunk["lines"].([]any); ok {
+				for _, l := range lines {
+					if lm, ok := l.(map[string]any); ok {
+						op, _ := lm["op"].(string)
+						text, _ := lm["text"].(string)
+						switch op {
+						case "add":
+							b.WriteString("+ " + text + "\n")
+						case "remove":
+							b.WriteString("- " + text + "\n")
+						default:
+							b.WriteString("  " + text + "\n")
+						}
+					}
+				}
+			}
+		}
+		fmt.Fprintf(&b, "*** End Patch")
+		return b.String()
+	case "batch":
+		var p struct {
+			Operations []map[string]any `json:"operations"`
+		}
+		if err := json.Unmarshal(input, &p); err != nil {
+			return string(input)
+		}
+		var b strings.Builder
+		for _, op := range p.Operations {
+			opType, _ := op["type"].(string)
+			path, _ := op["path"].(string)
+			switch opType {
+			case "add_file", "replace_file":
+				content, _ := op["content"].(string)
+				fmt.Fprintf(&b, "*** Add File: %s\n%s\n*** End Patch\n", path, content)
+			case "delete_file":
+				fmt.Fprintf(&b, "*** Delete File: %s\n*** End Patch\n", path)
+			case "update_file":
+				fmt.Fprintf(&b, "*** Update File: %s\n*** End Patch\n", path)
+			}
+		}
+		return b.String()
+	default:
+		return string(input)
+	}
+}
+
+// RebuildExecGrammar reconstructs the raw exec grammar from structured input.
+func RebuildExecGrammar(input json.RawMessage) string {
+	var p struct{ Source string `json:"source"` }
+	if err := json.Unmarshal(input, &p); err != nil || p.Source == "" {
+		return string(input)
+	}
+	return p.Source
 }

--- a/internal/extension/codextool/customtool.go
+++ b/internal/extension/codextool/customtool.go
@@ -109,8 +109,10 @@ func OutputItemFromBlock(
 	switch spec.Kind {
 	case ToolLocalShell:
 		return "local_shell_call", "", "", "", true, toolInput
-	case ToolApplyPatch, ToolRaw, ToolExec:
+	case ToolRaw:
 		return "custom_tool_call", spec.OpenAIName, "", InputFromRaw(toolInput), false, nil
+	case ToolApplyPatch, ToolExec:
+		return "function_call", spec.OpenAIName, "", string(toolInput), false, nil
 	case ToolFunction:
 		return "function_call", spec.OpenAIName, spec.Namespace, string(toolInput), false, nil
 	default:

--- a/internal/extension/codextool/tool_context.go
+++ b/internal/extension/codextool/tool_context.go
@@ -1,0 +1,98 @@
+// Package codex provides Codex CLI model catalog and tool compatibility logic.
+//
+// This package centralizes Codex-specific knowledge:
+// - catalog/config generation for Codex CLI
+// - custom tool (namespace, custom, local_shell) conversions
+// - apply_patch/exec proxy expansion for upstream models
+// - response-side reconstruction of Codex output item types
+package codextool
+
+// ToolKind categorizes an expanded Codex tool for response-side reconstruction.
+type ToolKind string
+
+const (
+	ToolApplyPatch ToolKind = "apply_patch"
+	ToolExec       ToolKind = "exec"
+	ToolRaw        ToolKind = "raw"
+	ToolFunction   ToolKind = "function"
+	ToolLocalShell ToolKind = "local_shell"
+	ToolUnknown    ToolKind = "unknown"
+)
+
+// ToolSpec describes an expanded tool entry for reverse mapping.
+type ToolSpec struct {
+	Kind       ToolKind `json:"kind"`
+	OpenAIName string   `json:"openai_name"`
+	Namespace  string   `json:"namespace,omitempty"`
+}
+
+// ToolMap maps from expanded (upstream-facing) tool names back to
+// their original Codex metadata for response-side reconstruction.
+type ToolMap map[string]ToolSpec
+
+// DecodeToolMap decodes a ToolMap from a map[string]any (e.g. from Extensions).
+func DecodeToolMap(raw map[string]any) ToolMap {
+	if raw == nil {
+		return nil
+	}
+	m := make(ToolMap, len(raw))
+	for k, val := range raw {
+		if specMap, ok := val.(map[string]any); ok {
+			spec := ToolSpec{}
+			if kind, ok := specMap["kind"].(string); ok {
+				spec.Kind = ToolKind(kind)
+			}
+			if name, ok := specMap["openai_name"].(string); ok {
+				spec.OpenAIName = name
+			}
+			if ns, ok := specMap["namespace"].(string); ok {
+				spec.Namespace = ns
+			}
+			m[k] = spec
+		}
+	}
+	return m
+}
+
+// Encode serialises a ToolMap to map[string]any for transport in Extensions.
+func (m ToolMap) Encode() map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, spec := range m {
+		out[k] = map[string]any{
+			"kind":        string(spec.Kind),
+			"openai_name": spec.OpenAIName,
+			"namespace":   spec.Namespace,
+		}
+	}
+	return out
+}
+
+// Lookup returns the ToolSpec for an expanded tool name.
+func (m ToolMap) Lookup(name string) (ToolSpec, bool) {
+	if m == nil {
+		return ToolSpec{}, false
+	}
+	spec, ok := m[name]
+	return spec, ok
+}
+
+// DecodeToolMapFromExtensions extracts the "codex_tool_map" entry from
+// CoreRequest/CoreResponse Extensions and decodes it into a ToolMap.
+// Returns nil when the entry is missing or malformed.
+func DecodeToolMapFromExtensions(extensions map[string]any) ToolMap {
+	if extensions == nil {
+		return nil
+	}
+	raw, ok := extensions["codex_tool_map"]
+	if !ok {
+		return nil
+	}
+	tmMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return DecodeToolMap(tmMap)
+}

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -228,14 +228,7 @@ func (a *OpenAIAdapter) FromCoreResponse(ctx context.Context, resp *format.CoreR
 					})
 					textParts = textParts[:0]
 				}
-				output = append(output, OutputItem{
-					Type:      "function_call",
-					ID:        block.ToolUseID,
-					CallID:    block.ToolUseID,
-					Name:      block.ToolName,
-					Arguments: toolInputString(block.ToolInput),
-					Status:    "completed",
-				})
+				output = append(output, buildToolOutputItem(block, resp.Extensions))
 
 			case "tool_result":
 				// Tool results don't translate to output items in the response.
@@ -470,14 +463,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 					toolUseID = fmt.Sprintf("call_%d", index)
 				}
 				itemIDs[index] = fmt.Sprintf("fc_item_%d", index)
-				item := OutputItem{
-					Type:      "function_call",
-					ID:        toolUseID,
-					CallID:    toolUseID,
-					Name:      event.ContentBlock.ToolName,
-					Arguments: toolInputString(event.ContentBlock.ToolInput),
-					Status:    "in_progress",
-				}
+				item := buildToolOutputItemStreaming(event.ContentBlock, coreReq.Extensions, toolUseID)
 				outputIndexes[index] = len(response.Output)
 				response.Output = append(response.Output, item)
 				send(StreamEvent{

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"moonbridge/internal/format"
+	"moonbridge/internal/extension/codextool"
 )
 
 // ============================================================================
@@ -108,10 +109,7 @@ func (a *OpenAIAdapter) ToCoreRequest(ctx context.Context, req any) (*format.Cor
 
 	// 5. Convert tools.
 	if len(openaiReq.Tools) > 0 {
-		coreReq.Tools = make([]format.CoreTool, 0, len(openaiReq.Tools))
-		for _, tool := range openaiReq.Tools {
-			coreReq.Tools = append(coreReq.Tools, convertTool(tool))
-		}
+		coreReq.Tools = flattenToolsWithNamespace(openaiReq.Tools, "")
 	}
 
 	// 6. Convert tool choice.
@@ -124,7 +122,11 @@ func (a *OpenAIAdapter) ToCoreRequest(ctx context.Context, req any) (*format.Cor
 	}
 
 	// 7. Cache metadata passthrough.
-	coreReq.Extensions = make(map[string]any)
+	if coreReq.Extensions == nil {
+		coreReq.Extensions = make(map[string]any)
+	}
+	// 5b. Store tool map for response-side reverse mapping.
+	coreReq.Extensions["codex_tool_map"] = codextool.BuildToolMapFromCore(coreReq.Tools).Encode()
 	if openaiReq.PromptCacheKey != "" || openaiReq.PromptCacheRetention != "" {
 		cacheMeta := make(map[string]string)
 		if openaiReq.PromptCacheKey != "" {
@@ -918,6 +920,8 @@ type inputItem struct {
 	Name      string          `json:"name"`
 	Arguments string          `json:"arguments"`
 	Output    json.RawMessage `json:"output"`
+	Input     string          `json:"input"`
+	Action    *ToolAction     `json:"action,omitempty"`
 	ID        string          `json:"id"`
 	Status    string          `json:"status"`
 }
@@ -1009,7 +1013,7 @@ func convertInput(raw json.RawMessage) ([]format.CoreMessage, []format.CoreConte
 		// Flush pending function_calls before non-function-call items.
 		// Don't flush between consecutive function_call items — they should
 		// be batched into a single assistant message.
-		if item.Type != "function_call" && len(pendingFCBlocks) > 0 {
+		if item.Type != "function_call" && item.Type != "custom_tool_call" && item.Type != "local_shell_call" && len(pendingFCBlocks) > 0 {
 			flushed := make([]format.CoreContentBlock, len(pendingFCBlocks))
 			copy(flushed, pendingFCBlocks)
 			messages = append(messages, format.CoreMessage{
@@ -1050,6 +1054,30 @@ func convertInput(raw json.RawMessage) ([]format.CoreMessage, []format.CoreConte
 			toolInput := json.RawMessage(item.Arguments)
 			if !json.Valid([]byte(item.Arguments)) {
 				toolInput = json.RawMessage(`{}`)
+			}
+			pendingFCBlocks = append(pendingFCBlocks, format.CoreContentBlock{
+				Type:      "tool_use",
+				ToolUseID: firstNonEmpty(item.CallID, item.ID),
+				ToolName:  item.Name,
+				ToolInput: toolInput,
+			})
+
+		case item.Type == "custom_tool_call" || item.Type == "local_shell_call":
+			if len(pendingReasoning) > 0 {
+				pendingFCBlocks = append(pendingFCBlocks, pendingReasoning...)
+				pendingReasoning = pendingReasoning[:0]
+			}
+			toolInput := json.RawMessage(item.Arguments)
+			if !json.Valid([]byte(item.Arguments)) {
+				if item.Input != "" {
+					toolInput, _ = json.Marshal(map[string]string{"input": item.Input})
+				} else {
+					toolInput = json.RawMessage(`{}`)
+				}
+			}
+			if item.Type == "local_shell_call" && item.Action != nil {
+				data, _ := json.Marshal(item.Action)
+				toolInput = data
 			}
 			pendingFCBlocks = append(pendingFCBlocks, format.CoreContentBlock{
 				Type:      "tool_use",
@@ -1207,114 +1235,8 @@ func imageSourceFromRaw(raw json.RawMessage) string {
 // ============================================================================
 
 // convertTool converts an OpenAI Tool to a CoreTool.
-func convertTool(tool Tool) format.CoreTool {
-	ext := make(map[string]any)
-
-	switch tool.Type {
-	case "function":
-		return format.CoreTool{
-			Name:        tool.Name,
-			Description: tool.Description,
-			InputSchema: tool.Parameters,
-		}
-
-	case "web_search", "web_search_preview":
-		ext["source_type"] = tool.Type
-		return format.CoreTool{
-			Name:        tool.Type,
-			Description: "Search the web for up-to-date information.",
-			Extensions:  ext,
-		}
-	case "file_search":
-		ext["source_type"] = tool.Type
-		ext["max_num_results"] = tool.MaxNumResults
-		return format.CoreTool{
-			Name:        tool.Type,
-			Description: "Search files in the user's file system.",
-			Extensions:  ext,
-		}
-
-	case "code_interpreter":
-		ext["source_type"] = tool.Type
-		return format.CoreTool{
-			Name:        tool.Type,
-			Description: "Execute code in a sandboxed interpreter.",
-			Extensions:  ext,
-		}
-
-	case "computer_use_preview":
-		ext["source_type"] = tool.Type
-		ext["display_width"] = tool.DisplayWidth
-		ext["display_height"] = tool.DisplayHeight
-		return format.CoreTool{
-			Name:        tool.Type,
-			Description: "Use a computer to perform actions.",
-			Extensions:  ext,
-		}
-
-
-	default:
-		ext["source_type"] = tool.Type
-		return format.CoreTool{
-			Name:        tool.Name,
-			Description: tool.Description,
-			InputSchema: adaptSchema(tool.Parameters, tool.Name),
-			Extensions:  ext,
-		}
-	}
-}
-
-// adaptSchema ensures custom Codex CLI tools have a proper input schema,
-// since models like DeepSeek/Claude don't natively understand the Codex
-// custom tool format (type: "custom").
-func adaptSchema(params map[string]any, toolName string) map[string]any {
-	if params != nil && len(params) > 0 {
-		// Has existing schema, just clean it
-		return params
-	}
-	// Generate schemas for known Codex custom tools
-	switch toolName {
-	case "apply_patch", "patch":
-		return map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"input": map[string]any{"type": "string", "description": "The patch content or operation to apply"},
-			},
-			"required": []string{"input"},
-		}
-	case "exec", "exec_command", "local_shell", "shell":
-		return map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"command": map[string]any{
-					"type": "array", "items": map[string]any{"type": "string"},
-					"description": "Command and arguments to execute",
-				},
-				"description": map[string]any{"type": "string"},
-			},
-			"required": []string{"command"},
-		}
-	case "read", "view", "view_image":
-		return map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"file_path": map[string]any{"type": "string"},
-			},
-			"required": []string{"file_path"},
-		}
-	default:
-		return map[string]any{"type": "object"}
-	}
-}
-
 // convertToolChoice parses an OpenAI tool_choice JSON value into a CoreToolChoice.
-//
-// Accepts:
-//   - string: "auto" / "none" / "required"
-//   - object: {type: "...", name: "..."} or {type: "function", function: {name: "..."}}
-//
-// On parse failure, the raw JSON is preserved in CoreToolChoice.Raw for
-// round-tripping; no error is returned for best-effort parsing.
+
 func convertToolChoice(raw json.RawMessage) (*format.CoreToolChoice, error) {
 	tc := &format.CoreToolChoice{
 		Raw: raw,
@@ -1442,4 +1364,231 @@ func outputToString(raw json.RawMessage) string {
 	}
 	// Fallback: return the raw JSON as a string (array/object).
 	return string(raw)
+}
+
+
+// localShellActionFromRaw parses tool input JSON into a ToolAction for local_shell.
+func localShellActionFromRaw(raw json.RawMessage) *ToolAction {
+	var input struct {
+		Command          []string          `json:"command"`
+		WorkingDirectory string            `json:"working_directory"`
+		TimeoutMS        int               `json:"timeout_ms"`
+		Env              map[string]string `json:"env"`
+	}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return &ToolAction{Type: "exec"}
+	}
+	return &ToolAction{
+		Type:             "exec",
+		Command:          input.Command,
+		WorkingDirectory: input.WorkingDirectory,
+		TimeoutMS:        input.TimeoutMS,
+		Env:              input.Env,
+	}
+}
+
+// ============================================================================
+// Response-side Tool Output Item Builder
+// ============================================================================
+
+// buildToolOutputItem constructs an OutputItem using the codex_tool_map
+// to determine the correct output item type (function_call, custom_tool_call, local_shell_call).
+func buildToolOutputItem(block format.CoreContentBlock, extensions map[string]any) OutputItem {
+	toolMap := codextool.DecodeToolMapFromExtensions(extensions)
+	itemT, itemN, itemNS, itemInput, isLS, actionJSON := codextool.OutputItemFromBlock(block.ToolName, block.ToolInput, toolMap)
+	if isLS {
+		return OutputItem{
+			Type:   "local_shell_call",
+			ID:     block.ToolUseID,
+			CallID: block.ToolUseID,
+			Status: "completed",
+			Action: localShellActionFromRaw(actionJSON),
+		}
+	}
+	return OutputItem{
+		Type:      itemT,
+		ID:        block.ToolUseID,
+		CallID:    block.ToolUseID,
+		Name:      itemN,
+		Namespace: itemNS,
+		Arguments: toolInputString(block.ToolInput),
+		Input:     itemInput,
+		Status:    "completed",
+	}
+}
+
+// buildToolOutputItemStreaming constructs a streaming OutputItem for a tool_use content block start.
+// The item is created with "in_progress" status.
+func buildToolOutputItemStreaming(block *format.CoreContentBlock, extensions map[string]any, toolUseID string) OutputItem {
+	toolMap := codextool.DecodeToolMapFromExtensions(extensions)
+	itemT, itemN, itemNS, itemInput, isLS, actionJSON := codextool.OutputItemFromBlock(block.ToolName, block.ToolInput, toolMap)
+	_ = itemInput
+	if isLS {
+		return OutputItem{
+			Type:   "local_shell_call",
+			ID:     toolUseID,
+			CallID: toolUseID,
+			Status: "in_progress",
+			Action: localShellActionFromRaw(actionJSON),
+		}
+	}
+	return OutputItem{
+		Type:      itemT,
+		ID:        toolUseID,
+		CallID:    toolUseID,
+		Name:      itemN,
+		Namespace: itemNS,
+		Arguments: toolInputString(block.ToolInput),
+		Status:    "in_progress",
+	}
+}
+
+// ============================================================================
+// Tool Conversion — custom/namespace/apply_patch
+// ============================================================================
+
+// convertToolWithNamespace converts a single OpenAI Tool to one or more CoreTools.
+// Function/web_search/file_search/code_interpreter/computer_use_preview pass through.
+// Custom tools are expanded using codex package helpers.
+// Namespace tools are recursively flattened.
+func convertToolWithNamespace(tool Tool, namespace string) []format.CoreTool {
+	name := namespacedToolName(namespace, tool.Name)
+	ext := make(map[string]any)
+
+	switch tool.Type {
+case "function":
+		ct := format.CoreTool{
+			Name:        name,
+			Description: tool.Description,
+			InputSchema: tool.Parameters,
+		}
+		codextool.AnnotateCoreTool(&ct, codextool.ToolFunction, name, namespace)
+		return []format.CoreTool{ct}
+
+	case "web_search", "web_search_preview":
+		ext["source_type"] = tool.Type
+		return []format.CoreTool{{
+			Name:        tool.Type,
+			Description: "Search the web for up-to-date information.",
+			Extensions:  ext,
+		}}
+	case "file_search":
+		ext["source_type"] = tool.Type
+		ext["max_num_results"] = tool.MaxNumResults
+		return []format.CoreTool{{
+			Name:        tool.Type,
+			Description: "Search files in the user's file system.",
+			Extensions:  ext,
+		}}
+
+	case "code_interpreter":
+		ext["source_type"] = tool.Type
+		return []format.CoreTool{{
+			Name:        tool.Type,
+			Description: "Execute code in a sandboxed interpreter.",
+			Extensions:  ext,
+		}}
+
+	case "computer_use_preview":
+		ext["source_type"] = tool.Type
+		ext["display_width"] = tool.DisplayWidth
+		ext["display_height"] = tool.DisplayHeight
+		return []format.CoreTool{{
+			Name:        tool.Type,
+			Description: "Use a computer to perform actions.",
+			Extensions:  ext,
+		}}
+
+	case "namespace":
+		ns := namespacedToolName(namespace, tool.Name)
+		return flattenToolsWithNamespace(tool.Tools, ns)
+
+	case "custom":
+		grammar := codextool.CustomToolGrammar(tool.Format)
+		if tool.Name == "local_shell" {
+			ct := format.CoreTool{
+				Name:        name,
+				Description: tool.Description,
+				InputSchema: codextool.LocalShellSchema(),
+			}
+			codextool.AnnotateCoreTool(&ct, codextool.ToolLocalShell, name, "")
+			return []format.CoreTool{ct}
+		}
+		if codextool.IsApplyPatchGrammar(grammar) {
+			proxyTools := codextool.ApplyPatchProxyCoreTools(name)
+			for i := range proxyTools {
+				codextool.AnnotateCoreTool(&proxyTools[i], codextool.ToolApplyPatch, name, "")
+			}
+			return proxyTools
+		}
+		if codextool.IsExecGrammar(grammar) {
+			ct := format.CoreTool{
+				Name:        name,
+				Description: codextool.ExecProxyDescription(),
+				InputSchema: codextool.ExecProxySchema(),
+			}
+			codextool.AnnotateCoreTool(&ct, codextool.ToolExec, name, "")
+			return []format.CoreTool{ct}
+		}
+		ct := format.CoreTool{
+			Name:        name,
+			Description: customToolDescription(tool, grammar),
+			InputSchema: codextool.CustomToolInputSchema(grammar),
+		}
+		codextool.AnnotateCoreTool(&ct, codextool.ToolRaw, name, "")
+		return []format.CoreTool{ct}
+
+	default:
+		ext["source_type"] = tool.Type
+		return []format.CoreTool{{
+			Name:        name,
+			Description: tool.Description,
+			InputSchema: tool.Parameters,
+			Extensions:  ext,
+		}}
+	}
+}
+
+// flattenToolsWithNamespace recursively flattens namespace tools and converts
+// individual tools, building a flat list of CoreTools suitable for upstream providers.
+func flattenToolsWithNamespace(openaiTools []Tool, namespace string) []format.CoreTool {
+	var result []format.CoreTool
+	for _, t := range openaiTools {
+		converted := convertToolWithNamespace(t, namespace)
+		result = append(result, converted...)
+	}
+	// Deduplicate by name: Codex may send the same tool both as a namespace member
+	// and as an independently-injected function tool (e.g. MCP tools that inject themselves
+	// after first use). Keep the first occurrence, which has the correct metadata.
+	seen := make(map[string]bool, len(result))
+	deduped := make([]format.CoreTool, 0, len(result))
+	for _, t := range result {
+		if seen[t.Name] {
+			continue
+		}
+		seen[t.Name] = true
+		deduped = append(deduped, t)
+	}
+	result = deduped
+	return result
+}
+
+// namespacedToolName joins namespace and name.
+func namespacedToolName(namespace, name string) string {
+	return codextool.NamespacedToolName(namespace, name)
+}
+
+// customToolDescription builds a description for a custom tool including grammar.
+func customToolDescription(tool Tool, grammar string) string {
+	parts := []string{}
+	if strings.TrimSpace(tool.Description) != "" {
+		parts = append(parts, strings.TrimSpace(tool.Description))
+	}
+	if grammar != "" {
+		parts = append(parts, "OpenAI custom tool grammar:\n"+grammar)
+	}
+	if len(parts) == 0 {
+		return "Use this custom tool with its raw freeform input in the input field."
+	}
+	return strings.Join(parts, "\n\n")
 }

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -365,6 +365,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 	}
 	contentText := make(map[int]string)
 	toolCallArgs := make(map[int]string)
+	toolBlockNames := make(map[int]string)
 	outputIndexes := make(map[int]int)
 	itemIDs := make(map[int]string)
 	reasonIndexes := make(map[int]bool)
@@ -463,6 +464,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 					toolUseID = fmt.Sprintf("call_%d", index)
 				}
 				itemIDs[index] = fmt.Sprintf("fc_item_%d", index)
+				toolBlockNames[index] = event.ContentBlock.ToolName
 				item := buildToolOutputItemStreaming(event.ContentBlock, coreReq.Extensions, toolUseID)
 				outputIndexes[index] = len(response.Output)
 				response.Output = append(response.Output, item)
@@ -633,6 +635,11 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 			if idx, ok := outputIndexes[index]; ok && idx < len(response.Output) {
 				response.Output[idx].Arguments = event.Delta
 				response.Output[idx].Status = "completed"
+				if response.Output[idx].Type == "custom_tool_call" {
+					if bn, ok := toolBlockNames[index]; ok && event.Delta != "" {
+						response.Output[idx].Input = codextool.RebuildGrammar(bn, json.RawMessage(event.Delta))
+					}
+				}
 			}
 			send(StreamEvent{
 				Event: "response.function_call_arguments.done",
@@ -843,6 +850,12 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 						response.Output[idx].Arguments = finalArgs
 					}
 					response.Output[idx].Status = "completed"
+					// Rebuild raw grammar for custom_tool_call items from accumulated args.
+					if response.Output[idx].Type == "custom_tool_call" {
+						if bn, ok := toolBlockNames[index]; ok && finalArgs != "" {
+							response.Output[idx].Input = codextool.RebuildGrammar(bn, json.RawMessage(finalArgs))
+						}
+					}
 				}
 
 				// function_call_arguments.done
@@ -870,6 +883,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 
 				// Clean up state.
 				delete(toolCallArgs, index)
+				delete(toolBlockNames, index)
 			}
 
 		case format.CoreItemAdded:

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1500,9 +1500,23 @@ case "function":
 			codextool.AnnotateCoreTool(&ct, codextool.ToolLocalShell, name, "")
 			return []format.CoreTool{ct}
 		}
-		// ToolApplyPatch and ToolExec: keep original name, use structured schema.
-		// DO NOT proxy-expand — the model must call the original tool name so
-		// Codex can match it on the response side for custom_tool_call routing.
+		if codextool.IsApplyPatchGrammar(grammar) {
+			proxyTools := codextool.ApplyPatchProxyCoreTools(name)
+			for i := range proxyTools {
+				codextool.AnnotateCoreTool(&proxyTools[i], codextool.ToolApplyPatch, name, "")
+			}
+			return proxyTools
+		}
+		if codextool.IsExecGrammar(grammar) {
+			ct := format.CoreTool{
+				Name:        name,
+				Description: codextool.ExecProxyDescription(),
+				InputSchema: codextool.ExecProxySchema(),
+			}
+			codextool.AnnotateCoreTool(&ct, codextool.ToolExec, name, "")
+			return []format.CoreTool{ct}
+		}
+		// Other custom tools: keep original name with raw input schema
 		ct := format.CoreTool{
 			Name:        name,
 			Description: customToolDescription(tool, grammar),

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1500,22 +1500,9 @@ case "function":
 			codextool.AnnotateCoreTool(&ct, codextool.ToolLocalShell, name, "")
 			return []format.CoreTool{ct}
 		}
-		if codextool.IsApplyPatchGrammar(grammar) {
-			proxyTools := codextool.ApplyPatchProxyCoreTools(name)
-			for i := range proxyTools {
-				codextool.AnnotateCoreTool(&proxyTools[i], codextool.ToolApplyPatch, name, "")
-			}
-			return proxyTools
-		}
-		if codextool.IsExecGrammar(grammar) {
-			ct := format.CoreTool{
-				Name:        name,
-				Description: codextool.ExecProxyDescription(),
-				InputSchema: codextool.ExecProxySchema(),
-			}
-			codextool.AnnotateCoreTool(&ct, codextool.ToolExec, name, "")
-			return []format.CoreTool{ct}
-		}
+		// ToolApplyPatch and ToolExec: keep original name, use structured schema.
+		// DO NOT proxy-expand — the model must call the original tool name so
+		// Codex can match it on the response side for custom_tool_call routing.
 		ct := format.CoreTool{
 			Name:        name,
 			Description: customToolDescription(tool, grammar),

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -528,6 +528,17 @@ func (s *Server) handleWithAdapters(
 	}
 
 	// ------------------------------------------------------------------
+
+
+	// Propagate codex_tool_map from CoreRequest to CoreResponse.
+	if coreReq != nil && coreResp != nil && coreReq.Extensions != nil {
+		if tm, ok := coreReq.Extensions["codex_tool_map"]; ok {
+			if coreResp.Extensions == nil {
+				coreResp.Extensions = make(map[string]any)
+			}
+			coreResp.Extensions["codex_tool_map"] = tm
+		}
+	}
 	// 7. Convert CoreResponse → outbound OpenAI Response.
 	// ------------------------------------------------------------------
 	outAny, err := client.FromCoreResponse(ctx, coreResp)


### PR DESCRIPTION
## 概述

修复 Moon Bridge 作为 Codex 代理时，自定义工具（custom tool）调用在协议适配层和流程控制层的多项问题。

## 变更内容

### 协议适配 (adapter)
- **响应侧工具类型恢复**：确保自定义工具调用在响应转换后仍保留正确的工具类型标识
- **原始工具名保留**：去除 apply_patch/exec 的 proxy 扩展名映射，保持原始名称传递
- **流式参数重建**：从 proxy tool inputs 和 streaming arguments 中重建 raw grammar
- **去除工具别名**：保持 proxy expansion 的纯粹性，去掉工具名别名层

### Codextool
- **begin patch 标记**：为 apply_patch 调用添加 begin 补丁标记
- **拦截裸 apply_patch 调用**：在 codextool 层拦截未经过包装的 apply_patch 调用

### OpenAI 协议
- **修复 orphan tool_use 400 错误**：解决自定义工具调用后产生的孤立 tool_use 导致的 400 响应错误

## 测试
- 所有现有测试通过
- 涉及的核心模块：adapter、codextool、openai protocol