### PR TITLE
Codex/bugfix

### DIFF
--- a/cmd/cloudflare/main.go
+++ b/cmd/cloudflare/main.go
@@ -8,12 +8,13 @@ import (
 
 	"moonbridge/internal/service/app"
 
+	"log/slog"
 	"moonbridge/internal/config"
 	"moonbridge/internal/db"
-	"log/slog"
 	"moonbridge/internal/logger"
 	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/service/provider"
+	"moonbridge/internal/service/runtime"
 	"moonbridge/internal/service/server"
 	"moonbridge/internal/service/stats"
 
@@ -66,6 +67,7 @@ func main() {
 	if len(pricing) > 0 {
 		sessionStats.SetPricing(pricing)
 	}
+	rt := runtime.NewRuntime(cfg, providerMgr, pricing)
 	cat := app.BuiltinExtensionCatalog{}
 	if d1Cfg := cfg.ExtensionRawConfig("db_d1", ""); len(d1Cfg) > 0 {
 		if binding, ok := d1Cfg["binding"].(string); ok && binding != "" {
@@ -82,6 +84,12 @@ func main() {
 		}
 	}
 	plugins := cat.NewRegistry(slog.Default(), cfg)
+	plugins.SetCurrentConfigProvider(func() config.Config {
+		if rt.Current() != nil {
+			return rt.Current().Config
+		}
+		return cfg
+	})
 	if err := plugins.InitAll(&cfg); err != nil {
 		slog.Error("init plugins", "error", err)
 		os.Exit(1)
@@ -97,9 +105,12 @@ func main() {
 	// Initialize persistence layer (db.Registry).
 	ctx := context.Background()
 	dbRegistry := db.NewRegistry(slog.Default())
-	for _, p := range plugins.DBProviders() {
+	dbProviders := plugins.DBProviders()
+	providers := make([]db.Provider, 0, len(dbProviders))
+	for _, p := range dbProviders {
 		if prov := p.DBProvider(); prov != nil {
 			dbRegistry.RegisterProvider(prov)
+			providers = append(providers, prov)
 		}
 	}
 	for _, c := range plugins.DBConsumers() {
@@ -107,18 +118,20 @@ func main() {
 			dbRegistry.RegisterConsumer(cons)
 		}
 	}
-	if err := dbRegistry.Init(ctx, cfg.Persistence.ActiveProvider); err != nil {
+	activePersistenceProvider := app.ResolvePersistenceActiveProvider(cfg.Persistence.ActiveProvider, providers)
+	if err := dbRegistry.Init(ctx, activePersistenceProvider); err != nil {
 		slog.Error("init persistence", "error", err)
 		os.Exit(1)
 	}
 	defer dbRegistry.Shutdown()
 
 	handler := server.New(server.Config{
-		Provider:       defaultClient,
+		Provider:       provider.NewAnthropicClientAdapter(defaultClient),
 		ProviderMgr:    providerMgr,
 		Stats:          sessionStats,
 		PluginRegistry: plugins,
-		AppConfig:      cfg,
+		AppConfig:      config.ServerFromGlobalConfig(&cfg),
+		Runtime:        rt,
 	})
 
 	workers.Serve(handler)
@@ -191,12 +204,17 @@ func resolveDefaultClient(pm *provider.ProviderManager) *anthropic.Client {
 		for _, key := range pm.ProviderKeys() {
 			c, err := pm.ClientForKey(key)
 			if err == nil {
-				return c
+				if acc, ok := c.(provider.AnthropicClientAccessor); ok {
+					return acc.AnthropicClient()
+				}
 			}
 		}
 		return nil
 	}
-	return client
+	if acc, ok := client.(provider.AnthropicClientAccessor); ok {
+		return acc.AnthropicClient()
+	}
+	return nil
 }
 
 func isDevEnv() bool {

--- a/cmd/moonbridge/main.go
+++ b/cmd/moonbridge/main.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 
 	"log/slog"
-	"moonbridge/internal/extension/codex"
 	"moonbridge/internal/config"
+	"moonbridge/internal/extension/codex"
 	"moonbridge/internal/logger"
 	"moonbridge/internal/service/app"
 )
@@ -117,7 +117,7 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 	if *printCodexConfig != "" {
 		if err := codex.GenerateConfigToml(stdout, *printCodexConfig, *codexBaseURL, *codexHome,
-			config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg)); err != nil {
+			config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg)); err != nil {
 			writeStartupError(stderr, "生成 Codex 配置失败", resolvedConfigPath, err,
 				"确认 -codex-home 目录可写，或去掉 -codex-home 只打印 config.toml。")
 			return exitRuntimeErr

--- a/cmd/moonbridge/main_test.go
+++ b/cmd/moonbridge/main_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"moonbridge/internal/extension/codex"
 	"moonbridge/internal/config"
+	"moonbridge/internal/extension/codex"
 )
 
 func TestPrintCodexConfigTomlDoesNotSetServiceTier(t *testing.T) {
@@ -23,7 +23,7 @@ func TestPrintCodexConfigTomlDoesNotSetServiceTier(t *testing.T) {
 		},
 	}
 	err := codex.GenerateConfigToml(&output, "moonbridge", "http://127.0.0.1:38440/v1", "",
-		config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
 	if err != nil {
 		t.Fatalf("codex.GenerateConfigToml() error = %v", err)
 	}
@@ -83,7 +83,7 @@ routes:
 	for _, want := range []string{
 		"Moon Bridge 启动失败：配置文件加载失败",
 		"配置文件: " + configPath,
-"providers.openai.protocol must be \"anthropic\", \"openai-response\", \"google-genai\", or \"openai-chat\"",
+		"providers.openai.protocol must be \"anthropic\", \"openai-response\", \"google-genai\", or \"openai-chat\"",
 		"Responses 直通请使用 openai-response",
 	} {
 		if !strings.Contains(output, want) {

--- a/internal/config/convert.go
+++ b/internal/config/convert.go
@@ -17,8 +17,10 @@ func (cfg Config) ToFileConfig() FileConfig {
 			Format: cfg.LogFormat,
 		},
 		Server: ServerFileConfig{
-			Addr:      cfg.Addr,
-			AuthToken: cfg.AuthToken,
+			Addr:        cfg.Addr,
+			AuthToken:   cfg.AuthToken,
+			MaxSessions: cfg.MaxSessions,
+			SessionTTL:  cfg.SessionTTL,
 		},
 		Defaults: DefaultsFileConfig{
 			Model:        cfg.Defaults.Model,
@@ -106,16 +108,16 @@ func toModelDefFileConfig(def ModelDef) ModelDefFileConfig {
 	}
 
 	m := ModelDefFileConfig{
-		ContextWindow:               def.ContextWindow,
-		MaxOutputTokens:             def.MaxOutputTokens,
-		DisplayName:                 def.DisplayName,
-		Description:                 def.Description,
-		BaseInstructions:            def.BaseInstructions,
-		DefaultReasoningLevel:       def.DefaultReasoningLevel,
-		SupportedReasoningLevels:    reasoningPresets,
-		DefaultReasoningSummary:     def.DefaultReasoningSummary,
-		InputModalities:             def.InputModalities,
-		WebSearch:                   toWebSearchFileConfig(def.WebSearch),
+		ContextWindow:            def.ContextWindow,
+		MaxOutputTokens:          def.MaxOutputTokens,
+		DisplayName:              def.DisplayName,
+		Description:              def.Description,
+		BaseInstructions:         def.BaseInstructions,
+		DefaultReasoningLevel:    def.DefaultReasoningLevel,
+		SupportedReasoningLevels: reasoningPresets,
+		DefaultReasoningSummary:  def.DefaultReasoningSummary,
+		InputModalities:          def.InputModalities,
+		WebSearch:                toWebSearchFileConfig(def.WebSearch),
 	}
 
 	if def.SupportsReasoningSummaries {

--- a/internal/e2e/plugin_hooks_e2e_test.go
+++ b/internal/e2e/plugin_hooks_e2e_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	"moonbridge/internal/extension/plugin"
-	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/protocol/openai"
 )
 
@@ -38,8 +38,8 @@ type e2eMockPlugin struct {
 	filterBlockType string
 
 	// RememberCoreContent tracking
-	rememberCalled      bool
-	rememberedContent   []format.CoreContentBlock
+	rememberCalled    bool
+	rememberedContent []format.CoreContentBlock
 }
 
 func (p *e2eMockPlugin) Name() string { return "e2e-test-plugin" }
@@ -78,11 +78,12 @@ type e2eMockPlugin2 struct {
 
 	mutatorCalled        bool
 	mutatorModifiedModel string
+	enabled              bool
 }
 
 func (p *e2eMockPlugin2) Name() string { return "e2e-test-plugin-2" }
 
-func (p *e2eMockPlugin2) EnabledForModel(string) bool { return true }
+func (p *e2eMockPlugin2) EnabledForModel(string) bool { return p.enabled }
 
 func (p *e2eMockPlugin2) MutateCoreRequest(ctx context.Context, req *format.CoreRequest) {
 	p.mu.Lock()
@@ -963,7 +964,7 @@ func TestPluginHooks_AdditionalHookAutoMapping(t *testing.T) {
 	}
 
 	// Call FilterContent directly and verify it works.
-	ctx := context.Background()
+	ctx := format.WithCoreHookModelAlias(context.Background(), "test-model")
 	block := &format.CoreContentBlock{Type: "text", Text: "test block"}
 	skip := hooks.FilterContent(ctx, block)
 	if skip {
@@ -1006,4 +1007,98 @@ func TestPluginHooks_AdditionalHookAutoMapping(t *testing.T) {
 	if hooks.PrependThinkingToAssistant == nil {
 		t.Error("PrependThinkingToAssistant is nil after WithDefaults()")
 	}
+}
+
+func TestPluginHooks_CoreHooksRespectEnabledForModel(t *testing.T) {
+	if os.Getenv("TEST_ANTHROPIC_API_KEY") != "" {
+		t.Skip("Real mode: skip mock test when TEST_ANTHROPIC_API_KEY is set")
+	}
+
+	ctx := context.Background()
+	cfg := e2eMinimalConfig()
+
+	enabledPlugin := &e2eMockPlugin{}
+	disabledPlugin := &e2eMockPlugin2{enabled: false}
+
+	pReg := plugin.NewRegistry(nil)
+	pReg.Register(enabledPlugin)
+	pReg.Register(disabledPlugin)
+	hooks := pReg.CorePluginHooks()
+
+	reg := newTestRegistry(t, cfg, hooks)
+	client, ok := reg.GetClient(configOpenAIResponse)
+	if !ok {
+		t.Fatal("client adapter not found")
+	}
+	provider, ok := reg.GetProvider(configAnthropic)
+	if !ok {
+		t.Fatal("provider adapter not found")
+	}
+
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"id": "msg_gate_001",
+			"type": "message",
+			"role": "assistant",
+			"content": [{"type": "text", "text": "EnabledForModel gate test"}],
+			"model": "claude-3.5-sonnet-20241022",
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`)
+	}))
+	defer mockSrv.Close()
+
+	openAIReq := openai.ResponsesRequest{
+		Model:           "claude-3.5-sonnet",
+		Input:           json.RawMessage(`"Gate me"`),
+		MaxOutputTokens: 100,
+	}
+
+	coreReq, err := client.ToCoreRequest(ctx, &openAIReq)
+	if err != nil {
+		t.Fatalf("ToCoreRequest: %v", err)
+	}
+
+	upstreamAny, err := provider.FromCoreRequest(ctx, coreReq)
+	if err != nil {
+		t.Fatalf("FromCoreRequest: %v", err)
+	}
+	upstreamReq := upstreamAny.(*anthropic.MessageRequest)
+
+	anthClient := anthropic.NewClient(anthropic.ClientConfig{
+		BaseURL: mockSrv.URL,
+		APIKey:  "test-key",
+		Client:  mockSrv.Client(),
+	})
+	upstreamResp, err := anthClient.CreateMessage(ctx, *upstreamReq)
+	if err != nil {
+		t.Fatalf("CreateMessage: %v", err)
+	}
+
+	coreResp, err := provider.ToCoreResponse(ctx, &upstreamResp)
+	if err != nil {
+		t.Fatalf("ToCoreResponse: %v", err)
+	}
+
+	_, err = client.FromCoreResponse(ctx, coreResp)
+	if err != nil {
+		t.Fatalf("FromCoreResponse: %v", err)
+	}
+
+	enabledPlugin.mu.Lock()
+	if !enabledPlugin.mutatorCalled {
+		t.Error("enabled plugin MutateCoreRequest was not called")
+	}
+	if !enabledPlugin.rememberCalled {
+		t.Error("enabled plugin RememberCoreContent was not called")
+	}
+	enabledPlugin.mu.Unlock()
+
+	disabledPlugin.mu.Lock()
+	if disabledPlugin.mutatorCalled {
+		t.Error("disabled plugin MutateCoreRequest should not be called")
+	}
+	disabledPlugin.mu.Unlock()
 }

--- a/internal/extension/codex/catalog.go
+++ b/internal/extension/codex/catalog.go
@@ -13,8 +13,8 @@ import (
 	"sort"
 	"strings"
 
-	"moonbridge/internal/extension/visual"
 	"moonbridge/internal/config"
+	"moonbridge/internal/extension/visual"
 	"moonbridge/internal/modelref"
 )
 
@@ -492,7 +492,7 @@ func routeFor(providerCfg config.ProviderConfig, modelAlias string) config.Route
 // GenerateConfigToml writes a Codex config.toml fragment to output for a given
 // model alias. If codexHome is non-empty, it also writes models_catalog.json
 // there and adds a model_catalog_json pointer.
-func GenerateConfigToml(output io.Writer, modelAlias string, baseURL string, codexHome string, providerCfg config.ProviderConfig, serverCfg config.ServerConfig) error {
+func GenerateConfigToml(output io.Writer, modelAlias string, baseURL string, codexHome string, providerCfg config.ProviderConfig, pluginCfg config.PluginConfig, serverCfg config.ServerConfig) error {
 	route := routeFor(providerCfg, modelAlias)
 
 	// When modelAlias is a direct provider/model reference (not a named route),
@@ -503,8 +503,6 @@ func GenerateConfigToml(output io.Writer, modelAlias string, baseURL string, cod
 			catalogAlias = model + "(" + provider + ")"
 		}
 	}
-
-	pluginCfg := config.PluginConfig{}
 
 	fmt.Fprintf(output, "model = %q\n", catalogAlias)
 	fmt.Fprintln(output, `model_provider = "moonbridge"`)
@@ -552,7 +550,7 @@ func writeAuthJSON(path, token string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/internal/extension/codex/catalog_test.go
+++ b/internal/extension/codex/catalog_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"moonbridge/internal/extension/codex"
 	"moonbridge/internal/config"
+	"moonbridge/internal/extension/codex"
+	"moonbridge/internal/extension/visual"
 )
 
 func TestBuildModelInfoFromRouteEnablesApplyPatchFreeform(t *testing.T) {
@@ -85,7 +87,7 @@ func TestGenerateConfigTomlDoesNotSetServiceTier(t *testing.T) {
 	}
 	var output bytes.Buffer
 	err := codex.GenerateConfigToml(&output, "moonbridge", "http://127.0.0.1:38440/v1", "",
-		config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
 	if err != nil {
 		t.Fatalf("GenerateConfigToml() error = %v", err)
 	}
@@ -116,7 +118,7 @@ func TestGenerateConfigTomlIncludesDeepWikiMCPServer(t *testing.T) {
 	}
 	var output bytes.Buffer
 	err := codex.GenerateConfigToml(&output, "test", "http://127.0.0.1:38440/v1", "",
-		config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
 	if err != nil {
 		t.Fatalf("GenerateConfigToml() error = %v", err)
 	}
@@ -125,7 +127,6 @@ func TestGenerateConfigTomlIncludesDeepWikiMCPServer(t *testing.T) {
 		t.Fatalf("missing deepwiki MCP server in generated config:\n%s", generated)
 	}
 }
-
 
 func TestBuildModelInfosFromConfig_DeduplicatesSameModelAcrossProviders(t *testing.T) {
 	cfg := config.Config{
@@ -279,11 +280,11 @@ func TestBuildModelInfosFromConfig_ReasoningLevelsDeduplicatedByEffort(t *testin
 	}
 	// Low from preferred provider.
 	if levels[1].Effort != "low" || levels[1].Description != "A Low" {
-	t.Fatalf("levels[1] = %+v, want effort=low description=A Low", levels[1])
+		t.Fatalf("levels[1] = %+v, want effort=low description=A Low", levels[1])
 	}
 	// Xhigh should come from provider-b since it's a new effort.
 	if levels[2].Effort != "xhigh" || levels[2].Description != "B XHigh" {
-	t.Fatalf("levels[2] = %+v, want effort=xhigh description=B XHigh", levels[2])
+		t.Fatalf("levels[2] = %+v, want effort=xhigh description=B XHigh", levels[2])
 	}
 }
 func TestGenerateConfigTomlNormalizesDirectProviderModelRef(t *testing.T) {
@@ -301,7 +302,7 @@ func TestGenerateConfigTomlNormalizesDirectProviderModelRef(t *testing.T) {
 	}
 	// No route for "deepseek/deepseek-v4-pro" — it is a direct provider/model reference.
 	err := codex.GenerateConfigToml(&output, "deepseek/deepseek-v4-pro", "http://127.0.0.1:38440/v1", "",
-		config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
 	if err != nil {
 		t.Fatalf("GenerateConfigToml() error = %v", err)
 	}
@@ -331,7 +332,7 @@ func TestGenerateConfigTomlModelProviderFormatInputStable(t *testing.T) {
 	}
 	// Input already in model(provider) format — should remain unchanged.
 	err := codex.GenerateConfigToml(&output, "deepseek-v4-pro(deepseek)", "http://127.0.0.1:38440/v1", "",
-		config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
 	if err != nil {
 		t.Fatalf("GenerateConfigToml() error = %v", err)
 	}
@@ -359,7 +360,7 @@ func TestGenerateConfigTomlRouteAliasWithSlashNotNormalized(t *testing.T) {
 	}
 	// p1/model-a is an explicit route alias — should NOT be normalized.
 	err := codex.GenerateConfigToml(&output, "p1/model-a", "http://127.0.0.1:38440/v1", "",
-		config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
 	if err != nil {
 		t.Fatalf("GenerateConfigToml() error = %v", err)
 	}
@@ -384,7 +385,7 @@ func TestGenerateConfigTomlCodexHomeContainsNormalizedSlug(t *testing.T) {
 		},
 	}
 	err := codex.GenerateConfigToml(&output, "deepseek/deepseek-v4-pro", "http://127.0.0.1:38440/v1", codexHome,
-		config.ProviderFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
 	if err != nil {
 		t.Fatalf("GenerateConfigToml() error = %v", err)
 	}
@@ -402,7 +403,6 @@ func TestGenerateConfigTomlCodexHomeContainsNormalizedSlug(t *testing.T) {
 		t.Fatalf("config missing normalized model slug:\n%s", generated)
 	}
 }
-
 
 func TestWriteModelsCatalogProducesValidJSON(t *testing.T) {
 	dir := t.TempDir()
@@ -436,6 +436,86 @@ func TestWriteModelsCatalogProducesValidJSON(t *testing.T) {
 	}
 	if len(result.Models) == 0 {
 		t.Fatal("expected at least 1 model in catalog")
+	}
+}
+
+func TestGenerateConfigTomlCatalogIncludesVisualInjectedImageModality(t *testing.T) {
+	enabled := true
+	codexHome := t.TempDir()
+	var output bytes.Buffer
+	cfg := config.Config{
+		Models: map[string]config.ModelDef{
+			"gpt-text": {InputModalities: []string{"text"}},
+		},
+		ProviderDefs: map[string]config.ProviderDef{
+			"openai": {
+				Offers: []config.OfferEntry{{Model: "gpt-text"}},
+			},
+		},
+		Routes: map[string]config.RouteEntry{
+			"text-route": {Provider: "openai", Model: "gpt-text"},
+		},
+		Extensions: map[string]config.ExtensionSettings{
+			visual.PluginName: {Enabled: &enabled},
+		},
+	}
+
+	err := codex.GenerateConfigToml(&output, "text-route", "http://127.0.0.1:38440/v1", codexHome,
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+	if err != nil {
+		t.Fatalf("GenerateConfigToml() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(codexHome, "models_catalog.json"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	var result struct {
+		Models []codex.ModelInfo `json:"models"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("JSON unmarshal error = %v", err)
+	}
+	if len(result.Models) != 2 {
+		t.Fatalf("expected provider model plus route alias, got %d", len(result.Models))
+	}
+	for _, model := range result.Models {
+		hasImage := false
+		for _, mod := range model.InputModalities {
+			if mod == "image" {
+				hasImage = true
+				break
+			}
+		}
+		if !hasImage {
+			t.Fatalf("model %q missing injected image modality: %v", model.Slug, model.InputModalities)
+		}
+	}
+}
+
+func TestGenerateConfigTomlWritesAuthJSONWithOwnerOnlyPermissions(t *testing.T) {
+	codexHome := t.TempDir()
+	var output bytes.Buffer
+	cfg := config.Config{
+		Routes: map[string]config.RouteEntry{
+			"secure": {Provider: "openai", Model: "gpt-4o"},
+		},
+		AuthToken: "secret-token",
+	}
+
+	err := codex.GenerateConfigToml(&output, "secure", "http://127.0.0.1:38440/v1", codexHome,
+		config.ProviderFromGlobalConfig(&cfg), config.PluginFromGlobalConfig(&cfg), config.ServerFromGlobalConfig(&cfg))
+	if err != nil {
+		t.Fatalf("GenerateConfigToml() error = %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(codexHome, "auth.json"))
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("auth.json perm = %04o, want 0600", perm)
 	}
 }
 

--- a/internal/extension/codextool/customtool.go
+++ b/internal/extension/codextool/customtool.go
@@ -346,6 +346,28 @@ func InputSchemaWithFallback(params map[string]any, toolName string) map[string]
 	}
 }
 
+type applyPatchLine struct {
+	Op   string `json:"op"`
+	Text string `json:"text"`
+}
+
+type applyPatchHunk struct {
+	Context string           `json:"context"`
+	Lines   []applyPatchLine `json:"lines"`
+}
+
+type applyPatchSingleOp struct {
+	Type    string           `json:"type"`
+	Path    string           `json:"path"`
+	MoveTo  string           `json:"move_to"`
+	Content string           `json:"content"`
+	Hunks   []applyPatchHunk `json:"hunks"`
+}
+
+type applyPatchBatch struct {
+	Operations []applyPatchSingleOp `json:"operations"`
+}
+
 // ToolKindForGrammar returns the ToolKind for a custom tool grammar definition.
 func ToolKindForGrammar(grammar string, toolName string) (ToolKind, bool) {
 	if toolName == "local_shell" {
@@ -369,6 +391,72 @@ func AnnotateCoreTool(t *format.CoreTool, kind ToolKind, openAIName, namespace s
 	t.Extensions["codex_openai_name"] = openAIName
 	t.Extensions["codex_namespace"] = namespace
 }
+
+func appendApplyPatchOperation(b *strings.Builder, op applyPatchSingleOp) bool {
+	if strings.TrimSpace(op.Path) == "" {
+		return false
+	}
+
+	switch op.Type {
+	case "", "batch":
+		return false
+	case "add_file", "replace_file":
+		fmt.Fprintln(b, "*** Begin Patch")
+		if op.Type == "replace_file" {
+			fmt.Fprintf(b, "*** Update File: %s\n", op.Path)
+			if strings.TrimSpace(op.MoveTo) != "" {
+				fmt.Fprintf(b, "*** Move to: %s\n", op.MoveTo)
+			}
+			if op.Content != "" {
+				for _, line := range strings.Split(op.Content, "\n") {
+					fmt.Fprintf(b, "+%s\n", line)
+				}
+			}
+		} else {
+			fmt.Fprintf(b, "*** Add File: %s\n", op.Path)
+			if op.Content != "" {
+				for _, line := range strings.Split(op.Content, "\n") {
+					fmt.Fprintf(b, "+%s\n", line)
+				}
+			}
+		}
+		fmt.Fprintln(b, "*** End Patch")
+		return true
+	case "delete_file":
+		fmt.Fprintln(b, "*** Begin Patch")
+		fmt.Fprintf(b, "*** Delete File: %s\n", op.Path)
+		fmt.Fprintln(b, "*** End Patch")
+		return true
+	case "update_file":
+		fmt.Fprintln(b, "*** Begin Patch")
+		fmt.Fprintf(b, "*** Update File: %s\n", op.Path)
+		if strings.TrimSpace(op.MoveTo) != "" {
+			fmt.Fprintf(b, "*** Move to: %s\n", op.MoveTo)
+		}
+		for _, hunk := range op.Hunks {
+			if strings.TrimSpace(hunk.Context) == "" {
+				fmt.Fprintln(b, "@@")
+			} else {
+				fmt.Fprintf(b, "@@ %s\n", hunk.Context)
+			}
+			for _, line := range hunk.Lines {
+				switch line.Op {
+				case "add":
+					fmt.Fprintf(b, "+%s\n", line.Text)
+				case "remove":
+					fmt.Fprintf(b, "-%s\n", line.Text)
+				default:
+					fmt.Fprintf(b, " %s\n", line.Text)
+				}
+			}
+		}
+		fmt.Fprintln(b, "*** End Patch")
+		return true
+	default:
+		return false
+	}
+}
+
 // RebuildApplyPatchGrammar reconstructs the raw apply_patch grammar from
 // a proxy tool name and its structured input, for use as custom_tool_call.input.
 func RebuildApplyPatchGrammar(proxyName string, input json.RawMessage) string {
@@ -378,74 +466,52 @@ func RebuildApplyPatchGrammar(proxyName string, input json.RawMessage) string {
 	}
 	switch action {
 	case "add_file", "replace_file":
-		var p struct {
-			Path    string `json:"path"`
-			Content string `json:"content"`
-		}
-		if err := json.Unmarshal(input, &p); err != nil || p.Path == "" {
+		var p applyPatchSingleOp
+		if err := json.Unmarshal(input, &p); err != nil {
 			return string(input)
 		}
-		return fmt.Sprintf("*** Add File: %s\n%s\n*** End Patch", p.Path, p.Content)
-	case "delete_file":
-		var p struct{ Path string `json:"path"` }
-		if err := json.Unmarshal(input, &p); err != nil || p.Path == "" {
-			return string(input)
-		}
-		return fmt.Sprintf("*** Delete File: %s\n*** End Patch", p.Path)
-	case "update_file":
-		var p struct {
-			Path   string `json:"path"`
-			Hunks []map[string]any `json:"hunks"`
-		}
-		if err := json.Unmarshal(input, &p); err != nil || p.Path == "" {
-			return string(input)
-		}
+		p.Type = action
 		var b strings.Builder
-		fmt.Fprintf(&b, "*** Update File: %s\n", p.Path)
-		for _, hunk := range p.Hunks {
-			ctx, _ := hunk["context"].(string)
-			if ctx != "" {
-				fmt.Fprintf(&b, "*** Context: %s\n", ctx)
-			}
-			if lines, ok := hunk["lines"].([]any); ok {
-				for _, l := range lines {
-					if lm, ok := l.(map[string]any); ok {
-						op, _ := lm["op"].(string)
-						text, _ := lm["text"].(string)
-						switch op {
-						case "add":
-							b.WriteString("+ " + text + "\n")
-						case "remove":
-							b.WriteString("- " + text + "\n")
-						default:
-							b.WriteString("  " + text + "\n")
-						}
-					}
-				}
-			}
+		if !appendApplyPatchOperation(&b, p) {
+			return string(input)
 		}
-		fmt.Fprintf(&b, "*** End Patch")
 		return b.String()
-	case "batch":
-		var p struct {
-			Operations []map[string]any `json:"operations"`
+	case "delete_file":
+		var p applyPatchSingleOp
+		if err := json.Unmarshal(input, &p); err != nil {
+			return string(input)
 		}
+		p.Type = action
+		var b strings.Builder
+		if !appendApplyPatchOperation(&b, p) {
+			return string(input)
+		}
+		return b.String()
+	case "update_file":
+		var p applyPatchSingleOp
 		if err := json.Unmarshal(input, &p); err != nil {
 			return string(input)
 		}
 		var b strings.Builder
+		p.Type = action
+		if !appendApplyPatchOperation(&b, p) {
+			return string(input)
+		}
+		return b.String()
+	case "batch":
+		var p applyPatchBatch
+		if err := json.Unmarshal(input, &p); err != nil {
+			return string(input)
+		}
+		var b strings.Builder
+		wrote := false
 		for _, op := range p.Operations {
-			opType, _ := op["type"].(string)
-			path, _ := op["path"].(string)
-			switch opType {
-			case "add_file", "replace_file":
-				content, _ := op["content"].(string)
-				fmt.Fprintf(&b, "*** Add File: %s\n%s\n*** End Patch\n", path, content)
-			case "delete_file":
-				fmt.Fprintf(&b, "*** Delete File: %s\n*** End Patch\n", path)
-			case "update_file":
-				fmt.Fprintf(&b, "*** Update File: %s\n*** End Patch\n", path)
+			if appendApplyPatchOperation(&b, op) {
+				wrote = true
 			}
+		}
+		if !wrote {
+			return string(input)
 		}
 		return b.String()
 	default:
@@ -455,12 +521,15 @@ func RebuildApplyPatchGrammar(proxyName string, input json.RawMessage) string {
 
 // RebuildExecGrammar reconstructs the raw exec grammar from structured input.
 func RebuildExecGrammar(input json.RawMessage) string {
-	var p struct{ Source string `json:"source"` }
+	var p struct {
+		Source string `json:"source"`
+	}
 	if err := json.Unmarshal(input, &p); err != nil || p.Source == "" {
 		return string(input)
 	}
 	return p.Source
 }
+
 // RebuildGrammar auto-detects the tool type from the proxy tool name and
 // reconstructs the raw grammar input for custom_tool_call from structured arguments.
 func RebuildGrammar(proxyName string, input json.RawMessage) string {
@@ -479,5 +548,5 @@ func RebuildGrammar(proxyName string, input json.RawMessage) string {
 	if strings.HasPrefix(proxyName, "exec_") {
 		return RebuildExecGrammar(input)
 	}
-	return string(input)
+	return InputFromRaw(input)
 }

--- a/internal/extension/codextool/customtool_test.go
+++ b/internal/extension/codextool/customtool_test.go
@@ -1,0 +1,87 @@
+package codextool
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRebuildApplyPatchGrammarUpdateFileIncludesValidPatchMarkers(t *testing.T) {
+	input := json.RawMessage(`{
+		"path":"internal/example.go",
+		"move_to":"internal/example_v2.go",
+		"hunks":[
+			{
+				"context":"func demo()",
+				"lines":[
+					{"op":"context","text":"func demo() {"},
+					{"op":"remove","text":"\told()"},
+					{"op":"add","text":"\tnew()"},
+					{"op":"context","text":"}"}
+				]
+			}
+		]
+	}`)
+
+	got := RebuildApplyPatchGrammar("apply_patch_update_file", input)
+
+	for _, want := range []string{
+		"*** Begin Patch\n",
+		"*** Update File: internal/example.go\n",
+		"*** Move to: internal/example_v2.go\n",
+		"@@ func demo()\n",
+		" func demo() {\n",
+		"-\told()\n",
+		"+\tnew()\n",
+		" }\n",
+		"*** End Patch\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rebuilt patch missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRebuildApplyPatchGrammarBatchPreservesAllOperations(t *testing.T) {
+	input := json.RawMessage(`{
+		"operations":[
+			{"type":"add_file","path":"new.txt","content":"hello\nworld"},
+			{"type":"delete_file","path":"old.txt"},
+			{
+				"type":"update_file",
+				"path":"edit.txt",
+				"hunks":[
+					{
+						"context":"header",
+						"lines":[
+							{"op":"context","text":"same"},
+							{"op":"add","text":"added"}
+						]
+					}
+				]
+			}
+		]
+	}`)
+
+	got := RebuildApplyPatchGrammar("apply_patch_batch", input)
+
+	if strings.Count(got, "*** Begin Patch\n") != 3 {
+		t.Fatalf("expected 3 begin markers, got:\n%s", got)
+	}
+	for _, want := range []string{
+		"*** Add File: new.txt\n+hello\n+world\n*** End Patch\n",
+		"*** Delete File: old.txt\n*** End Patch\n",
+		"*** Update File: edit.txt\n@@ header\n same\n+added\n*** End Patch\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rebuilt batch missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRebuildGrammarUsesRawInputForGenericCustomTools(t *testing.T) {
+	got := RebuildGrammar("custom_tool", json.RawMessage(`{"input":"plain freeform body"}`))
+	if got != "plain freeform body" {
+		t.Fatalf("RebuildGrammar() = %q, want raw input", got)
+	}
+}

--- a/internal/extension/deepseek_v4/plugin.go
+++ b/internal/extension/deepseek_v4/plugin.go
@@ -6,10 +6,10 @@ import (
 	"log/slog"
 	"strings"
 
-	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/config"
-	"moonbridge/internal/protocol/anthropic"
+	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/protocol/openai"
 )
 
@@ -35,10 +35,11 @@ type EnabledFunc func(modelAlias string) bool
 // DSPlugin implements the new plugin.Plugin interface plus relevant capabilities.
 type DSPlugin struct {
 	plugin.BasePlugin
-	isEnabled EnabledFunc
-	pluginCfg config.PluginConfig
-	logger    *slog.Logger
-	cfg       *Config
+	isEnabled     EnabledFunc
+	pluginCfg     config.PluginConfig
+	currentConfig func() config.Config
+	logger        *slog.Logger
+	cfg           *Config
 }
 
 // NewPlugin creates a DeepSeek V4 plugin.
@@ -53,6 +54,9 @@ func NewPlugin(isEnabled ...EnabledFunc) *DSPlugin {
 func (p *DSPlugin) Name() string                              { return PluginName }
 func (p *DSPlugin) ConfigSpecs() []config.ExtensionConfigSpec { return ConfigSpecs() }
 func (p *DSPlugin) EnabledForModel(model string) bool {
+	if p.currentConfig != nil {
+		return p.currentConfig().ExtensionEnabled(PluginName, model)
+	}
 	if p.isEnabled != nil {
 		return p.isEnabled(model)
 	}
@@ -63,6 +67,7 @@ func (p *DSPlugin) EnabledForModel(model string) bool {
 }
 func (p *DSPlugin) Init(ctx plugin.PluginContext) error {
 	p.pluginCfg = config.PluginFromGlobalConfig(&ctx.AppConfig)
+	p.currentConfig = ctx.CurrentConfig
 	p.logger = ctx.Logger
 	p.cfg = plugin.Config[Config](ctx)
 	return nil
@@ -112,12 +117,13 @@ func (p *DSPlugin) MutateRequest(ctx *plugin.RequestContext, req *format.CoreReq
 // --- MessageRewriter ---
 
 func (p *DSPlugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.CoreMessage) []format.CoreMessage {
-	if p.cfg == nil || p.cfg.ReinforceInstructions == nil || !*p.cfg.ReinforceInstructions {
+	cfg := p.configForModel(modelAliasFromRequestContext(ctx))
+	if cfg == nil || cfg.ReinforceInstructions == nil || !*cfg.ReinforceInstructions {
 		return messages
 	}
 	prompt := DefaultReinforcePrompt
-	if p.cfg.ReinforcePrompt != nil && *p.cfg.ReinforcePrompt != "" {
-		prompt = *p.cfg.ReinforcePrompt
+	if cfg.ReinforcePrompt != nil && *cfg.ReinforcePrompt != "" {
+		prompt = *cfg.ReinforcePrompt
 	}
 	// Inject a reinforcement message before the last real user message.
 	// Skip tool_result messages (they have Role="user" but are tool responses).
@@ -136,6 +142,34 @@ func (p *DSPlugin) RewriteMessages(ctx *plugin.RequestContext, messages []format
 		}
 	}
 	return messages
+}
+
+func (p *DSPlugin) configForModel(modelAlias string) *Config {
+	if p.currentConfig != nil {
+		current := p.currentConfig()
+		cfg, _ := current.ExtensionConfig(PluginName, modelAlias).(*Config)
+		if cfg != nil {
+			return cfg
+		}
+		raw := current.ExtensionRawConfig(PluginName, modelAlias)
+		if len(raw) > 0 {
+			data, err := json.Marshal(raw)
+			if err == nil {
+				var decoded Config
+				if err := json.Unmarshal(data, &decoded); err == nil {
+					return &decoded
+				}
+			}
+		}
+	}
+	return p.cfg
+}
+
+func modelAliasFromRequestContext(ctx *plugin.RequestContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return ctx.ModelAlias
 }
 
 // isToolResultMessageFormat checks if a user message contains only tool_result blocks.
@@ -331,8 +365,8 @@ func (p *DSPlugin) OnStreamEvent(ctx *plugin.StreamContext, event plugin.StreamE
 		}
 		// Track tool_use block IDs so they can be matched to thinking blocks
 		// during RememberStreamResult.
-			if event.Block != nil && event.Block.Type == "tool_use" && event.Block.ToolUseID != "" {
-				ss.RecordToolCall(event.Block.ToolUseID)
+		if event.Block != nil && event.Block.Type == "tool_use" && event.Block.ToolUseID != "" {
+			ss.RecordToolCall(event.Block.ToolUseID)
 		}
 	case "block_delta":
 		if ss.Delta(event.Index, event.Delta) {

--- a/internal/extension/kimi_workaround/plugin.go
+++ b/internal/extension/kimi_workaround/plugin.go
@@ -7,10 +7,11 @@
 package kimi_workaround
 
 import (
+	"encoding/json"
 	"fmt"
 
-	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/format"
 )
 
@@ -29,17 +30,18 @@ type EnabledFunc func(modelAlias string) bool
 
 // Config holds the kimi_workaround extension configuration.
 type Config struct {
-	MaxToolRounds       *int     `json:"max_tool_rounds,omitempty" yaml:"max_tool_rounds"`
-	ConvergenceMargin   *float64 `json:"convergence_margin,omitempty" yaml:"convergence_margin"`
+	MaxToolRounds     *int     `json:"max_tool_rounds,omitempty" yaml:"max_tool_rounds"`
+	ConvergenceMargin *float64 `json:"convergence_margin,omitempty" yaml:"convergence_margin"`
 }
 
 // Plugin implements the kimi workaround extension.
 type Plugin struct {
 	plugin.BasePlugin
-	isEnabled EnabledFunc
-	pluginCfg config.PluginConfig
-	maxRounds int
-	margin    float64
+	isEnabled     EnabledFunc
+	pluginCfg     config.PluginConfig
+	currentConfig func() config.Config
+	maxRounds     int
+	margin        float64
 }
 
 func NewPlugin(isEnabled ...EnabledFunc) *Plugin {
@@ -69,6 +71,7 @@ func ConfigSpecs() []config.ExtensionConfigSpec {
 
 func (p *Plugin) Init(ctx plugin.PluginContext) error {
 	p.pluginCfg = config.PluginFromGlobalConfig(&ctx.AppConfig)
+	p.currentConfig = ctx.CurrentConfig
 	if cfg := plugin.Config[Config](ctx); cfg != nil {
 		if cfg.MaxToolRounds != nil && *cfg.MaxToolRounds > 0 {
 			p.maxRounds = *cfg.MaxToolRounds
@@ -83,6 +86,9 @@ func (p *Plugin) Init(ctx plugin.PluginContext) error {
 func (p *Plugin) Shutdown() error { return nil }
 
 func (p *Plugin) EnabledForModel(model string) bool {
+	if p.currentConfig != nil {
+		return p.currentConfig().ExtensionEnabled(PluginName, model)
+	}
 	if p.isEnabled != nil {
 		return p.isEnabled(model)
 	}
@@ -101,12 +107,7 @@ func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.C
 	if !p.EnabledForModel(modelAlias) {
 		return messages
 	}
-	if p.maxRounds <= 0 {
-		p.maxRounds = 50
-	}
-	if p.margin <= 0 {
-		p.margin = 0.8
-	}
+	maxRounds, margin := p.limitsForModel(modelAlias)
 
 	// Count tool call rounds since the last real user message.
 	// Each new user prompt resets the counter — we only care about how many
@@ -169,7 +170,7 @@ func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.C
 	// When approaching limit: append prompts to the last tool_result's content.
 	// When AT limit: REPLACE the last tool_result's content with a hard error
 	// so the model sees that tools are "broken" and must produce a final answer.
-	threshold := int(float64(p.maxRounds) * p.margin)
+	threshold := int(float64(maxRounds) * margin)
 	messagesCopy := make([]format.CoreMessage, len(messages))
 	copy(messagesCopy, messages)
 
@@ -179,12 +180,12 @@ func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.C
 		if msg.Role == "tool" || (msg.Role == "user" && isToolResultMessage(*msg)) {
 			for j := len(msg.Content) - 1; j >= 0; j-- {
 				if msg.Content[j].Type == "tool_result" && msg.Content[j].ToolUseID != "" {
-					if roundCount >= p.maxRounds {
+					if roundCount >= maxRounds {
 						// Hard cap reached — replace tool_result content with an error.
 						// The model will see the tool as failed and stop calling it.
 						errJSON := fmt.Sprintf(
 							"{\"error\":\"MAX_TOOL_ROUNDS\",\"message\":\"Tool call limit reached after %d rounds. Must produce final response immediately without any additional tool calls.\"}",
-							p.maxRounds,
+							maxRounds,
 						)
 						msg.Content[j].ToolResultContent = []format.CoreContentBlock{{
 							Type: "text",
@@ -193,7 +194,7 @@ func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.C
 						return messagesCopy
 					}
 					// Approaching limit — append prompts.
-					prompt := fmt.Sprintf(DefaultPrompt, roundCount, p.maxRounds)
+					prompt := fmt.Sprintf(DefaultPrompt, roundCount, maxRounds)
 					msg.Content[j].ToolResultContent = append(
 						msg.Content[j].ToolResultContent,
 						format.CoreContentBlock{Type: "text", Text: prompt},
@@ -212,6 +213,39 @@ func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.C
 
 	// Fallback: if we couldn't find a tool_result to append to, return unchanged.
 	return messages
+}
+
+func (p *Plugin) limitsForModel(modelAlias string) (int, float64) {
+	maxRounds := p.maxRounds
+	margin := p.margin
+	if maxRounds <= 0 {
+		maxRounds = 50
+	}
+	if margin <= 0 {
+		margin = 0.8
+	}
+	if p.currentConfig == nil {
+		return maxRounds, margin
+	}
+	raw := p.currentConfig().ExtensionRawConfig(PluginName, modelAlias)
+	if len(raw) == 0 {
+		return maxRounds, margin
+	}
+	var cfg Config
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return maxRounds, margin
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return maxRounds, margin
+	}
+	if cfg.MaxToolRounds != nil && *cfg.MaxToolRounds > 0 {
+		maxRounds = *cfg.MaxToolRounds
+	}
+	if cfg.ConvergenceMargin != nil && *cfg.ConvergenceMargin > 0 {
+		margin = *cfg.ConvergenceMargin
+	}
+	return maxRounds, margin
 }
 
 // isSystemReminder checks if a user message is one of our injected prompts.
@@ -294,7 +328,7 @@ func hasUnmatchedToolUse(messages []format.CoreMessage, lastIdx int) bool {
 }
 
 var (
-	_ plugin.Plugin          = (*Plugin)(nil)
+	_ plugin.Plugin             = (*Plugin)(nil)
 	_ plugin.ConfigSpecProvider = (*Plugin)(nil)
-	_ plugin.MessageRewriter = (*Plugin)(nil)
+	_ plugin.MessageRewriter    = (*Plugin)(nil)
 )

--- a/internal/extension/plugin/plugin.go
+++ b/internal/extension/plugin/plugin.go
@@ -34,9 +34,10 @@ type PluginContext struct {
 	// Config is the decoded typed config struct for the plugin, or nil if
 	// the plugin has not registered a config type. Populated by Registry.InitAll.
 	// Use plugin.Config[T](ctx) to retrieve a typed struct.
-	Config    any
-	AppConfig config.Config // read-only global config
-	Logger    *slog.Logger  // logger prefixed with the plugin name
+	Config        any
+	AppConfig     config.Config // read-only init-time config snapshot
+	CurrentConfig func() config.Config
+	Logger        *slog.Logger // logger prefixed with the plugin name
 }
 
 // ConfigSpecProvider lets plugins declare extension-owned configuration across

--- a/internal/extension/plugin/registry.go
+++ b/internal/extension/plugin/registry.go
@@ -35,6 +35,7 @@ type Registry struct {
 	routeRegistrars        []RouteRegistrar
 	configSpecs            []config.ExtensionConfigSpec
 	logger                 *slog.Logger
+	currentConfig          func() config.Config
 }
 
 // NewRegistry creates an empty plugin registry.
@@ -43,6 +44,15 @@ func NewRegistry(logger *slog.Logger) *Registry {
 		logger = slog.Default()
 	}
 	return &Registry{logger: logger}
+}
+
+// SetCurrentConfigProvider installs a callback used by plugins that need the
+// latest resolved configuration at request time.
+func (r *Registry) SetCurrentConfigProvider(provider func() config.Config) {
+	if r == nil {
+		return
+	}
+	r.currentConfig = provider
 }
 
 // Register adds a plugin and detects its capabilities.
@@ -136,9 +146,10 @@ func (r *Registry) InitAll(appCfg InitConfigProvider) error {
 			}
 		}
 		ctx := PluginContext{
-			Config:    typedCfg,
-			AppConfig: appConfig,
-			Logger:    r.logger.With("plugin", p.Name()),
+			Config:        typedCfg,
+			AppConfig:     appConfig,
+			CurrentConfig: r.currentConfig,
+			Logger:        r.logger.With("plugin", p.Name()),
 		}
 		if err := p.Init(ctx); err != nil {
 			return fmt.Errorf("plugin %s init failed: %w", p.Name(), err)

--- a/internal/extension/plugin/registry.go
+++ b/internal/extension/plugin/registry.go
@@ -1,16 +1,15 @@
 package plugin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 
-	"context"
-
 	"moonbridge/internal/config"
-	"moonbridge/internal/logger"
 	"moonbridge/internal/format"
+	"moonbridge/internal/logger"
 	"moonbridge/internal/protocol/openai"
 )
 
@@ -491,27 +490,45 @@ func (r *Registry) CorePluginHooks() format.CorePluginHooks {
 		// MutateCoreRequest
 		if m, ok := p.(CoreRequestMutator); ok {
 			prev := hooks.MutateCoreRequest
+			pluginImpl := p
 			hooks.MutateCoreRequest = func(ctx context.Context, req *format.CoreRequest) {
-				if prev != nil { prev(ctx, req) }
+				if prev != nil {
+					prev(ctx, req)
+				}
+				if req == nil || !pluginImpl.EnabledForModel(req.Model) {
+					return
+				}
 				m.MutateCoreRequest(ctx, req)
 			}
 		}
 		// FilterCoreContent
 		if f, ok := p.(CoreContentFilter); ok {
 			prev := hooks.FilterContent
+			pluginImpl := p
 			hooks.FilterContent = func(ctx context.Context, block *format.CoreContentBlock) bool {
-				if prev != nil && prev(ctx, block) { return true }
+				if prev != nil && prev(ctx, block) {
+					return true
+				}
+				model := format.ModelAliasFromCoreHookContext(ctx)
+				if model == "" || !pluginImpl.EnabledForModel(model) {
+					return false
+				}
 				return f.FilterCoreContent(ctx, block)
 			}
 		}
 		// RewriteMessages — only chain plugins enabled for this model.
 		if mw, ok := p.(MessageRewriter); ok {
 			prev := hooks.RewriteMessages
-			plugin := p.(Plugin) // for EnabledForModel check
+			pluginImpl := p
 			hooks.RewriteMessages = func(ctx context.Context, req *format.CoreRequest) {
-				if prev != nil { prev(ctx, req) }
+				if prev != nil {
+					prev(ctx, req)
+				}
+				if req == nil {
+					return
+				}
 				pluginCtx := &RequestContext{ModelAlias: req.Model}
-				if plugin.EnabledForModel(req.Model) {
+				if pluginImpl.EnabledForModel(req.Model) {
 					req.Messages = mw.RewriteMessages(pluginCtx, req.Messages)
 				}
 			}
@@ -519,8 +536,15 @@ func (r *Registry) CorePluginHooks() format.CorePluginHooks {
 		// RememberCoreContent
 		if rmem, ok := p.(CoreContentRememberer); ok {
 			prev := hooks.RememberContent
+			pluginImpl := p
 			hooks.RememberContent = func(ctx context.Context, content []format.CoreContentBlock) {
-				if prev != nil { prev(ctx, content) }
+				if prev != nil {
+					prev(ctx, content)
+				}
+				model := format.ModelAliasFromCoreHookContext(ctx)
+				if model == "" || !pluginImpl.EnabledForModel(model) {
+					return
+				}
 				rmem.RememberCoreContent(ctx, content)
 			}
 		}

--- a/internal/extension/plugin/registry_test.go
+++ b/internal/extension/plugin/registry_test.go
@@ -1,9 +1,10 @@
 package plugin_test
 
 import (
+	"context"
 	"encoding/json"
-	"testing"
 	"moonbridge/internal/format"
+	"testing"
 
 	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/protocol/openai"
@@ -43,6 +44,16 @@ func (p *testMutator) MutateRequest(_ *plugin.RequestContext, req *format.CoreRe
 	req.Temperature = &v
 }
 
+type testCoreRequestMutator struct {
+	testPlugin
+	called int
+}
+
+func (p *testCoreRequestMutator) MutateCoreRequest(_ context.Context, req *format.CoreRequest) {
+	p.called++
+	req.Metadata = map[string]any{"mutated": true}
+}
+
 type testToolInjector struct {
 	testPlugin
 }
@@ -60,6 +71,25 @@ func (p *testContentFilter) FilterContent(_ *plugin.RequestContext, block format
 		return true
 	}
 	return false
+}
+
+type testCoreContentFilter struct {
+	testPlugin
+	called int
+}
+
+func (p *testCoreContentFilter) FilterCoreContent(_ context.Context, block *format.CoreContentBlock) bool {
+	p.called++
+	return block != nil && block.Type == "reasoning"
+}
+
+type testCoreContentRememberer struct {
+	testPlugin
+	called int
+}
+
+func (p *testCoreContentRememberer) RememberCoreContent(_ context.Context, _ []format.CoreContentBlock) {
+	p.called++
 }
 
 type testErrorTransformer struct {
@@ -218,8 +248,8 @@ func TestRegistryOnStreamEvent(t *testing.T) {
 	r := plugin.NewRegistry(nil)
 	r.Register(&testStreamInterceptor{testPlugin: testPlugin{name: "si", enabled: true}})
 
-		states := r.NewStreamStates("model")
-		block := &format.CoreContentBlock{Type: "reasoning"}
+	states := r.NewStreamStates("model")
+	block := &format.CoreContentBlock{Type: "reasoning"}
 	consumed, _ := r.OnStreamEvent("model", plugin.StreamEvent{Type: "block_start", Index: 0, Block: block}, states)
 	if !consumed {
 		t.Fatal("should consume thinking block_start")
@@ -247,6 +277,64 @@ func TestRegistryNilSafe(t *testing.T) {
 		t.Fatal("nil registry should not have enabled plugins")
 	}
 }
+
+func TestCorePluginHooksMutateCoreRequestHonorsEnabledForModel(t *testing.T) {
+	r := plugin.NewRegistry(nil)
+	disabled := &testCoreRequestMutator{testPlugin: testPlugin{name: "disabled_mutator", enabled: false}}
+	enabled := &testCoreRequestMutator{testPlugin: testPlugin{name: "enabled_mutator", enabled: true}}
+	r.Register(disabled)
+	r.Register(enabled)
+
+	req := &format.CoreRequest{Model: "test-model"}
+	hooks := r.CorePluginHooks()
+	hooks.MutateCoreRequest(context.Background(), req)
+
+	if disabled.called != 0 {
+		t.Fatalf("disabled mutator called %d times", disabled.called)
+	}
+	if enabled.called != 1 {
+		t.Fatalf("enabled mutator called %d times", enabled.called)
+	}
+	if req.Metadata == nil || req.Metadata["mutated"] != true {
+		t.Fatalf("request metadata not mutated as expected: %+v", req.Metadata)
+	}
+}
+
+func TestCorePluginHooksFilterAndRememberRequireModelContext(t *testing.T) {
+	r := plugin.NewRegistry(nil)
+	enabledFilter := &testCoreContentFilter{testPlugin: testPlugin{name: "enabled_filter", enabled: true}}
+	enabledRemember := &testCoreContentRememberer{testPlugin: testPlugin{name: "enabled_remember", enabled: true}}
+	r.Register(enabledFilter)
+	r.Register(enabledRemember)
+
+	hooks := r.CorePluginHooks()
+	block := &format.CoreContentBlock{Type: "reasoning"}
+	content := []format.CoreContentBlock{{Type: "text", Text: "hello"}}
+
+	if hooks.FilterContent(context.Background(), block) {
+		t.Fatal("FilterContent should not run without model context")
+	}
+	hooks.RememberContent(context.Background(), content)
+	if enabledFilter.called != 0 {
+		t.Fatalf("filter called without model context: %d", enabledFilter.called)
+	}
+	if enabledRemember.called != 0 {
+		t.Fatalf("remember called without model context: %d", enabledRemember.called)
+	}
+
+	ctx := format.WithCoreHookModelAlias(context.Background(), "test-model")
+	if !hooks.FilterContent(ctx, block) {
+		t.Fatal("FilterContent should run and skip reasoning block with model context")
+	}
+	hooks.RememberContent(ctx, content)
+	if enabledFilter.called != 1 {
+		t.Fatalf("filter called %d times with model context", enabledFilter.called)
+	}
+	if enabledRemember.called != 1 {
+		t.Fatalf("remember called %d times with model context", enabledRemember.called)
+	}
+}
+
 type onStreamCompleteRecorder struct {
 	testPlugin
 	called bool

--- a/internal/extension/visual/core_orchestrator.go
+++ b/internal/extension/visual/core_orchestrator.go
@@ -56,13 +56,15 @@ func (o *CoreOrchestrator) CreateCore(ctx context.Context, req *format.CoreReque
 	if o.client == nil {
 		return nil, fmt.Errorf("visual client is nil")
 	}
+	req = cloneCoreRequest(req)
 	req, availableImages := prepareCoreRequestForVisual(req)
 	log := slog.Default()
 	aggregatedUsage := format.CoreUsage{}
 	hasAggregatedUsage := false
 
 	for round := 0; round < o.maxRounds; round++ {
-		resp, err := o.upstream.CreateCore(ctx, req)
+		roundReq := cloneCoreRequest(req)
+		resp, err := o.upstream.CreateCore(ctx, roundReq)
 		if err != nil {
 			return nil, err
 		}
@@ -268,4 +270,23 @@ func applyCoreUsageAggregation(resp *format.CoreResponse, usage format.CoreUsage
 	resp.Usage = usage
 	resp.Usage.TotalTokens = resp.Usage.InputTokens + resp.Usage.OutputTokens
 	return resp
+}
+
+func cloneCoreRequest(req *format.CoreRequest) *format.CoreRequest {
+	if req == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		cloned := *req
+		return &cloned
+	}
+
+	var cloned format.CoreRequest
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		cloned = *req
+		return &cloned
+	}
+	return &cloned
 }

--- a/internal/extension/visual/core_orchestrator.go
+++ b/internal/extension/visual/core_orchestrator.go
@@ -34,7 +34,6 @@ type CoreOrchestratorConfig struct {
 }
 
 // NewCoreOrchestrator creates a CoreOrchestrator.
-// If Client is nil, it falls back to creating a BridgeCoreClient from the config.
 func NewCoreOrchestrator(cfg CoreOrchestratorConfig) *CoreOrchestrator {
 	maxRounds := cfg.MaxRounds
 	if maxRounds <= 0 {
@@ -54,10 +53,15 @@ func (o *CoreOrchestrator) CreateCore(ctx context.Context, req *format.CoreReque
 	if o == nil || o.upstream == nil {
 		return nil, fmt.Errorf("visual upstream provider is nil")
 	}
+	if o.client == nil {
+		return nil, fmt.Errorf("visual client is nil")
+	}
 	req, availableImages := prepareCoreRequestForVisual(req)
 	log := slog.Default()
+	aggregatedUsage := format.CoreUsage{}
+	hasAggregatedUsage := false
 
-	for round := 0; round <= o.maxRounds; round++ {
+	for round := 0; round < o.maxRounds; round++ {
 		resp, err := o.upstream.CreateCore(ctx, req)
 		if err != nil {
 			return nil, err
@@ -65,21 +69,25 @@ func (o *CoreOrchestrator) CreateCore(ctx context.Context, req *format.CoreReque
 		if resp == nil {
 			return nil, fmt.Errorf("upstream returned nil response")
 		}
+		if coreUsagePresent(resp.Usage) {
+			hasAggregatedUsage = true
+			aggregateCoreUsage(&aggregatedUsage, resp.Usage)
+		}
 
 		// If not a tool_use stop, we're done.
 		if resp.StopReason != "tool_use" {
-			return resp, nil
+			return applyCoreUsageAggregation(resp, aggregatedUsage, hasAggregatedUsage), nil
 		}
 
 		// Find visual tool uses in the last assistant message.
 		lastAssistant := findLastAssistantMessage(resp.Messages)
 		if lastAssistant == nil {
-			return resp, nil
+			return applyCoreUsageAggregation(resp, aggregatedUsage, hasAggregatedUsage), nil
 		}
 
 		toolUses, nonVisual := coreSplitVisualToolUses(lastAssistant.Content)
 		if len(nonVisual) > 0 || len(toolUses) == 0 {
-			return resp, nil
+			return applyCoreUsageAggregation(resp, aggregatedUsage, hasAggregatedUsage), nil
 		}
 
 		// Execute each visual tool via the vision client.
@@ -87,8 +95,8 @@ func (o *CoreOrchestrator) CreateCore(ctx context.Context, req *format.CoreReque
 		for _, toolUse := range toolUses {
 			result := o.executeCoreVisualTool(ctx, toolUse, availableImages)
 			toolResults = append(toolResults, format.CoreContentBlock{
-				Type:         "tool_result",
-				ToolUseID:    toolUse.ToolUseID,
+				Type:              "tool_result",
+				ToolUseID:         toolUse.ToolUseID,
 				ToolResultContent: []format.CoreContentBlock{{Type: "text", Text: result}},
 			})
 		}
@@ -240,4 +248,24 @@ func coreAnalysisRequestFromToolUse(toolUse format.CoreContentBlock, availableIm
 	default:
 		return AnalysisRequest{}, fmt.Errorf("unknown visual tool %q", toolUse.ToolName)
 	}
+}
+
+func coreUsagePresent(usage format.CoreUsage) bool {
+	return usage.InputTokens > 0 || usage.OutputTokens > 0 || usage.CachedInputTokens > 0 || usage.TotalTokens > 0
+}
+
+func aggregateCoreUsage(total *format.CoreUsage, usage format.CoreUsage) {
+	total.InputTokens += usage.InputTokens
+	total.OutputTokens += usage.OutputTokens
+	total.CachedInputTokens += usage.CachedInputTokens
+	total.TotalTokens = total.InputTokens + total.OutputTokens
+}
+
+func applyCoreUsageAggregation(resp *format.CoreResponse, usage format.CoreUsage, hasUsage bool) *format.CoreResponse {
+	if resp == nil || !hasUsage {
+		return resp
+	}
+	resp.Usage = usage
+	resp.Usage.TotalTokens = resp.Usage.InputTokens + resp.Usage.OutputTokens
+	return resp
 }

--- a/internal/extension/visual/core_orchestrator_test.go
+++ b/internal/extension/visual/core_orchestrator_test.go
@@ -17,7 +17,7 @@ type fakeCoreUpstream struct {
 }
 
 func (f *fakeCoreUpstream) CreateCore(_ context.Context, req *format.CoreRequest) (*format.CoreResponse, error) {
-	f.requests = append(f.requests, req)
+	f.requests = append(f.requests, cloneCoreRequest(req))
 	if len(f.responses) == 0 {
 		return nil, io.EOF
 	}
@@ -33,7 +33,7 @@ type fakeCoreVision struct {
 }
 
 func (f *fakeCoreVision) CreateCore(_ context.Context, req *format.CoreRequest) (*format.CoreResponse, error) {
-	f.requests = append(f.requests, req)
+	f.requests = append(f.requests, cloneCoreRequest(req))
 	return &format.CoreResponse{
 		ID:     "vision_resp",
 		Status: "completed",
@@ -56,6 +56,27 @@ type fakeCoreVisionClient struct {
 func (f *fakeCoreVisionClient) Analyze(_ context.Context, req AnalysisRequest) (string, error) {
 	f.requests = append(f.requests, req)
 	return f.text, nil
+}
+
+type mutatingCoreUpstream struct {
+	responses []*format.CoreResponse
+	requests  []*format.CoreRequest
+}
+
+func (m *mutatingCoreUpstream) CreateCore(_ context.Context, req *format.CoreRequest) (*format.CoreResponse, error) {
+	m.requests = append(m.requests, cloneCoreRequest(req))
+	if len(req.Messages) > 0 && len(req.Messages[len(req.Messages)-1].Content) > 0 {
+		req.Messages[len(req.Messages)-1].Content = append(
+			req.Messages[len(req.Messages)-1].Content,
+			format.CoreContentBlock{Type: "text", Text: "upstream-side mutation"},
+		)
+	}
+	if len(m.responses) == 0 {
+		return nil, io.EOF
+	}
+	resp := m.responses[0]
+	m.responses = m.responses[1:]
+	return resp, nil
 }
 
 // ============================================================================
@@ -763,5 +784,90 @@ func TestCoreOrchestrator_ImageStrippedAcrossMultipleTurns(t *testing.T) {
 	if placeholderCount != 2 {
 		t.Fatalf("expected 2 text placeholders in first upstream request, got %d. Content=%+v",
 			placeholderCount, firstMsg.Content)
+	}
+}
+
+func TestCoreOrchestratorIsolatesRequestsAcrossRounds(t *testing.T) {
+	upstream := &mutatingCoreUpstream{
+		responses: []*format.CoreResponse{
+			{
+				ID: "turn1", Status: "completed", StopReason: "tool_use",
+				Messages: []format.CoreMessage{{
+					Role: "assistant",
+					Content: []format.CoreContentBlock{
+						{
+							Type: "tool_use", ToolUseID: "toolu_1", ToolName: ToolVisualBrief,
+							ToolInput: json.RawMessage(`{"image_refs":["Image #1"],"context":"describe"}`),
+						},
+					},
+				}},
+			},
+			{
+				ID: "turn2", Status: "completed", StopReason: "tool_use",
+				Messages: []format.CoreMessage{{
+					Role: "assistant",
+					Content: []format.CoreContentBlock{
+						{
+							Type: "tool_use", ToolUseID: "toolu_2", ToolName: ToolVisualQA,
+							ToolInput: json.RawMessage(`{"question":"what changed?","image_refs":["Image #1"]}`),
+						},
+					},
+				}},
+			},
+			{
+				ID: "turn3", Status: "completed", StopReason: "end_turn",
+				Messages: []format.CoreMessage{{
+					Role: "assistant",
+					Content: []format.CoreContentBlock{
+						{Type: "text", Text: "final answer"},
+					},
+				}},
+			},
+		},
+	}
+	vision := &fakeCoreVisionClient{text: "visual analysis result"}
+	orchestrator := NewCoreOrchestrator(CoreOrchestratorConfig{
+		Upstream:  upstream,
+		Client:    vision,
+		MaxRounds: 5,
+	})
+
+	_, err := orchestrator.CreateCore(context.Background(), &format.CoreRequest{
+		Model: "test-model",
+		Messages: []format.CoreMessage{{
+			Role: "user",
+			Content: []format.CoreContentBlock{
+				{Type: "text", Text: "look at this"},
+				{Type: "image", ImageData: "b64_image_1", MediaType: "image/png"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateCore() error = %v", err)
+	}
+
+	if len(upstream.requests) != 3 {
+		t.Fatalf("upstream requests = %d, want 3", len(upstream.requests))
+	}
+
+	secondReq := upstream.requests[1]
+	if len(secondReq.Messages) != 3 {
+		t.Fatalf("second upstream request messages = %d, want 3; got %+v", len(secondReq.Messages), secondReq.Messages)
+	}
+
+	assistantMsg := secondReq.Messages[1]
+	if assistantMsg.Role != "assistant" {
+		t.Fatalf("second request assistant role = %q", assistantMsg.Role)
+	}
+	if len(assistantMsg.Content) != 1 || assistantMsg.Content[0].Type != "tool_use" || assistantMsg.Content[0].ToolUseID != "toolu_1" {
+		t.Fatalf("second request assistant content = %+v", assistantMsg.Content)
+	}
+
+	toolResultMsg := secondReq.Messages[2]
+	if toolResultMsg.Role != "user" {
+		t.Fatalf("tool_result message role = %q", toolResultMsg.Role)
+	}
+	if len(toolResultMsg.Content) != 1 || toolResultMsg.Content[0].Type != "tool_result" || toolResultMsg.Content[0].ToolUseID != "toolu_1" {
+		t.Fatalf("tool_result message content = %+v", toolResultMsg.Content)
 	}
 }

--- a/internal/extension/visual/core_orchestrator_test.go
+++ b/internal/extension/visual/core_orchestrator_test.go
@@ -224,7 +224,7 @@ func TestCoreOrchestratorExecutesVisualBrief(t *testing.T) {
 			{
 				ID: "msg_final", Status: "completed", StopReason: "end_turn",
 				Messages: []format.CoreMessage{{
-					Role: "assistant",
+					Role:    "assistant",
 					Content: []format.CoreContentBlock{{Type: "text", Text: "done"}},
 				}},
 			},
@@ -238,7 +238,7 @@ func TestCoreOrchestratorExecutesVisualBrief(t *testing.T) {
 	})
 
 	resp, err := orchestrator.CreateCore(context.Background(), &format.CoreRequest{
-		Model: "test-model",
+		Model:      "test-model",
 		ToolChoice: &format.CoreToolChoice{Mode: "auto"},
 	})
 	if err != nil {
@@ -271,7 +271,7 @@ func TestCoreOrchestratorPreparesRequest(t *testing.T) {
 			{
 				ID: "msg_final", Status: "completed", StopReason: "end_turn",
 				Messages: []format.CoreMessage{{
-					Role: "assistant",
+					Role:    "assistant",
 					Content: []format.CoreContentBlock{{Type: "text", Text: "ok"}},
 				}},
 			},
@@ -367,7 +367,7 @@ func TestCoreOrchestratorMaxRounds(t *testing.T) {
 		}},
 	}
 	upstream := &fakeCoreUpstream{}
-	// Fill responses with enough tool_use responses to exceed maxRounds+1.
+	// Fill responses with enough tool_use responses to exceed maxRounds.
 	for i := 0; i < 10; i++ {
 		upstream.responses = append(upstream.responses, toolUseResp)
 	}
@@ -375,7 +375,7 @@ func TestCoreOrchestratorMaxRounds(t *testing.T) {
 	orchestrator := NewCoreOrchestrator(CoreOrchestratorConfig{
 		Upstream:  upstream,
 		Client:    vision,
-		MaxRounds: 1, // maxRounds=1 means 0,1,2 iterations → 3 calls, exceeds max 1
+		MaxRounds: 1, // maxRounds=1 means at most 1 iteration.
 	})
 
 	_, err := orchestrator.CreateCore(context.Background(), &format.CoreRequest{
@@ -383,6 +383,105 @@ func TestCoreOrchestratorMaxRounds(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "exceeded max rounds") {
 		t.Fatalf("expected max rounds error, got: %v", err)
+	}
+	if len(upstream.requests) != 1 {
+		t.Fatalf("upstream requests = %d, want 1", len(upstream.requests))
+	}
+}
+
+func TestCoreOrchestratorNilClient(t *testing.T) {
+	upstream := &fakeCoreUpstream{}
+	orchestrator := NewCoreOrchestrator(CoreOrchestratorConfig{
+		Upstream:  upstream,
+		Client:    nil,
+		MaxRounds: 2,
+	})
+
+	_, err := orchestrator.CreateCore(context.Background(), &format.CoreRequest{
+		Model: "test-model",
+	})
+	if err == nil || !strings.Contains(err.Error(), "visual client is nil") {
+		t.Fatalf("expected visual client error, got: %v", err)
+	}
+	if len(upstream.requests) != 0 {
+		t.Fatalf("upstream requests = %d, want 0", len(upstream.requests))
+	}
+}
+
+func TestCoreOrchestratorAggregatesUsageAcrossRounds(t *testing.T) {
+	upstream := &fakeCoreUpstream{
+		responses: []*format.CoreResponse{
+			{
+				ID: "msg_tool_1", Status: "completed", StopReason: "tool_use",
+				Messages: []format.CoreMessage{{
+					Role: "assistant",
+					Content: []format.CoreContentBlock{{
+						Type: "tool_use", ToolUseID: "toolu_1", ToolName: ToolVisualBrief,
+						ToolInput: json.RawMessage(`{"image_urls":["https://example.test/a.png"]}`),
+					}},
+				}},
+				Usage: format.CoreUsage{
+					InputTokens:       10,
+					OutputTokens:      4,
+					CachedInputTokens: 3,
+				},
+			},
+			{
+				ID: "msg_tool_2", Status: "completed", StopReason: "tool_use",
+				Messages: []format.CoreMessage{{
+					Role: "assistant",
+					Content: []format.CoreContentBlock{{
+						Type: "tool_use", ToolUseID: "toolu_2", ToolName: ToolVisualQA,
+						ToolInput: json.RawMessage(`{"question":"what color?"}`),
+					}},
+				}},
+				Usage: format.CoreUsage{
+					InputTokens:       8,
+					OutputTokens:      5,
+					CachedInputTokens: 2,
+				},
+			},
+			{
+				ID: "msg_final", Status: "completed", StopReason: "end_turn",
+				Messages: []format.CoreMessage{{
+					Role:    "assistant",
+					Content: []format.CoreContentBlock{{Type: "text", Text: "done"}},
+				}},
+				Usage: format.CoreUsage{
+					InputTokens:       6,
+					OutputTokens:      7,
+					CachedInputTokens: 1,
+				},
+			},
+		},
+	}
+	vision := &fakeCoreVisionClient{text: "visual result"}
+	orchestrator := NewCoreOrchestrator(CoreOrchestratorConfig{
+		Upstream:  upstream,
+		Client:    vision,
+		MaxRounds: 5,
+	})
+
+	resp, err := orchestrator.CreateCore(context.Background(), &format.CoreRequest{
+		Model: "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateCore() error = %v", err)
+	}
+	if resp == nil {
+		t.Fatal("CreateCore() returned nil response")
+	}
+	if resp.Usage.InputTokens != 24 {
+		t.Fatalf("usage input_tokens = %d, want 24", resp.Usage.InputTokens)
+	}
+	if resp.Usage.OutputTokens != 16 {
+		t.Fatalf("usage output_tokens = %d, want 16", resp.Usage.OutputTokens)
+	}
+	if resp.Usage.CachedInputTokens != 6 {
+		t.Fatalf("usage cached_input_tokens = %d, want 6", resp.Usage.CachedInputTokens)
+	}
+	if resp.Usage.TotalTokens != 40 {
+		t.Fatalf("usage total_tokens = %d, want 40", resp.Usage.TotalTokens)
 	}
 }
 
@@ -590,7 +689,7 @@ func TestCoreOrchestrator_ImageStrippedAcrossMultipleTurns(t *testing.T) {
 			{
 				ID: "turn3", Status: "completed", StopReason: "end_turn",
 				Messages: []format.CoreMessage{{
-					Role: "assistant",
+					Role:    "assistant",
 					Content: []format.CoreContentBlock{{Type: "text", Text: "final answer"}},
 				}},
 			},
@@ -666,4 +765,3 @@ func TestCoreOrchestrator_ImageStrippedAcrossMultipleTurns(t *testing.T) {
 			placeholderCount, firstMsg.Content)
 	}
 }
-

--- a/internal/extension/visual/core_orchestrator_test.go
+++ b/internal/extension/visual/core_orchestrator_test.go
@@ -871,3 +871,110 @@ func TestCoreOrchestratorIsolatesRequestsAcrossRounds(t *testing.T) {
 		t.Fatalf("tool_result message content = %+v", toolResultMsg.Content)
 	}
 }
+
+type finalizingCoreUpstream struct {
+	responses []*format.CoreResponse
+	requests  []*format.CoreRequest
+	finalize  func(*format.CoreRequest)
+}
+
+func (f *finalizingCoreUpstream) CreateCore(_ context.Context, req *format.CoreRequest) (*format.CoreResponse, error) {
+	cloned := cloneCoreRequest(req)
+	if f.finalize != nil {
+		f.finalize(cloned)
+	}
+	f.requests = append(f.requests, cloned)
+	if len(f.responses) == 0 {
+		return nil, io.EOF
+	}
+	resp := f.responses[0]
+	f.responses = f.responses[1:]
+	return resp, nil
+}
+
+func TestCoreOrchestratorPreservesFinalizedAssistantHistoryAcrossRounds(t *testing.T) {
+	upstream := &finalizingCoreUpstream{
+		finalize: func(req *format.CoreRequest) {
+			for i := range req.Messages {
+				msg := &req.Messages[i]
+				if msg.Role != "assistant" || len(msg.Content) == 0 {
+					continue
+				}
+				hasToolUse := false
+				hasReasoning := false
+				for _, block := range msg.Content {
+					if block.Type == "tool_use" {
+						hasToolUse = true
+					}
+					if block.Type == "reasoning" {
+						hasReasoning = true
+					}
+				}
+				if hasToolUse && !hasReasoning {
+					msg.Content = append([]format.CoreContentBlock{{
+						Type:               "reasoning",
+						ReasoningText:      "replayed thinking",
+						ReasoningSignature: "sig-visual",
+					}}, msg.Content...)
+				}
+			}
+		},
+		responses: []*format.CoreResponse{
+			{
+				ID: "turn1", Status: "completed", StopReason: "tool_use",
+				Messages: []format.CoreMessage{{
+					Role: "assistant",
+					Content: []format.CoreContentBlock{{
+						Type: "tool_use", ToolUseID: "toolu_1", ToolName: ToolVisualBrief,
+						ToolInput: json.RawMessage(`{"image_refs":["Image #1"],"context":"describe"}`),
+					}},
+				}},
+			},
+			{
+				ID: "turn2", Status: "completed", StopReason: "end_turn",
+				Messages: []format.CoreMessage{{
+					Role:    "assistant",
+					Content: []format.CoreContentBlock{{Type: "text", Text: "done"}},
+				}},
+			},
+		},
+	}
+	vision := &fakeCoreVisionClient{text: "visual analysis result"}
+	orchestrator := NewCoreOrchestrator(CoreOrchestratorConfig{
+		Upstream:  upstream,
+		Client:    vision,
+		MaxRounds: 5,
+	})
+
+	_, err := orchestrator.CreateCore(context.Background(), &format.CoreRequest{
+		Model: "test-model",
+		Messages: []format.CoreMessage{{
+			Role: "user",
+			Content: []format.CoreContentBlock{
+				{Type: "text", Text: "look"},
+				{Type: "image", ImageData: "b64_image_1", MediaType: "image/png"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateCore() error = %v", err)
+	}
+
+	if len(upstream.requests) != 2 {
+		t.Fatalf("upstream requests = %d, want 2", len(upstream.requests))
+	}
+	secondReq := upstream.requests[1]
+	if len(secondReq.Messages) != 3 {
+		t.Fatalf("second upstream request messages = %d, want 3; got %+v", len(secondReq.Messages), secondReq.Messages)
+	}
+	assistantMsg := secondReq.Messages[1]
+	if len(assistantMsg.Content) < 2 {
+		t.Fatalf("assistant history content too short: %+v", assistantMsg.Content)
+	}
+	if assistantMsg.Content[0].Type != "reasoning" || assistantMsg.Content[0].ReasoningText != "replayed thinking" || assistantMsg.Content[0].ReasoningSignature != "sig-visual" {
+		t.Fatalf("assistant history lost finalized reasoning block: %+v", assistantMsg.Content)
+	}
+	if assistantMsg.Content[1].Type != "tool_use" || assistantMsg.Content[1].ToolUseID != "toolu_1" {
+		t.Fatalf("assistant tool_use misplaced after finalized reasoning: %+v", assistantMsg.Content)
+	}
+}

--- a/internal/extension/visual/orchestrator.go
+++ b/internal/extension/visual/orchestrator.go
@@ -61,7 +61,7 @@ func (o *Orchestrator) CreateMessage(ctx context.Context, req anthropic.MessageR
 	}
 	req, availableImages := prepareRequestForVisual(req)
 	log := slog.Default()
-	for round := 0; round <= o.maxRounds; round++ {
+	for round := 0; round < o.maxRounds; round++ {
 		resp, err := o.upstream.CreateMessage(ctx, req)
 		if err != nil {
 			return anthropic.MessageResponse{}, err
@@ -106,7 +106,7 @@ func (o *Orchestrator) StreamMessage(ctx context.Context, req anthropic.MessageR
 	req, availableImages := prepareRequestForVisual(req)
 	log := slog.Default()
 	var allEvents []anthropic.StreamEvent
-	for round := 0; round <= o.maxRounds; round++ {
+	for round := 0; round < o.maxRounds; round++ {
 		stream, err := o.upstream.StreamMessage(ctx, req)
 		if err != nil {
 			return nil, err

--- a/internal/extension/visual/plugin.go
+++ b/internal/extension/visual/plugin.go
@@ -24,8 +24,9 @@ type Config struct {
 // Plugin injects the Visual tools for models that opt in.
 type Plugin struct {
 	plugin.BasePlugin
-	isEnabled EnabledFunc
-	pluginCfg config.PluginConfig
+	isEnabled     EnabledFunc
+	pluginCfg     config.PluginConfig
+	currentConfig func() config.Config
 }
 
 func NewPlugin(isEnabled ...EnabledFunc) *Plugin {
@@ -42,10 +43,14 @@ func (p *Plugin) ConfigSpecs() []config.ExtensionConfigSpec { return ConfigSpecs
 
 func (p *Plugin) Init(ctx plugin.PluginContext) error {
 	p.pluginCfg = config.PluginFromGlobalConfig(&ctx.AppConfig)
+	p.currentConfig = ctx.CurrentConfig
 	return nil
 }
 
 func (p *Plugin) EnabledForModel(model string) bool {
+	if p.currentConfig != nil {
+		return p.currentConfig().ExtensionEnabled(PluginName, model)
+	}
 	if p.isEnabled != nil {
 		return p.isEnabled(model)
 	}

--- a/internal/extension/visual/plugin.go
+++ b/internal/extension/visual/plugin.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/format"
 )
 
@@ -103,6 +103,19 @@ func ConfigForModel(pluginCfg config.PluginConfig, modelAlias string) (Config, b
 	return cfg.Normalized(), true
 }
 
+// ConfigForModelFromResolvedConfig resolves visual config using the full
+// extension scope precedence from config.Config.
+func ConfigForModelFromResolvedConfig(fullCfg config.Config, modelAlias string) (Config, bool) {
+	if !fullCfg.ExtensionEnabled(PluginName, modelAlias) {
+		return Config{}, false
+	}
+	cfg, err := decodeVisualConfig(fullCfg, modelAlias)
+	if err != nil {
+		return Config{}, false
+	}
+	return cfg, true
+}
+
 func pluginExtensionEnabled(pluginCfg config.PluginConfig, name string) bool {
 	if setting, ok := pluginCfg.Extensions[name]; ok && setting.Enabled != nil {
 		return *setting.Enabled
@@ -121,7 +134,6 @@ func (cfg Config) Normalized() Config {
 	}
 	return cfg
 }
-
 
 // decodeVisualConfig decodes the visual extension config for a model alias.
 func decodeVisualConfig(fullCfg config.Config, modelAlias string) (Config, error) {

--- a/internal/extension/visual/plugin_test.go
+++ b/internal/extension/visual/plugin_test.go
@@ -1,0 +1,71 @@
+package visual
+
+import (
+	"testing"
+
+	"moonbridge/internal/config"
+)
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func TestConfigForModelFromResolvedConfig_UsesRouteScope(t *testing.T) {
+	cfg := config.Config{
+		ProviderDefs: map[string]config.ProviderDef{
+			"anthropic": {
+				BaseURL: "https://api.anthropic.com",
+				APIKey:  "sk-ant-test",
+				Models: map[string]config.ModelMeta{
+					"claude-sonnet-20241022": {},
+				},
+			},
+			"vision": {
+				BaseURL: "https://vision.example.com",
+				APIKey:  "sk-vision-test",
+				Models: map[string]config.ModelMeta{
+					"vision-route": {},
+				},
+			},
+		},
+		Routes: map[string]config.RouteEntry{
+			"claude-sonnet": {
+				Provider: "anthropic",
+				Model:    "claude-sonnet-20241022",
+				Extensions: map[string]config.ExtensionSettings{
+					PluginName: {
+						Enabled: boolPtr(true),
+						RawConfig: map[string]any{
+							"provider":   "vision",
+							"model":      "vision-route",
+							"max_rounds": 7,
+							"max_tokens": 3333,
+						},
+					},
+				},
+			},
+		},
+		Extensions: map[string]config.ExtensionSettings{
+			PluginName: {
+				Enabled: boolPtr(true),
+				RawConfig: map[string]any{
+					"provider":   "vision",
+					"model":      "vision-global",
+					"max_rounds": 2,
+					"max_tokens": 1000,
+				},
+			},
+		},
+	}
+
+	got, ok := ConfigForModelFromResolvedConfig(cfg, "claude-sonnet")
+	if !ok {
+		t.Fatal("expected visual config to be enabled")
+	}
+	if got.Provider != "vision" || got.Model != "vision-route" {
+		t.Fatalf("visual config provider/model = %s/%s", got.Provider, got.Model)
+	}
+	if got.MaxRounds != 7 || got.MaxTokens != 3333 {
+		t.Fatalf("visual config rounds/tokens = %d/%d", got.MaxRounds, got.MaxTokens)
+	}
+}

--- a/internal/extension/websearch/orchestrator.go
+++ b/internal/extension/websearch/orchestrator.go
@@ -93,7 +93,7 @@ func NewInjectedOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 // tool loops. The caller receives a fully resolved response.
 func (o *Orchestrator) CreateMessage(ctx context.Context, req anthropic.MessageRequest) (anthropic.MessageResponse, error) {
 	log := slog.Default()
-	for round := 0; round <= o.maxRounds; round++ {
+	for round := 0; round < o.maxRounds; round++ {
 		resp, err := o.anthropic.CreateMessage(ctx, req)
 		if err != nil {
 			return anthropic.MessageResponse{}, err
@@ -103,7 +103,7 @@ func (o *Orchestrator) CreateMessage(ctx context.Context, req anthropic.MessageR
 			return resp, nil
 		}
 
-		toolUses, otherBlocks := splitToolUses(resp.Content)
+		toolUses, _ := splitToolUses(resp.Content)
 		searchUses := o.filterSearchTools(toolUses)
 		nonSearchUses := subtractToolUses(toolUses, searchUses)
 
@@ -141,7 +141,7 @@ func (o *Orchestrator) CreateMessage(ctx context.Context, req anthropic.MessageR
 		// user message (with tool_results) to the request for the next round.
 		req.Messages = append(req.Messages, anthropic.Message{
 			Role:    "assistant",
-			Content: toContentBlocks(append(searchUses, otherBlocks...)),
+			Content: resp.Content,
 		})
 		req.Messages = append(req.Messages, anthropic.Message{
 			Role:    "user",
@@ -159,7 +159,7 @@ func (o *Orchestrator) CreateMessage(ctx context.Context, req anthropic.MessageR
 func (o *Orchestrator) StreamMessage(ctx context.Context, req anthropic.MessageRequest) (anthropic.Stream, error) {
 	log := slog.Default()
 	var allEvents []anthropic.StreamEvent
-	for round := 0; round <= o.maxRounds; round++ {
+	for round := 0; round < o.maxRounds; round++ {
 		stream, err := o.anthropic.StreamMessage(ctx, req)
 		if err != nil {
 			return nil, err
@@ -382,13 +382,6 @@ func subtractToolUses(a, b []anthropic.ContentBlock) []anthropic.ContentBlock {
 		}
 	}
 	return result
-}
-
-// toContentBlocks converts tool_use blocks to generic content blocks.
-func toContentBlocks(toolUses []anthropic.ContentBlock) []anthropic.ContentBlock {
-	blocks := make([]anthropic.ContentBlock, len(toolUses))
-	copy(blocks, toolUses)
-	return blocks
 }
 
 // collectStream reads all events from a stream into a slice.

--- a/internal/extension/websearch/orchestrator_test.go
+++ b/internal/extension/websearch/orchestrator_test.go
@@ -1,8 +1,12 @@
 package websearch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"moonbridge/internal/protocol/anthropic"
@@ -383,4 +387,89 @@ func TestCollectContentFromEvents_preservesNonRebuiltBlockFields(t *testing.T) {
 
 	// Drain staticStream fully as a final sanity check.
 	fmt.Println("staticStream drain test: OK")
+}
+
+type orchestratorRTFunc func(*http.Request) (*http.Response, error)
+
+func (fn orchestratorRTFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func newTestAnthropicClient(t *testing.T, rt http.RoundTripper) *anthropic.Client {
+	t.Helper()
+	return anthropic.NewClient(anthropic.ClientConfig{
+		BaseURL: "https://provider.example.test",
+		APIKey:  "test-key",
+		Version: "2023-06-01",
+		Client:  &http.Client{Transport: rt},
+	})
+}
+
+func TestOrchestratorCreateMessage_PreservesAssistantBlockOrder(t *testing.T) {
+	var payloads []anthropic.MessageRequest
+	client := newTestAnthropicClient(t, orchestratorRTFunc(func(r *http.Request) (*http.Response, error) {
+		var req anthropic.MessageRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		payloads = append(payloads, req)
+
+		if len(payloads) == 1 {
+			body := `{"id":"msg_1","type":"message","role":"assistant","stop_reason":"tool_use","content":[{"type":"text","text":"Before search."},{"type":"tool_use","id":"tu_1","name":"tavily_search","input":{"query":""}},{"type":"text","text":"After search."}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+		// Validate follow-up assistant content keeps original ordering.
+		if len(req.Messages) < 2 {
+			t.Fatalf("expected follow-up messages, got %d", len(req.Messages))
+		}
+		assistant := req.Messages[len(req.Messages)-2]
+		if assistant.Role != "assistant" {
+			t.Fatalf("expected assistant message before tool_result, got role=%q", assistant.Role)
+		}
+		if len(assistant.Content) != 3 {
+			t.Fatalf("assistant content len=%d, want 3", len(assistant.Content))
+		}
+		if assistant.Content[0].Type != "text" || assistant.Content[0].Text != "Before search." {
+			t.Fatalf("content[0]=%+v", assistant.Content[0])
+		}
+		if assistant.Content[1].Type != "tool_use" || assistant.Content[1].ID != "tu_1" {
+			t.Fatalf("content[1]=%+v", assistant.Content[1])
+		}
+		if assistant.Content[2].Type != "text" || assistant.Content[2].Text != "After search." {
+			t.Fatalf("content[2]=%+v", assistant.Content[2])
+		}
+
+		body := `{"id":"msg_2","type":"message","role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"final"}]}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	}))
+
+	orch := NewInjectedOrchestrator(OrchestratorConfig{
+		Anthropic:       client,
+		TavilyKey:       "",
+		FirecrawlKey:    "",
+		SearchMaxRounds: 3,
+	})
+
+	resp, err := orch.CreateMessage(context.Background(), anthropic.MessageRequest{
+		Model:     "claude-test",
+		MaxTokens: 32,
+		Messages:  []anthropic.Message{{Role: "user", Content: []anthropic.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage error: %v", err)
+	}
+	if resp.ID != "msg_2" {
+		t.Fatalf("final response id=%q, want msg_2", resp.ID)
+	}
+	if len(payloads) != 2 {
+		t.Fatalf("request count=%d, want 2", len(payloads))
+	}
 }

--- a/internal/format/core_hook_context.go
+++ b/internal/format/core_hook_context.go
@@ -1,0 +1,25 @@
+package format
+
+import "context"
+
+type coreHookContextKey string
+
+const coreHookModelAliasKey coreHookContextKey = "moonbridge.core_hook_model_alias"
+
+// WithCoreHookModelAlias tags a context with the model alias used by Core hooks.
+func WithCoreHookModelAlias(ctx context.Context, modelAlias string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, coreHookModelAliasKey, modelAlias)
+}
+
+// ModelAliasFromCoreHookContext extracts the model alias previously tagged
+// by WithCoreHookModelAlias. Returns empty string when unset.
+func ModelAliasFromCoreHookContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	model, _ := ctx.Value(coreHookModelAliasKey).(string)
+	return model
+}

--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -44,11 +44,11 @@ type CacheManager interface {
 // Only references: config, format, and anthropic types.
 type AnthropicProviderAdapter struct {
 	cfgMaxTokens int
-	cacheMgr CacheManager
-	hooks    format.CorePluginHooks
+	cacheMgr     CacheManager
+	hooks        format.CorePluginHooks
 
-	streamMu         sync.Mutex
-	streamEvents     []StreamEvent
+	streamMu     sync.Mutex
+	streamEvents []StreamEvent
 }
 
 // NewAnthropicProviderAdapter creates a new AnthropicProviderAdapter.
@@ -58,8 +58,8 @@ type AnthropicProviderAdapter struct {
 func NewAnthropicProviderAdapter(cfgMaxTokens int, cacheMgr CacheManager, hooks format.CorePluginHooks) *AnthropicProviderAdapter {
 	return &AnthropicProviderAdapter{
 		cfgMaxTokens: cfgMaxTokens,
-		cacheMgr: cacheMgr,
-		hooks:    hooks.WithDefaults(),
+		cacheMgr:     cacheMgr,
+		hooks:        hooks.WithDefaults(),
 	}
 }
 
@@ -166,7 +166,7 @@ func (a *AnthropicProviderAdapter) toCoreCacheControl(cc *CacheControl) *format.
 		return nil
 	}
 	return &format.CoreCacheControl{
-		Enabled: true,
+		Enabled:    true,
 		TTLSeconds: parseTTLSeconds(cc.TTL),
 		Strategy:   "auto",
 	}
@@ -325,7 +325,7 @@ func (a *AnthropicProviderAdapter) FromCoreRequest(ctx context.Context, req *for
 	// ToolChoice
 	if req.ToolChoice != nil {
 		tc := a.toAnthropicToolChoice(*req.ToolChoice)
-	anthropicReq.ToolChoice = &tc
+		anthropicReq.ToolChoice = &tc
 	} else {
 		anthropicReq.ToolChoice = &ToolChoice{Type: "auto"}
 	}
@@ -351,6 +351,7 @@ func (a *AnthropicProviderAdapter) ToCoreResponse(ctx context.Context, resp any)
 	if !ok {
 		return nil, fmt.Errorf("anthropic adapter: expected *MessageResponse, got %T", resp)
 	}
+	ctx = coreHookContext(ctx, msgResp.Model)
 
 	// Map stop_reason to Core status.
 	status := a.mapStopReasonToStatus(msgResp.StopReason)
@@ -371,7 +372,6 @@ func (a *AnthropicProviderAdapter) ToCoreResponse(ctx context.Context, resp any)
 		Usage:      a.toCoreUsage(msgResp.Usage),
 		StopReason: msgResp.StopReason,
 	}
-	a.hooks.RememberContent(ctx, coreContent)
 	a.hooks.RememberContent(ctx, coreContent)
 
 	// Map error-like stop reasons.
@@ -402,11 +402,11 @@ type streamConverterState struct {
 	seqNum          int64
 	msgID           string
 	model           string
-	blockTypes      map[int]string // content index → block type
-	blockSignatures map[int]string // content index → reasoning signature (from signature_delta)
-	finalUsage      *format.CoreUsage // tracked from message_delta, passed to message_stop
+	blockTypes      map[int]string            // content index → block type
+	blockSignatures map[int]string            // content index → reasoning signature (from signature_delta)
+	finalUsage      *format.CoreUsage         // tracked from message_delta, passed to message_stop
 	adapter         *AnthropicProviderAdapter // for buffering raw stream events (trace)
-	suppressText    map[int]bool   // text indices to suppress (server-side search status, etc.)
+	suppressText    map[int]bool              // text indices to suppress (server-side search status, etc.)
 }
 
 // ToCoreStream consumes an anthropic.Stream and returns a channel of CoreStreamEvent.
@@ -418,6 +418,7 @@ func (a *AnthropicProviderAdapter) ToCoreStream(ctx context.Context, src any) (<
 	if !ok {
 		return nil, fmt.Errorf("anthropic adapter: expected anthropic.Stream, got %T", src)
 	}
+	ctx = coreHookContext(ctx, "")
 	events := make(chan format.CoreStreamEvent, 64)
 
 	// Initialize stream event buffer for trace capture.
@@ -472,7 +473,6 @@ func (a *AnthropicProviderAdapter) ToCoreStream(ctx context.Context, src any) (<
 // =========================================================================
 // Stream event conversion
 // =========================================================================
-
 
 func (s *streamConverterState) nextSeq() int64 {
 	s.seqNum++
@@ -644,7 +644,7 @@ func (s *streamConverterState) convertEvent(events chan<- format.CoreStreamEvent
 				CachedInputTokens: ev.Usage.CacheReadInputTokens,
 			}
 			s.emit(events, format.CoreStreamEvent{
-				Type: format.CoreEventInProgress,
+				Type:       format.CoreEventInProgress,
 				Usage:      s.finalUsage,
 				StopReason: ev.Delta.StopReason,
 			})
@@ -679,8 +679,8 @@ func (s *streamConverterState) convertEvent(events chan<- format.CoreStreamEvent
 		})
 	}
 
-
 }
+
 // =========================================================================
 // Helpers: Core → Anthropic
 // =========================================================================
@@ -928,7 +928,7 @@ func (a *AnthropicProviderAdapter) toCoreUsage(u Usage) format.CoreUsage {
 	}
 	totalInput := u.InputTokens + cached
 	return format.CoreUsage{
-		InputTokens:       totalInput,                // Total input (fresh + cache) matching OpenAI API semantics
+		InputTokens:       totalInput, // Total input (fresh + cache) matching OpenAI API semantics
 		OutputTokens:      u.OutputTokens,
 		TotalTokens:       totalInput + u.OutputTokens,
 		CachedInputTokens: cached,
@@ -950,6 +950,7 @@ func (a *AnthropicProviderAdapter) mapStopReasonToStatus(reason string) string {
 		return "completed"
 	}
 }
+
 // bufferStreamEvent buffers the raw anthropic stream event for trace capture,
 // up to the 4MB limit. The event is JSON-marshalled to estimate its size.
 func (a *AnthropicProviderAdapter) bufferStreamEvent(ev StreamEvent) {
@@ -969,13 +970,19 @@ func (a *AnthropicProviderAdapter) StreamBuffer() []StreamEvent {
 	return a.streamEvents
 }
 
-
 // RememberStreamContent stores response content from a stream for plugin state tracking.
 func (a *AnthropicProviderAdapter) RememberStreamContent(ctx context.Context, blocks []format.CoreContentBlock) {
 	if len(blocks) == 0 {
 		return
 	}
 	a.hooks.RememberContent(ctx, blocks)
+}
+
+func coreHookContext(ctx context.Context, model string) context.Context {
+	if model == "" {
+		return ctx
+	}
+	return format.WithCoreHookModelAlias(ctx, model)
 }
 
 // =========================================================================

--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -347,9 +347,9 @@ func (a *AnthropicProviderAdapter) FromCoreRequest(ctx context.Context, req *for
 // The response content blocks become a single assistant message. Cache registry
 // is updated from usage signals via CacheManager.
 func (a *AnthropicProviderAdapter) ToCoreResponse(ctx context.Context, resp any) (*format.CoreResponse, error) {
-	msgResp, ok := resp.(*MessageResponse)
-	if !ok {
-		return nil, fmt.Errorf("anthropic adapter: expected *MessageResponse, got %T", resp)
+	msgResp, err := normalizeAnthropicMessageResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic adapter: %w", err)
 	}
 	ctx = coreHookContext(ctx, msgResp.Model)
 
@@ -391,6 +391,21 @@ func (a *AnthropicProviderAdapter) ToCoreResponse(ctx context.Context, resp any)
 	}
 
 	return coreResp, nil
+}
+
+func normalizeAnthropicMessageResponse(resp any) (*MessageResponse, error) {
+	switch v := resp.(type) {
+	case MessageResponse:
+		msgResp := v
+		return &msgResp, nil
+	case *MessageResponse:
+		if v == nil {
+			return nil, fmt.Errorf("expected anthropic.MessageResponse, got nil *anthropic.MessageResponse")
+		}
+		return v, nil
+	default:
+		return nil, fmt.Errorf("expected anthropic.MessageResponse, got %T", resp)
+	}
 }
 
 // =========================================================================

--- a/internal/protocol/anthropic/adapter_test.go
+++ b/internal/protocol/anthropic/adapter_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/anthropic"
 )
 
 // ---------------------------------------------------------------------------
@@ -24,9 +24,6 @@ func (n noopCacheManager) UpdateRegistry(_ context.Context, _, _ string, _ anthr
 func newTestAdapter() *anthropic.AnthropicProviderAdapter {
 	return anthropic.NewAnthropicProviderAdapter(0, noopCacheManager{}, format.CorePluginHooks{})
 }
-
-
-
 
 func TestFromCoreRequest_BasicTextMessage(t *testing.T) {
 	// 测试纯文本 CoreRequest → *anthropic.MessageRequest
@@ -73,7 +70,7 @@ func TestFromCoreRequest_SystemField(t *testing.T) {
 	adapter := newTestAdapter()
 
 	coreReq := &format.CoreRequest{
-		Model: "claude-sonnet-4",
+		Model:  "claude-sonnet-4",
 		System: []format.CoreContentBlock{{Type: "text", Text: "You are helpful."}},
 		Messages: []format.CoreMessage{
 			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},
@@ -412,6 +409,43 @@ func TestToCoreResponse_BasicText(t *testing.T) {
 	}
 }
 
+func TestToCoreResponse_BasicTextValueResponse(t *testing.T) {
+	adapter := newTestAdapter()
+
+	anthResp := anthropic.MessageResponse{
+		ID:   "msg_value_123",
+		Type: "message",
+		Role: "assistant",
+		Content: []anthropic.ContentBlock{
+			{Type: "text", Text: "Hello from value"},
+		},
+		Model:      "claude-sonnet-4",
+		StopReason: "end_turn",
+		Usage:      anthropic.Usage{InputTokens: 7, OutputTokens: 11},
+	}
+
+	result, err := adapter.ToCoreResponse(context.Background(), anthResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.ID != "msg_value_123" {
+		t.Errorf("ID = %q", result.ID)
+	}
+	if result.Model != "claude-sonnet-4" {
+		t.Errorf("Model = %q", result.Model)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(result.Messages))
+	}
+	if len(result.Messages[0].Content) != 1 {
+		t.Fatalf("got %d content blocks, want 1", len(result.Messages[0].Content))
+	}
+	if result.Messages[0].Content[0].Text != "Hello from value" {
+		t.Errorf("text = %q", result.Messages[0].Content[0].Text)
+	}
+}
+
 func TestToCoreResponse_Incomplete(t *testing.T) {
 	adapter := newTestAdapter()
 
@@ -542,7 +576,7 @@ func TestFromCoreRequest_PluginHooksCalled(t *testing.T) {
 			req.Model = "mutated-model"
 		},
 	}
-		adapter := anthropic.NewAnthropicProviderAdapter(0, noopCacheManager{}, hooks)
+	adapter := anthropic.NewAnthropicProviderAdapter(0, noopCacheManager{}, hooks)
 
 	coreReq := &format.CoreRequest{
 		Model: "claude-sonnet-4",
@@ -617,8 +651,8 @@ func TestFromCoreRequest_MergesConsecutiveToolResultMessages(t *testing.T) {
 				Role: "user",
 				Content: []format.CoreContentBlock{
 					{
-						Type:             "tool_result",
-						ToolUseID:        "call_1",
+						Type:      "tool_result",
+						ToolUseID: "call_1",
 						ToolResultContent: []format.CoreContentBlock{
 							{Type: "text", Text: "Sunny, 25°C"},
 						},
@@ -629,8 +663,8 @@ func TestFromCoreRequest_MergesConsecutiveToolResultMessages(t *testing.T) {
 				Role: "tool",
 				Content: []format.CoreContentBlock{
 					{
-						Type:             "tool_result",
-						ToolUseID:        "call_2",
+						Type:      "tool_result",
+						ToolUseID: "call_2",
 						ToolResultContent: []format.CoreContentBlock{
 							{Type: "text", Text: "Windy, 15°C"},
 						},

--- a/internal/protocol/chat/adapter.go
+++ b/internal/protocol/chat/adapter.go
@@ -25,11 +25,11 @@ import (
 // Only references: config, format, and chat types.
 type ChatProviderAdapter struct {
 	cfgMaxTokens int
-	client *Client
-	hooks format.CorePluginHooks
+	client       *Client
+	hooks        format.CorePluginHooks
 
-	streamMu      sync.Mutex
-	streamEvents  []ChatStreamChunk
+	streamMu     sync.Mutex
+	streamEvents []ChatStreamChunk
 }
 
 // NewChatProviderAdapter creates a new ChatProviderAdapter.
@@ -39,8 +39,8 @@ type ChatProviderAdapter struct {
 func NewChatProviderAdapter(cfgMaxTokens int, client *Client, hooks format.CorePluginHooks) *ChatProviderAdapter {
 	return &ChatProviderAdapter{
 		cfgMaxTokens: cfgMaxTokens,
-		client: client,
-		hooks:  hooks.WithDefaults(),
+		client:       client,
+		hooks:        hooks.WithDefaults(),
 	}
 }
 
@@ -241,13 +241,14 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 
 		// Per-choice state for streaming.
 		type choiceState struct {
-			started    bool
-			blockIndex int // monotonically increasing content block index
-			hasReasoning bool   // whether a reasoning block is active
-				reasonIndex  int   // block index for the reasoning content block
-			toolCallIdx  int   // next tool call content block index (starts after text block)
-			callStarted map[int]bool // tracks which tool call indices have been started
-			reasoningContent string // accumulated reasoning content for the current reasoning block
+			started          bool
+			blockIndex       int          // monotonically increasing content block index
+			hasReasoning     bool         // whether a reasoning block is active
+			reasonIndex      int          // block index for the reasoning content block
+			toolCallIdx      int          // next tool call content block index (starts after text block)
+			callStarted      map[int]bool // tracks which tool call indices have been started
+			toolCallSlot     map[int]int  // tool_call delta index -> content block index
+			reasoningContent string       // accumulated reasoning content for the current reasoning block
 		}
 		choices := make(map[int]*choiceState)
 		var seqNum int64
@@ -335,8 +336,8 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 							state.reasonIndex = state.blockIndex + 1
 							state.blockIndex = state.reasonIndex
 							emit(format.CoreStreamEvent{
-								Type:  format.CoreContentBlockDone,
-								Index: state.blockIndex,
+								Type:        format.CoreContentBlockDone,
+								Index:       state.blockIndex,
 								ChoiceIndex: &ci,
 							})
 							emit(format.CoreStreamEvent{
@@ -360,11 +361,11 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 					// Transition from reasoning block to text block.
 					if sc.Delta.Content != "" && state.hasReasoning {
 						emit(format.CoreStreamEvent{
-							Type:  format.CoreContentBlockDone,
-							Index: state.reasonIndex,
+							Type:        format.CoreContentBlockDone,
+							Index:       state.reasonIndex,
 							ChoiceIndex: &ci,
 							ContentBlock: &format.CoreContentBlock{
-								Type: "reasoning",
+								Type:          "reasoning",
 								ReasoningText: state.reasoningContent,
 							},
 						})
@@ -390,39 +391,52 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 					}
 
 					// Emit tool call content blocks and args deltas.
-					for _, tc := range sc.Delta.ToolCalls {
-						// Emit content_block.started for first occurrence of each tool call.
-						if tc.ID != "" {
-							if state.callStarted == nil {
-								state.callStarted = make(map[int]bool)
-								// Start tool call indices after the current text/reasoning block.
-								state.toolCallIdx = state.blockIndex + 1
-							}
-							if !state.callStarted[state.toolCallIdx] {
-								state.callStarted[state.toolCallIdx] = true
-								emit(format.CoreStreamEvent{
-									Type:        format.CoreContentBlockStarted,
-									Index:       state.toolCallIdx,
-									ChoiceIndex: &ci,
-									ContentBlock: &format.CoreContentBlock{
-										Type:      "tool_use",
-										ToolUseID: tc.ID,
-										ToolName:  tc.Function.Name,
-									},
-								})
-								state.toolCallIdx++
-							}
+					for toolPos, tc := range sc.Delta.ToolCalls {
+						callPos := toolPos
+						if tc.Index != nil && *tc.Index >= 0 {
+							callPos = *tc.Index
+						}
+						if state.callStarted == nil {
+							state.callStarted = make(map[int]bool)
+							// Start tool call indices after the current text/reasoning block.
+							state.toolCallIdx = state.blockIndex + 1
+						}
+						if state.toolCallSlot == nil {
+							state.toolCallSlot = make(map[int]int)
+						}
+						slot, hasSlot := state.toolCallSlot[callPos]
+						// Emit content_block.started for first occurrence of each tool call slot.
+						if !hasSlot {
+							slot = state.toolCallIdx
+							state.toolCallSlot[callPos] = slot
+							state.toolCallIdx++
+						}
+						if !state.callStarted[slot] && (tc.ID != "" || tc.Function.Name != "") {
+							state.callStarted[slot] = true
+							emit(format.CoreStreamEvent{
+								Type:        format.CoreContentBlockStarted,
+								Index:       slot,
+								ChoiceIndex: &ci,
+								ContentBlock: &format.CoreContentBlock{
+									Type:      "tool_use",
+									ToolUseID: tc.ID,
+									ToolName:  tc.Function.Name,
+								},
+							})
 						}
 						// Skip empty argument deltas (avoids accumulating "" at the start).
 						// Decode each JSON string chunk to get the actual content (strips surrounding quotes).
 						// Raw bytes include JSON string quotes (e.g. "" -> empty, "{" -> {, "\"" -> ").
+						if !state.callStarted[slot] {
+							continue
+						}
 						if len(tc.Function.Arguments) > 0 {
 							var decoded string
 							if err := json.Unmarshal(tc.Function.Arguments, &decoded); err == nil {
 								if decoded != "" {
 									emit(format.CoreStreamEvent{
 										Type:        format.CoreToolCallArgsDelta,
-										Index:       state.toolCallIdx - 1,
+										Index:       slot,
 										Delta:       decoded,
 										ChoiceIndex: &ci,
 									})
@@ -430,7 +444,7 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 							} else {
 								emit(format.CoreStreamEvent{
 									Type:        format.CoreToolCallArgsDelta,
-									Index:       state.toolCallIdx - 1,
+									Index:       slot,
 									Delta:       string(tc.Function.Arguments),
 									ChoiceIndex: &ci,
 								})
@@ -448,7 +462,7 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 								StopReason:  stopReason,
 								ChoiceIndex: &ci,
 								ContentBlock: &format.CoreContentBlock{
-									Type: "reasoning",
+									Type:          "reasoning",
 									ReasoningText: state.reasoningContent,
 								},
 							})
@@ -462,15 +476,18 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 							})
 						}
 						// Complete tool call blocks.
-						for idx := range state.callStarted {
+						for idx := state.blockIndex + 1; idx < state.toolCallIdx; idx++ {
+							if !state.callStarted[idx] {
+								continue
+							}
 							emit(format.CoreStreamEvent{
-								Type:  format.CoreToolCallArgsDone,
-								Index: idx,
+								Type:        format.CoreToolCallArgsDone,
+								Index:       idx,
 								ChoiceIndex: &ci,
 							})
 							emit(format.CoreStreamEvent{
-								Type:  format.CoreContentBlockDone,
-								Index: idx,
+								Type:        format.CoreContentBlockDone,
+								Index:       idx,
 								ChoiceIndex: &ci,
 							})
 						}
@@ -693,8 +710,8 @@ func (a *ChatProviderAdapter) toChatToolChoice(tc format.CoreToolChoice) json.Ra
 				"type": "function",
 				"function": map[string]string{
 					"name": tc.Name,
-			},
-		}
+				},
+			}
 			data, _ := json.Marshal(choice)
 			return data
 		}
@@ -706,8 +723,8 @@ func (a *ChatProviderAdapter) toChatToolChoice(tc format.CoreToolChoice) json.Ra
 				"type": "function",
 				"function": map[string]string{
 					"name": tc.Name,
-			},
-		}
+				},
+			}
 			data, _ := json.Marshal(choice)
 			return data
 		}

--- a/internal/protocol/chat/chat_test.go
+++ b/internal/protocol/chat/chat_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"moonbridge/internal/protocol/chat"
 	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/chat"
 )
 
 // ============================================================================
@@ -105,6 +105,32 @@ func TestTypes_ChatRequest_JSON(t *testing.T) {
 	}
 	if out.Stream {
 		t.Error("Stream should be false")
+	}
+}
+
+func TestTypes_ChatMessage_MarshalJSON_EmitsEmptyReasoningContentWhenForced(t *testing.T) {
+	message := chat.ChatMessage{
+		Role:                      "assistant",
+		ToolCalls:                 []chat.ToolCall{{ID: "call_1", Type: "function", Function: chat.ToolCallFunc{Name: "exec_command", Arguments: json.RawMessage(`{}`)}}},
+		ReasoningContent:          "",
+		EmitEmptyReasoningContent: true,
+	}
+
+	data, err := json.Marshal(message)
+	if err != nil {
+		t.Fatalf("Marshal(ChatMessage) error = %v", err)
+	}
+	if !strings.Contains(string(data), `"reasoning_content":""`) {
+		t.Fatalf("expected reasoning_content to be explicitly present, got %s", string(data))
+	}
+
+	message.EmitEmptyReasoningContent = false
+	data2, err := json.Marshal(message)
+	if err != nil {
+		t.Fatalf("Marshal(ChatMessage) error = %v", err)
+	}
+	if strings.Contains(string(data2), `"reasoning_content":""`) {
+		t.Fatalf("reasoning_content should be omitted without force flag, got %s", string(data2))
 	}
 }
 
@@ -1039,8 +1065,8 @@ func TestFromCoreRequest_ToolChoice(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &format.CoreRequest{
-				Model:    "gpt-4o",
-				Messages: []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
+				Model:      "gpt-4o",
+				Messages:   []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
 				ToolChoice: &format.CoreToolChoice{Mode: tt.mode, Name: tt.tname},
 			}
 			result, err := adapter.FromCoreRequest(context.Background(), r)
@@ -1271,8 +1297,8 @@ func TestFromCoreRequest_RawToolChoice(t *testing.T) {
 	adapter := newTestAdapter()
 	raw := json.RawMessage(`{"type":"function","function":{"name":"my_tool"}}`)
 	result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{
-		Model:    "gpt-4o",
-		Messages: []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
+		Model:      "gpt-4o",
+		Messages:   []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
 		ToolChoice: &format.CoreToolChoice{Raw: raw},
 	})
 	if err != nil {
@@ -1319,8 +1345,8 @@ func TestToCoreResponse_BasicText(t *testing.T) {
 	chatResp := &chat.ChatResponse{
 		ID: "chatcmpl-1",
 		Choices: []chat.Choice{{
-			Index: 0,
-			Message: chat.ChatMessage{Role: "assistant", Content: "Hello!"},
+			Index:        0,
+			Message:      chat.ChatMessage{Role: "assistant", Content: "Hello!"},
 			FinishReason: "stop",
 		}},
 		Usage: &chat.Usage{PromptTokens: 5, CompletionTokens: 10, TotalTokens: 15},
@@ -1903,8 +1929,8 @@ func TestFromCoreRequest_ToolChoiceUnknownMode(t *testing.T) {
 	adapter := newTestAdapter()
 	t.Run("unknown mode without name", func(t *testing.T) {
 		result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{
-			Model:    "gpt-4o",
-			Messages: []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
+			Model:      "gpt-4o",
+			Messages:   []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
 			ToolChoice: &format.CoreToolChoice{Mode: "unknown_mode"},
 		})
 		if err != nil {
@@ -1922,8 +1948,8 @@ func TestFromCoreRequest_ToolChoiceUnknownMode(t *testing.T) {
 	})
 	t.Run("unknown mode with name", func(t *testing.T) {
 		result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{
-			Model:    "gpt-4o",
-			Messages: []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
+			Model:      "gpt-4o",
+			Messages:   []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
 			ToolChoice: &format.CoreToolChoice{Mode: "unknown_mode", Name: "my_tool"},
 		})
 		if err != nil {
@@ -2257,9 +2283,9 @@ func TestFromCoreRequest_DefaultContentBlockNoText(t *testing.T) {
 
 func TestNewClient_NormalizesBaseURL(t *testing.T) {
 	tests := []struct {
-		name     string
+		name      string
 		urlSuffix string // appended to srv.URL
-		wantPath string  // expected request path
+		wantPath  string // expected request path
 	}{
 		{"no /v1", "", "/v1/chat/completions"},
 		{"with /v1", "/v1", "/v1/chat/completions"},

--- a/internal/protocol/chat/chat_test.go
+++ b/internal/protocol/chat/chat_test.go
@@ -2191,6 +2191,141 @@ func TestToCoreStream_ContentBlockStartedNoRole(t *testing.T) {
 	}
 }
 
+func TestToCoreStream_ToolCallArgsDeltaByPosition(t *testing.T) {
+	adapter := newTestAdapter()
+	src := make(chan chat.ChatStreamChunk, 4)
+	idx0 := 0
+	idx1 := 1
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{
+				Role: "assistant",
+				ToolCalls: []chat.ToolCall{
+					{
+						Index: &idx0, ID: "call_a", Type: "function",
+						Function: chat.ToolCallFunc{Name: "tool_a", Arguments: json.RawMessage(``)},
+					},
+					{
+						Index: &idx1, ID: "call_b", Type: "function",
+						Function: chat.ToolCallFunc{Name: "tool_b", Arguments: json.RawMessage(``)},
+					},
+				},
+			},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{
+				ToolCalls: []chat.ToolCall{
+					{Index: &idx0, Function: chat.ToolCallFunc{Arguments: json.RawMessage(`"{\"a\":1}"`)}},
+					{Index: &idx1, Function: chat.ToolCallFunc{Arguments: json.RawMessage(`"{\"b\":2}"`)}},
+				},
+			},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{Index: 0, FinishReason: "tool_calls"}},
+	}
+	close(src)
+
+	events, err := adapter.ToCoreStream(context.Background(), (<-chan chat.ChatStreamChunk)(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var deltas []format.CoreStreamEvent
+	for e := range events {
+		if e.Type == format.CoreToolCallArgsDelta {
+			deltas = append(deltas, e)
+		}
+	}
+	if len(deltas) != 2 {
+		t.Fatalf("tool_call_args.delta count = %d, want 2", len(deltas))
+	}
+	if deltas[0].Index == deltas[1].Index {
+		t.Fatalf("tool deltas should map to different indices, got both at %d", deltas[0].Index)
+	}
+}
+
+func TestToCoreStream_ToolCallArgsDeltaRespectsExplicitToolIndex(t *testing.T) {
+	adapter := newTestAdapter()
+	src := make(chan chat.ChatStreamChunk, 4)
+	idx0 := 0
+	idx1 := 1
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{
+				Role: "assistant",
+				ToolCalls: []chat.ToolCall{
+					{
+						Index: &idx0, ID: "call_a", Type: "function",
+						Function: chat.ToolCallFunc{Name: "tool_a", Arguments: json.RawMessage(``)},
+					},
+					{
+						Index: &idx1, ID: "call_b", Type: "function",
+						Function: chat.ToolCallFunc{Name: "tool_b", Arguments: json.RawMessage(``)},
+					},
+				},
+			},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{
+				ToolCalls: []chat.ToolCall{
+					{Index: &idx1, Function: chat.ToolCallFunc{Arguments: json.RawMessage(`"{\"b\":2}"`)}},
+					{Index: &idx0, Function: chat.ToolCallFunc{Arguments: json.RawMessage(`"{\"a\":1}"`)}},
+				},
+			},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{Index: 0, FinishReason: "tool_calls"}},
+	}
+	close(src)
+
+	events, err := adapter.ToCoreStream(context.Background(), (<-chan chat.ChatStreamChunk)(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var started []format.CoreStreamEvent
+	var deltas []format.CoreStreamEvent
+	for e := range events {
+		if e.Type == format.CoreContentBlockStarted && e.ContentBlock != nil && e.ContentBlock.Type == "tool_use" {
+			started = append(started, e)
+		}
+		if e.Type == format.CoreToolCallArgsDelta {
+			deltas = append(deltas, e)
+		}
+	}
+	if len(started) != 2 || len(deltas) != 2 {
+		t.Fatalf("started=%d deltas=%d, want 2/2", len(started), len(deltas))
+	}
+	toolIndexByID := map[string]int{
+		started[0].ContentBlock.ToolUseID: started[0].Index,
+		started[1].ContentBlock.ToolUseID: started[1].Index,
+	}
+	idxA, okA := toolIndexByID["call_a"]
+	idxB, okB := toolIndexByID["call_b"]
+	if !okA || !okB {
+		t.Fatalf("missing tool start mapping: %+v", toolIndexByID)
+	}
+	if idxA == idxB {
+		t.Fatalf("tool indices should differ, both=%d", idxA)
+	}
+	for _, d := range deltas {
+		if d.Delta == `{"a":1}` && d.Index != idxA {
+			t.Fatalf("delta for call_a routed to %d, want %d", d.Index, idxA)
+		}
+		if d.Delta == `{"b":2}` && d.Index != idxB {
+			t.Fatalf("delta for call_b routed to %d, want %d", d.Index, idxB)
+		}
+	}
+}
+
 func TestFromCoreRequest_ToolResultInImagePath(t *testing.T) {
 	adapter := newTestAdapter()
 	result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{

--- a/internal/protocol/chat/types.go
+++ b/internal/protocol/chat/types.go
@@ -10,32 +10,54 @@ import "encoding/json"
 // ChatRequest maps to OpenAI Chat Completions request body.
 // https://platform.openai.com/docs/api-reference/chat/create
 type ChatRequest struct {
-	Model            string          `json:"model"`
-	Messages         []ChatMessage   `json:"messages"`
-	Temperature      *float64        `json:"temperature,omitempty"`
-	TopP             *float64        `json:"top_p,omitempty"`
-	MaxTokens        int             `json:"max_completion_tokens,omitempty"`
-	Stop             []string        `json:"stop,omitempty"`
-	Stream           bool            `json:"stream,omitempty"`
-	Tools            []ChatTool      `json:"tools,omitempty"`
-	ToolChoice       json.RawMessage `json:"tool_choice,omitempty"`
-	ParallelToolCalls *bool          `json:"parallel_tool_calls,omitempty"`
-	StreamOptions    *StreamOptions  `json:"stream_options,omitempty"`
-	Metadata         map[string]any  `json:"metadata,omitempty"`
-	User             string          `json:"user,omitempty"`
+	Model             string          `json:"model"`
+	Messages          []ChatMessage   `json:"messages"`
+	Temperature       *float64        `json:"temperature,omitempty"`
+	TopP              *float64        `json:"top_p,omitempty"`
+	MaxTokens         int             `json:"max_completion_tokens,omitempty"`
+	Stop              []string        `json:"stop,omitempty"`
+	Stream            bool            `json:"stream,omitempty"`
+	Tools             []ChatTool      `json:"tools,omitempty"`
+	ToolChoice        json.RawMessage `json:"tool_choice,omitempty"`
+	ParallelToolCalls *bool           `json:"parallel_tool_calls,omitempty"`
+	StreamOptions     *StreamOptions  `json:"stream_options,omitempty"`
+	Metadata          map[string]any  `json:"metadata,omitempty"`
+	User              string          `json:"user,omitempty"`
 }
 
 // ChatMessage represents a single message in the conversation.
 type ChatMessage struct {
-	Role       string      `json:"role"` // "system" | "user" | "assistant" | "tool"
-	Content    any         `json:"content,omitempty"` // string or []ContentPart
-	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
-	ToolCallID string      `json:"tool_call_id,omitempty"`
-	Name       string      `json:"name,omitempty"`
+	Role       string     `json:"role"`              // "system" | "user" | "assistant" | "tool"
+	Content    any        `json:"content,omitempty"` // string or []ContentPart
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Name       string     `json:"name,omitempty"`
 	// ReasoningContent is a non-standard field used by providers like DeepSeek
 	// to return chain-of-thought reasoning. When present, it must be echoed
 	// back in follow-up assistant messages.
 	ReasoningContent string `json:"reasoning_content,omitempty"`
+	// EmitEmptyReasoningContent forces JSON serialization of reasoning_content
+	// as an explicit empty string when ReasoningContent == "". This is used by
+	// DeepSeek fallback replay for assistant tool-call messages.
+	EmitEmptyReasoningContent bool `json:"-"`
+}
+
+// MarshalJSON preserves normal omitempty behavior, except when
+// EmitEmptyReasoningContent is true — then reasoning_content is emitted as "".
+func (message ChatMessage) MarshalJSON() ([]byte, error) {
+	type alias ChatMessage
+	base := struct {
+		alias
+		ReasoningContent *string `json:"reasoning_content,omitempty"`
+	}{
+		alias: alias(message),
+	}
+	base.alias.EmitEmptyReasoningContent = false
+	if message.ReasoningContent != "" || message.EmitEmptyReasoningContent {
+		value := message.ReasoningContent
+		base.ReasoningContent = &value
+	}
+	return json.Marshal(base)
 }
 
 // ContentPart is a multimodal content part (text or image_url).
@@ -99,9 +121,9 @@ type ChatResponse struct {
 
 // Choice represents a single completion choice in a non-streaming response.
 type Choice struct {
-	Index        int          `json:"index"`
-	Message      ChatMessage  `json:"message"`
-	FinishReason string       `json:"finish_reason"`
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
 }
 
 // Usage reports token usage from the API response.
@@ -128,19 +150,19 @@ type PromptTokensDetails struct {
 // Each data: line contains one ChatStreamChunk.
 // The final chunk before the data: [DONE] marker may contain usage.
 type ChatStreamChunk struct {
-	ID      string          `json:"id"`
-	Object  string          `json:"object"`
-	Created int64           `json:"created"`
-	Model   string          `json:"model"`
-	Choices []StreamChoice  `json:"choices"`
-	Usage   *Usage          `json:"usage,omitempty"` // only on final chunk when stream_options.include_usage
+	ID      string         `json:"id"`
+	Object  string         `json:"object"`
+	Created int64          `json:"created"`
+	Model   string         `json:"model"`
+	Choices []StreamChoice `json:"choices"`
+	Usage   *Usage         `json:"usage,omitempty"` // only on final chunk when stream_options.include_usage
 }
 
 // StreamChoice represents a single streaming choice with delta content.
 type StreamChoice struct {
-	Index        int      `json:"index"`
-	Delta        Delta    `json:"delta"`
-	FinishReason string   `json:"finish_reason,omitempty"`
+	Index        int    `json:"index"`
+	Delta        Delta  `json:"delta"`
+	FinishReason string `json:"finish_reason,omitempty"`
 }
 
 // Delta contains the incremental content for a streaming choice.

--- a/internal/protocol/chat/types.go
+++ b/internal/protocol/chat/types.go
@@ -89,6 +89,7 @@ type FunctionDef struct {
 
 // ToolCall represents a tool call in a response or streaming delta.
 type ToolCall struct {
+	Index    *int         `json:"index,omitempty"` // tool call position in streaming deltas
 	ID       string       `json:"id"`
 	Type     string       `json:"type"` // "function"
 	Function ToolCallFunc `json:"function"`

--- a/internal/protocol/google/adapter.go
+++ b/internal/protocol/google/adapter.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"moonbridge/internal/format"
@@ -25,8 +26,8 @@ import (
 // Only references: config, format, and google types.
 type GeminiProviderAdapter struct {
 	cfgMaxTokens int
-	client *Client
-	hooks format.CorePluginHooks
+	client       *Client
+	hooks        format.CorePluginHooks
 
 	// Cache config and registry (nil = caching disabled).
 	cacheCfg *cache.PlanCacheConfig
@@ -53,11 +54,11 @@ type GeminiProviderAdapter struct {
 // is registered for type conversion only (dispatch layer manages the client).
 func NewGeminiProviderAdapter(cfgMaxTokens int, client *Client, hooks format.CorePluginHooks, cacheCfg *cache.PlanCacheConfig, registry *cache.MemoryRegistry) *GeminiProviderAdapter {
 	return &GeminiProviderAdapter{
-		cfgMaxTokens: cfgMaxTokens,
-		client:    client,
-		hooks:     hooks.WithDefaults(),
-		cacheCfg:  cacheCfg,
-		registry:  registry,
+		cfgMaxTokens:  cfgMaxTokens,
+		client:        client,
+		hooks:         hooks.WithDefaults(),
+		cacheCfg:      cacheCfg,
+		registry:      registry,
 		prevSnapshots: make(map[int]string),
 	}
 
@@ -375,9 +376,9 @@ func (a *GeminiProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-ch
 				// Track usage from the last chunk.
 				if chunk.UsageMetadata != nil {
 					finalUsage = &format.CoreUsage{
-						InputTokens:  chunk.UsageMetadata.PromptTokenCount,
-						OutputTokens: chunk.UsageMetadata.CandidatesTokenCount,
-						TotalTokens:  chunk.UsageMetadata.TotalTokenCount,
+						InputTokens:       chunk.UsageMetadata.PromptTokenCount,
+						OutputTokens:      chunk.UsageMetadata.CandidatesTokenCount,
+						TotalTokens:       chunk.UsageMetadata.TotalTokenCount,
 						CachedInputTokens: chunk.UsageMetadata.CachedContentTokenCount,
 					}
 				}
@@ -406,47 +407,47 @@ func (a *GeminiProviderAdapter) blocksToContent(blocks []format.CoreContentBlock
 					Data:     b.ImageData,
 				},
 			})
-	case "tool_use":
-		// Store ToolUseID -> ToolName mapping for later FunctionResponse resolution (G-01).
-		a.toolUseIDMu.Lock()
-		a.toolUseIDMap[b.ToolUseID] = b.ToolName
-		a.toolUseIDMu.Unlock()
-		parts = append(parts, Part{
-			FunctionCall: &FunctionCall{
-				Name: b.ToolName,
-				Args: b.ToolInput,
-			},
-		})
-	case "tool_result":
-		// Look up the function name from ToolUseID (G-01).
-		funcName := b.ToolUseID
-		a.toolUseIDMu.Lock()
-		if fn, ok := a.toolUseIDMap[b.ToolUseID]; ok {
-			funcName = fn
-		}
-		a.toolUseIDMu.Unlock()
-
-		// Combine tool result content into a single text for the response.
-		var respText string
-		if len(b.ToolResultContent) > 0 {
-			for _, tc := range b.ToolResultContent {
-				respText += tc.Text
+		case "tool_use":
+			// Store ToolUseID -> ToolName mapping for later FunctionResponse resolution (G-01).
+			a.toolUseIDMu.Lock()
+			a.toolUseIDMap[b.ToolUseID] = b.ToolName
+			a.toolUseIDMu.Unlock()
+			parts = append(parts, Part{
+				FunctionCall: &FunctionCall{
+					Name: b.ToolName,
+					Args: b.ToolInput,
+				},
+			})
+		case "tool_result":
+			// Look up the function name from ToolUseID (G-01).
+			funcName := b.ToolUseID
+			a.toolUseIDMu.Lock()
+			if fn, ok := a.toolUseIDMap[b.ToolUseID]; ok {
+				funcName = fn
 			}
-		}
-		respMap := map[string]any{"response": respText}
-		respRaw, _ := marshalRaw(respMap)
-		parts = append(parts, Part{
-			FunctionResponse: &FunctionResponse{
-				Name:     funcName,
-				Response: respRaw,
-			},
-		})
-	case "reasoning":
-		// Gemini does not natively support a "reasoning" content type, so
-		// convert reasoning text to a regular text Part to retain the content (G-06).
-		if b.ReasoningText != "" {
-			parts = append(parts, Part{Text: b.ReasoningText})
-		}
+			a.toolUseIDMu.Unlock()
+
+			// Combine tool result content into a single text for the response.
+			var respText string
+			if len(b.ToolResultContent) > 0 {
+				for _, tc := range b.ToolResultContent {
+					respText += tc.Text
+				}
+			}
+			respMap := map[string]any{"response": respText}
+			respRaw, _ := marshalRaw(respMap)
+			parts = append(parts, Part{
+				FunctionResponse: &FunctionResponse{
+					Name:     funcName,
+					Response: respRaw,
+				},
+			})
+		case "reasoning":
+			// Gemini does not natively support a "reasoning" content type, so
+			// convert reasoning text to a regular text Part to retain the content (G-06).
+			if b.ReasoningText != "" {
+				parts = append(parts, Part{Text: b.ReasoningText})
+			}
 		default:
 			// Fallback: treat unknown types as text.
 			if b.Text != "" {
@@ -552,14 +553,15 @@ func (a *GeminiProviderAdapter) applyGenerationConfigMap(gc *GenerationConfig, c
 // fromParts converts Gemini Parts to []CoreContentBlock.
 func (a *GeminiProviderAdapter) fromParts(parts []Part) []format.CoreContentBlock {
 	result := make([]format.CoreContentBlock, 0, len(parts))
+	funcCallSeq := make(map[string]int)
 	for _, p := range parts {
-		result = append(result, a.fromPart(p))
+		result = append(result, a.fromPartWithSeq(p, funcCallSeq))
 	}
 	return result
 }
 
-// fromPart converts a single Gemini Part to CoreContentBlock.
-func (a *GeminiProviderAdapter) fromPart(p Part) format.CoreContentBlock {
+// fromPartWithSeq converts a single Gemini Part to CoreContentBlock.
+func (a *GeminiProviderAdapter) fromPartWithSeq(p Part, funcCallSeq map[string]int) format.CoreContentBlock {
 	switch {
 	case p.Text != "":
 		return format.CoreContentBlock{
@@ -567,10 +569,13 @@ func (a *GeminiProviderAdapter) fromPart(p Part) format.CoreContentBlock {
 			Text: p.Text,
 		}
 	case p.FunctionCall != nil:
+		callName := p.FunctionCall.Name
+		funcCallSeq[callName]++
+		callID := callName + "__call_" + strconv.Itoa(funcCallSeq[callName])
 		return format.CoreContentBlock{
 			Type:      "tool_use",
-			ToolUseID: p.FunctionCall.Name, // Gemini uses function name as identifier
-			ToolName:  p.FunctionCall.Name,
+			ToolUseID: callID,
+			ToolName:  callName,
 			ToolInput: p.FunctionCall.Args,
 		}
 	case p.FunctionResponse != nil:

--- a/internal/protocol/google/google_test.go
+++ b/internal/protocol/google/google_test.go
@@ -755,7 +755,7 @@ func TestFromCoreRequest_MultiTurn(t *testing.T) {
 func TestFromCoreRequest_SystemInstruction(t *testing.T) {
 	adapter := newTestAdapter()
 	coreReq := &format.CoreRequest{
-		Model: "gemini-2.0-flash",
+		Model:  "gemini-2.0-flash",
 		System: []format.CoreContentBlock{{Type: "text", Text: "You are helpful."}},
 		Messages: []format.CoreMessage{
 			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},
@@ -880,7 +880,7 @@ func TestFromCoreRequest_Tools(t *testing.T) {
 func TestFromCoreRequest_SafetySettingsMap(t *testing.T) {
 	adapter := newTestAdapter()
 	coreReq := &format.CoreRequest{
-		Model: "test",
+		Model:          "test",
 		SafetySettings: map[string]any{"harassment": "block_only_high", "hate_speech": "block_medium_and_above"},
 		Messages: []format.CoreMessage{
 			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},
@@ -922,10 +922,10 @@ func TestFromCoreRequest_GenerationConfigMap(t *testing.T) {
 	coreReq := &format.CoreRequest{
 		Model: "test",
 		GenerationConfig: map[string]any{
-			"temperature":       float64(0.7),
+			"temperature":      float64(0.7),
 			"topP":             float64(0.9),
 			"topK":             float64(40),
-			"maxOutputTokens": float64(8192),
+			"maxOutputTokens":  float64(8192),
 			"stopSequences":    []any{"\n\n", "**"},
 			"responseMimeType": "text/plain",
 			"candidateCount":   float64(1),
@@ -973,7 +973,7 @@ func TestFromCoreRequest_GenerationConfigMap_NonStringThreshold(t *testing.T) {
 
 	// Non-string threshold should be silently skipped.
 	coreReq := &format.CoreRequest{
-		Model: "test",
+		Model:          "test",
 		SafetySettings: map[string]any{"harassment": float64(3)},
 		Messages: []format.CoreMessage{
 			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},
@@ -1311,11 +1311,42 @@ func TestToCoreResponse_ToolCallResponse(t *testing.T) {
 	if blocks[1].ToolName != "get_weather" {
 		t.Errorf("ToolName = %q", blocks[1].ToolName)
 	}
-	if blocks[1].ToolUseID != "get_weather" {
+	if blocks[1].ToolUseID != "get_weather__call_1" {
 		t.Errorf("ToolUseID = %q", blocks[1].ToolUseID)
 	}
 	if string(blocks[1].ToolInput) != `{"loc":"NYC"}` {
 		t.Errorf("ToolInput = %s", string(blocks[1].ToolInput))
+	}
+}
+
+func TestToCoreResponse_ToolCallResponse_DuplicateFunctionNameGetsUniqueIDs(t *testing.T) {
+	adapter := newTestAdapter()
+	geminiResp := &google.GenerateContentResponse{
+		Candidates: []google.Candidate{{
+			Index: 0,
+			Content: google.Content{Role: "model", Parts: []google.Part{
+				{FunctionCall: &google.FunctionCall{Name: "get_weather", Args: json.RawMessage(`{"loc":"NYC"}`)}},
+				{FunctionCall: &google.FunctionCall{Name: "get_weather", Args: json.RawMessage(`{"loc":"Paris"}`)}},
+			}},
+			FinishReason: "STOP",
+		}},
+	}
+	result, err := adapter.ToCoreResponse(context.Background(), geminiResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks := result.Messages[0].Content
+	if len(blocks) != 2 {
+		t.Fatalf("Content blocks: got %d, want 2", len(blocks))
+	}
+	if blocks[0].ToolUseID == blocks[1].ToolUseID {
+		t.Fatalf("duplicate ToolUseID: %q", blocks[0].ToolUseID)
+	}
+	if blocks[0].ToolUseID != "get_weather__call_1" {
+		t.Errorf("first ToolUseID = %q, want get_weather__call_1", blocks[0].ToolUseID)
+	}
+	if blocks[1].ToolUseID != "get_weather__call_2" {
+		t.Errorf("second ToolUseID = %q, want get_weather__call_2", blocks[1].ToolUseID)
 	}
 }
 
@@ -1339,7 +1370,7 @@ func TestToCoreStream_SingleCandidate(t *testing.T) {
 		Candidates: []google.Candidate{{Index: 0, Content: google.Content{Parts: []google.Part{{Text: "Hel"}}}}},
 	}
 	src <- google.GenerateContentResponse{
-		Candidates: []google.Candidate{{Index: 0, Content: google.Content{Parts: []google.Part{{Text: "Hello world"}}}, FinishReason: "STOP"}},
+		Candidates:    []google.Candidate{{Index: 0, Content: google.Content{Parts: []google.Part{{Text: "Hello world"}}}, FinishReason: "STOP"}},
 		UsageMetadata: &google.UsageMetadata{PromptTokenCount: 5, CandidatesTokenCount: 10, TotalTokenCount: 15},
 	}
 	close(src)
@@ -1602,8 +1633,8 @@ func TestFromCoreRequest_EmptyToolResult(t *testing.T) {
 				Role: "user",
 				Content: []format.CoreContentBlock{
 					{
-						Type:             "tool_result",
-						ToolUseID:        "call_xyz",
+						Type:              "tool_result",
+						ToolUseID:         "call_xyz",
 						ToolResultContent: []format.CoreContentBlock{},
 					},
 				},
@@ -1667,13 +1698,13 @@ func TestFromCoreRequest_GenerationConfigMap_TypeVariants(t *testing.T) {
 	coreReq := &format.CoreRequest{
 		Model: "test",
 		GenerationConfig: map[string]any{
-			"temperature":       int(8) / 10, // int → toFloat64
-			"topP":             json.Number("0.85"), // json.Number → toFloat64
-			"maxOutputTokens": int(4096), // json.Number → toInt
-			"candidateCount":   json.Number("2"),
-			"candidate_count_int64": int64(1), // int64 → toInt
-			"stopSequences":    []string{"END"}, // []string → toStringSlice
-			"responseMimeType": "application/json",
+			"temperature":           int(8) / 10,         // int → toFloat64
+			"topP":                  json.Number("0.85"), // json.Number → toFloat64
+			"maxOutputTokens":       int(4096),           // json.Number → toInt
+			"candidateCount":        json.Number("2"),
+			"candidate_count_int64": int64(1),        // int64 → toInt
+			"stopSequences":         []string{"END"}, // []string → toStringSlice
+			"responseMimeType":      "application/json",
 		},
 		Messages: []format.CoreMessage{
 			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},
@@ -1700,10 +1731,10 @@ func TestFromCoreRequest_GenerationConfigMap_TypeVariants(t *testing.T) {
 	if gc.MaxOutputTokens != 4096 {
 		t.Errorf("MaxOutputTokens = %d, want 4096", gc.MaxOutputTokens)
 	}
-		// candidate_count from int64
-		if gc.CandidateCount != 2 {
-			t.Errorf("CandidateCount = %d, want 2", gc.CandidateCount)
-		}
+	// candidate_count from int64
+	if gc.CandidateCount != 2 {
+		t.Errorf("CandidateCount = %d, want 2", gc.CandidateCount)
+	}
 	// stop_sequences from []string
 	if len(gc.StopSequences) != 1 || gc.StopSequences[0] != "END" {
 		t.Errorf("StopSequences = %v", gc.StopSequences)
@@ -1716,9 +1747,9 @@ func TestFromCoreRequest_GenerationConfigMap_DefaultBranch(t *testing.T) {
 	coreReq := &format.CoreRequest{
 		Model: "test",
 		GenerationConfig: map[string]any{
-			"temperature":       "invalid", // string → toFloat64 default → false → skipped
+			"temperature":     "invalid", // string → toFloat64 default → false → skipped
 			"maxOutputTokens": "invalid", // string → toInt default → false → skipped
-			"unknown_key":       "should be ignored",
+			"unknown_key":     "should be ignored",
 		},
 		Messages: []format.CoreMessage{
 			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},
@@ -2019,8 +2050,8 @@ func TestFromCoreRequest_GenerationConfigMap_Int64AndDefault(t *testing.T) {
 	coreReq := &format.CoreRequest{
 		Model: "test",
 		GenerationConfig: map[string]any{
-			"topK":          int64(30),          // int64 → toFloat64
-			"stopSequences": 42,                 // int (not []any or []string) → toStringSlice default
+			"topK":          int64(30), // int64 → toFloat64
+			"stopSequences": 42,        // int (not []any or []string) → toStringSlice default
 		},
 		Messages: []format.CoreMessage{
 			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -987,6 +987,13 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 
 	for _, item := range items {
 		if item.Type == "function_call_output" {
+			// Keep any pending reasoning within the same assistant tool-call turn.
+			// Emitting a standalone assistant reasoning message here would break
+			// the required adjacency of assistant tool_use -> immediate tool_result.
+			if len(pendingFCBlocks) > 0 && len(pendingReasoning) > 0 {
+				pendingFCBlocks = mergeReasoningBeforeToolUse(pendingFCBlocks, pendingReasoning)
+				pendingReasoning = pendingReasoning[:0]
+			}
 			// Flush pending function_calls before tool results.
 			if len(pendingFCBlocks) > 0 {
 				flushed := make([]format.CoreContentBlock, len(pendingFCBlocks))
@@ -1023,7 +1030,7 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 		// Flush pending function_calls before non-function-call items.
 		// Don't flush between consecutive function_call items — they should
 		// be batched into a single assistant message.
-		if item.Type != "function_call" && item.Type != "custom_tool_call" && item.Type != "local_shell_call" && len(pendingFCBlocks) > 0 {
+		if item.Type != "function_call" && item.Type != "custom_tool_call" && item.Type != "local_shell_call" && item.Type != "reasoning" && len(pendingFCBlocks) > 0 {
 			flushed := make([]format.CoreContentBlock, len(pendingFCBlocks))
 			copy(flushed, pendingFCBlocks)
 			messages = append(messages, format.CoreMessage{
@@ -1041,6 +1048,10 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 		// Handle reasoning input items — convert to thinking blocks for the next assistant message.
 		if item.Type == "reasoning" {
 			blocks := reasoningBlocksFromSummary(item.Summary)
+			if len(pendingFCBlocks) > 0 {
+				pendingFCBlocks = mergeReasoningBeforeToolUse(pendingFCBlocks, blocks)
+				continue
+			}
 			pendingReasoning = append(pendingReasoning, blocks...)
 			continue
 		}
@@ -1348,6 +1359,21 @@ func reasoningBlocksFromSummary(raw json.RawMessage) []format.CoreContentBlock {
 		})
 	}
 	return blocks
+}
+
+func mergeReasoningBeforeToolUse(blocks []format.CoreContentBlock, reasoning []format.CoreContentBlock) []format.CoreContentBlock {
+	if len(reasoning) == 0 {
+		return blocks
+	}
+	insertAt := 0
+	for insertAt < len(blocks) && blocks[insertAt].Type == "reasoning" {
+		insertAt++
+	}
+	merged := make([]format.CoreContentBlock, 0, len(blocks)+len(reasoning))
+	merged = append(merged, blocks[:insertAt]...)
+	merged = append(merged, reasoning...)
+	merged = append(merged, blocks[insertAt:]...)
+	return merged
 }
 
 // cloneResponse creates a shallow copy of a Response for use in stream events.

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -944,8 +944,8 @@ type inputItem struct {
 //   - Items with role "system" or "developer" → system blocks.
 //   - Items with role "assistant" → assistant messages (including tool_use blocks
 //     from function_call items).
-//   - Items with type "function_call_output" → tool_result user messages.
-//   - Items with type "function_call" → tool_use within assistant messages.
+//   - Items with tool-call output types → tool_result user messages.
+//   - Items with tool-call input types → tool_use within assistant messages.
 func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []format.CoreContentBlock, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, nil, nil
@@ -986,7 +986,7 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 	var pendingFCBlocks []format.CoreContentBlock // batch consecutive function_calls
 
 	for _, item := range items {
-		if item.Type == "function_call_output" {
+		if isToolCallOutputType(item.Type) {
 			// Keep any pending reasoning within the same assistant tool-call turn.
 			// Emitting a standalone assistant reasoning message here would break
 			// the required adjacency of assistant tool_use -> immediate tool_result.
@@ -1030,7 +1030,7 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 		// Flush pending function_calls before non-function-call items.
 		// Don't flush between consecutive function_call items — they should
 		// be batched into a single assistant message.
-		if item.Type != "function_call" && item.Type != "custom_tool_call" && item.Type != "local_shell_call" && item.Type != "reasoning" && len(pendingFCBlocks) > 0 {
+		if !isToolCallInputType(item.Type) && item.Type != "reasoning" && len(pendingFCBlocks) > 0 {
 			flushed := make([]format.CoreContentBlock, len(pendingFCBlocks))
 			copy(flushed, pendingFCBlocks)
 			messages = append(messages, format.CoreMessage{
@@ -1374,6 +1374,24 @@ func mergeReasoningBeforeToolUse(blocks []format.CoreContentBlock, reasoning []f
 	merged = append(merged, reasoning...)
 	merged = append(merged, blocks[insertAt:]...)
 	return merged
+}
+
+func isToolCallInputType(itemType string) bool {
+	switch itemType {
+	case "function_call", "custom_tool_call", "local_shell_call":
+		return true
+	default:
+		return false
+	}
+}
+
+func isToolCallOutputType(itemType string) bool {
+	switch itemType {
+	case "function_call_output", "custom_tool_call_output", "local_shell_call_output":
+		return true
+	default:
+		return false
+	}
 }
 
 // cloneResponse creates a shallow copy of a Response for use in stream events.

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"sync"
 
-	"moonbridge/internal/format"
 	"moonbridge/internal/extension/codextool"
+	"moonbridge/internal/format"
 )
 
 // ============================================================================
@@ -31,7 +31,6 @@ import (
 //
 // The adapter is stateless; all configuration is injected via the constructor.
 type OpenAIAdapter struct {
-
 	hooks format.CorePluginHooks
 
 	streamMu     sync.Mutex
@@ -82,7 +81,7 @@ func (a *OpenAIAdapter) ToCoreRequest(ctx context.Context, req any) (*format.Cor
 	openaiReq.Input = preprocessed
 
 	// 2. Parse Input → Messages + System.
-	messages, system, err := convertInput(openaiReq.Input)
+	messages, system, err := convertInput(openaiReq.Input, openaiReq.Model)
 	if err != nil {
 		return nil, fmt.Errorf("invalid input: %w", err)
 	}
@@ -164,7 +163,6 @@ func (a *OpenAIAdapter) ToCoreRequest(ctx context.Context, req any) (*format.Cor
 	if len(openaiExt) > 0 {
 		coreReq.Extensions["openai"] = openaiExt
 	}
-
 
 	a.hooks.MutateCoreRequest(ctx, coreReq)
 
@@ -288,7 +286,6 @@ func (a *OpenAIAdapter) FromCoreResponse(ctx context.Context, resp *format.CoreR
 	}
 	response.Usage = usage
 
-
 	// Map error.
 	if resp.Error != nil {
 		response.Error = &ErrorObject{
@@ -369,6 +366,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 	outputIndexes := make(map[int]int)
 	itemIDs := make(map[int]string)
 	reasonIndexes := make(map[int]bool)
+	toolCallFinalized := make(map[int]bool)
 
 	for event := range events {
 		// Let hooks skip events.
@@ -627,20 +625,28 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 				},
 			})
 
-		// ==================================================================
-		// Tool call arguments done
-		// ==================================================================
+			// ==================================================================
+			// Tool call arguments done
+			// ==================================================================
 		case format.CoreToolCallArgsDone:
 			index := event.Index
+			if toolCallFinalized[index] {
+				break
+			}
+			finalArgs := event.Delta
+			if finalArgs == "" {
+				finalArgs = toolCallArgs[index]
+			}
 			if idx, ok := outputIndexes[index]; ok && idx < len(response.Output) {
-				response.Output[idx].Arguments = event.Delta
+				response.Output[idx].Arguments = finalArgs
 				response.Output[idx].Status = "completed"
 				if response.Output[idx].Type == "custom_tool_call" {
-					if bn, ok := toolBlockNames[index]; ok && event.Delta != "" {
-						response.Output[idx].Input = codextool.RebuildGrammar(bn, json.RawMessage(event.Delta))
+					if bn, ok := toolBlockNames[index]; ok && finalArgs != "" {
+						response.Output[idx].Input = codextool.RebuildGrammar(bn, json.RawMessage(finalArgs))
 					}
 				}
 			}
+			toolCallFinalized[index] = true
 			send(StreamEvent{
 				Event: "response.function_call_arguments.done",
 				Data: FunctionCallArgumentsDoneEvent{
@@ -648,7 +654,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 					SequenceNumber: next(),
 					ItemID:         itemIDs[index],
 					OutputIndex:    outputIndexes[index],
-					Arguments:      event.Delta,
+					Arguments:      finalArgs,
 				},
 			})
 			send(StreamEvent{
@@ -839,6 +845,9 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 				delete(contentText, index)
 
 			} else if _, ok := outputIndexes[index]; ok {
+				if toolCallFinalized[index] {
+					break
+				}
 				// 2. Tool_use block done — emit function_call_arguments.done + output_item.done.
 				itemID := itemIDs[index]
 				outputIndex := outputIndexes[index]
@@ -880,6 +889,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 						Item:           response.Output[outputIndexes[index]],
 					},
 				})
+				toolCallFinalized[index] = true
 
 				// Clean up state.
 				delete(toolCallArgs, index)
@@ -936,7 +946,7 @@ type inputItem struct {
 //     from function_call items).
 //   - Items with type "function_call_output" → tool_result user messages.
 //   - Items with type "function_call" → tool_use within assistant messages.
-func convertInput(raw json.RawMessage) ([]format.CoreMessage, []format.CoreContentBlock, error) {
+func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []format.CoreContentBlock, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, nil, nil
 	}
@@ -1037,13 +1047,19 @@ func convertInput(raw json.RawMessage) ([]format.CoreMessage, []format.CoreConte
 
 		switch {
 		case item.Type == "function_call":
-		// NOTE: Reasoning alignment for inference models (o3/o4-mini):
-		// OpenAI requires a "reasoning" input item before each "function_call" item
-		// when using reasoning models. Currently, pendingReasoning blocks (from preceding
-		// reasoning input items) are merged into the next assistant message, but no
-		// dummy reasoning block is injected if pendingReasoning is empty.
-		// A future fix should add a dummy reasoning block here when:
-		// (a) the model is a reasoning model, and (b) pendingReasoning is empty.
+			// NOTE: Reasoning alignment for inference models (o3/o4-mini):
+			// OpenAI requires a "reasoning" input item before each "function_call" item
+			// when using reasoning models. Currently, pendingReasoning blocks (from preceding
+			// reasoning input items) are merged into the next assistant message, but no
+			// dummy reasoning block is injected if pendingReasoning is empty.
+			// A future fix should add a dummy reasoning block here when:
+			// (a) the model is a reasoning model, and (b) pendingReasoning is empty.
+			if len(pendingReasoning) == 0 && isReasoningModel(model) {
+				pendingReasoning = append(pendingReasoning, format.CoreContentBlock{
+					Type:          "reasoning",
+					ReasoningText: "",
+				})
+			}
 
 			// function_call in input → tool_use assistant block.
 			// Collect into pendingFCBlocks to batch consecutive calls into a single assistant message.
@@ -1342,6 +1358,17 @@ func cloneResponse(r *Response) Response {
 	return *r
 }
 
+func isReasoningModel(model string) bool {
+	m := strings.TrimSpace(strings.ToLower(model))
+	if m == "" {
+		return false
+	}
+	return strings.HasPrefix(m, "o1") ||
+		strings.HasPrefix(m, "o3") ||
+		strings.HasPrefix(m, "o4") ||
+		strings.Contains(m, "reasoning")
+}
+
 // toolInputString converts a json.RawMessage tool input to a string,
 // defaulting to "{}" when the input is nil or null.
 func toolInputString(input json.RawMessage) string {
@@ -1365,7 +1392,6 @@ func outputToString(raw json.RawMessage) string {
 	// Fallback: return the raw JSON as a string (array/object).
 	return string(raw)
 }
-
 
 // localShellActionFromRaw parses tool input JSON into a ToolAction for local_shell.
 func localShellActionFromRaw(raw json.RawMessage) *ToolAction {
@@ -1456,7 +1482,7 @@ func convertToolWithNamespace(tool Tool, namespace string) []format.CoreTool {
 	ext := make(map[string]any)
 
 	switch tool.Type {
-case "function":
+	case "function":
 		ct := format.CoreTool{
 			Name:        name,
 			Description: tool.Description,

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1532,7 +1532,7 @@ func convertToolWithNamespace(tool Tool, namespace string) []format.CoreTool {
 			Description: tool.Description,
 			InputSchema: tool.Parameters,
 		}
-		codextool.AnnotateCoreTool(&ct, codextool.ToolFunction, name, namespace)
+		codextool.AnnotateCoreTool(&ct, codextool.ToolFunction, tool.Name, namespace)
 		return []format.CoreTool{ct}
 
 	case "web_search", "web_search_preview":
@@ -1581,13 +1581,13 @@ func convertToolWithNamespace(tool Tool, namespace string) []format.CoreTool {
 				Description: tool.Description,
 				InputSchema: codextool.LocalShellSchema(),
 			}
-			codextool.AnnotateCoreTool(&ct, codextool.ToolLocalShell, name, "")
+			codextool.AnnotateCoreTool(&ct, codextool.ToolLocalShell, tool.Name, "")
 			return []format.CoreTool{ct}
 		}
 		if codextool.IsApplyPatchGrammar(grammar) {
 			proxyTools := codextool.ApplyPatchProxyCoreTools(name)
 			for i := range proxyTools {
-				codextool.AnnotateCoreTool(&proxyTools[i], codextool.ToolApplyPatch, name, "")
+				codextool.AnnotateCoreTool(&proxyTools[i], codextool.ToolApplyPatch, tool.Name, "")
 			}
 			return proxyTools
 		}
@@ -1597,7 +1597,7 @@ func convertToolWithNamespace(tool Tool, namespace string) []format.CoreTool {
 				Description: codextool.ExecProxyDescription(),
 				InputSchema: codextool.ExecProxySchema(),
 			}
-			codextool.AnnotateCoreTool(&ct, codextool.ToolExec, name, "")
+			codextool.AnnotateCoreTool(&ct, codextool.ToolExec, tool.Name, "")
 			return []format.CoreTool{ct}
 		}
 		// Other custom tools: keep original name with raw input schema
@@ -1606,7 +1606,7 @@ func convertToolWithNamespace(tool Tool, namespace string) []format.CoreTool {
 			Description: customToolDescription(tool, grammar),
 			InputSchema: codextool.CustomToolInputSchema(grammar),
 		}
-		codextool.AnnotateCoreTool(&ct, codextool.ToolRaw, name, "")
+		codextool.AnnotateCoreTool(&ct, codextool.ToolRaw, tool.Name, "")
 		return []format.CoreTool{ct}
 
 	default:

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -157,6 +157,48 @@ func TestToCoreRequest_ReasoningModelInjectsEmptyReasoningBeforeFunctionCall(t *
 	}
 }
 
+func TestToCoreRequest_KeepsToolUseAdjacentToToolResultWhenReasoningPrecedesOutput(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	req := &openai.ResponsesRequest{
+		Model: "gpt-5.4",
+		Input: json.RawMessage(`[
+			{"type":"function_call","id":"fc_1","call_id":"call_1","name":"tool_a","arguments":"{\"a\":1}"},
+			{"type":"reasoning","summary":[{"type":"text","text":"thinking after tool call"}]},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]`),
+	}
+
+	result, err := adapter.ToCoreRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Messages) != 2 {
+		t.Fatalf("messages len=%d, want 2; got %+v", len(result.Messages), result.Messages)
+	}
+
+	assistant := result.Messages[0]
+	if assistant.Role != "assistant" {
+		t.Fatalf("messages[0].Role=%q, want assistant", assistant.Role)
+	}
+	if len(assistant.Content) != 2 {
+		t.Fatalf("assistant content len=%d, want 2; got %+v", len(assistant.Content), assistant.Content)
+	}
+	if assistant.Content[0].Type != "reasoning" || assistant.Content[0].ReasoningText != "thinking after tool call" {
+		t.Fatalf("assistant.Content[0]=%+v, want merged reasoning", assistant.Content[0])
+	}
+	if assistant.Content[1].Type != "tool_use" || assistant.Content[1].ToolUseID != "call_1" {
+		t.Fatalf("assistant.Content[1]=%+v, want tool_use call_1", assistant.Content[1])
+	}
+
+	toolResult := result.Messages[1]
+	if toolResult.Role != "tool" {
+		t.Fatalf("messages[1].Role=%q, want tool", toolResult.Role)
+	}
+	if len(toolResult.Content) != 1 || toolResult.Content[0].Type != "tool_result" || toolResult.Content[0].ToolUseID != "call_1" {
+		t.Fatalf("tool result message=%+v", toolResult)
+	}
+}
+
 func TestFromCoreStream_NoDuplicateDoneForToolUse(t *testing.T) {
 	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
 	coreReq := &format.CoreRequest{Model: "gpt-4o"}

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -199,6 +199,68 @@ func TestToCoreRequest_KeepsToolUseAdjacentToToolResultWhenReasoningPrecedesOutp
 	}
 }
 
+func TestToCoreRequest_BatchesCustomToolCallsAndOutputsIntoSingleRound(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	req := &openai.ResponsesRequest{
+		Model: "gpt-5.4",
+		Input: json.RawMessage(`[
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"before tools"}]},
+			{"type":"custom_tool_call","call_id":"call_a","name":"apply_patch","input":"patch a","arguments":"{\"input\":\"patch a\"}"},
+			{"type":"custom_tool_call_output","call_id":"call_a","output":"ok a"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"between tools"}]},
+			{"type":"custom_tool_call","call_id":"call_b","name":"apply_patch","input":"patch b","arguments":"{\"input\":\"patch b\"}"},
+			{"type":"custom_tool_call_output","call_id":"call_b","output":"ok b"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"between tools 2"}]},
+			{"type":"custom_tool_call","call_id":"call_c","name":"apply_patch","input":"patch c","arguments":"{\"input\":\"patch c\"}"},
+			{"type":"custom_tool_call_output","call_id":"call_c","output":"ok c"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"after tools"}]}
+		]`),
+	}
+
+	result, err := adapter.ToCoreRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 10 {
+		t.Fatalf("messages len=%d, want 10; got %+v", len(result.Messages), result.Messages)
+	}
+
+	if result.Messages[0].Role != "assistant" || len(result.Messages[0].Content) != 1 || result.Messages[0].Content[0].Text != "before tools" {
+		t.Fatalf("messages[0]=%+v, want pre-tool assistant text", result.Messages[0])
+	}
+
+	for i, want := range []struct {
+		assistantTextIdx int
+		msgIdx           int
+		callID  string
+		outcome string
+	}{
+		{0, 1, "call_a", "ok a"},
+		{3, 4, "call_b", "ok b"},
+		{6, 7, "call_c", "ok c"},
+	} {
+		if result.Messages[want.assistantTextIdx].Role != "assistant" {
+			t.Fatalf("assistant commentary turn %d = %+v", i, result.Messages[want.assistantTextIdx])
+		}
+		assistant := result.Messages[want.msgIdx]
+		if assistant.Role != "assistant" || len(assistant.Content) != 1 || assistant.Content[0].Type != "tool_use" || assistant.Content[0].ToolUseID != want.callID {
+			t.Fatalf("assistant tool turn %d = %+v", i, assistant)
+		}
+		toolResult := result.Messages[want.msgIdx+1]
+		if toolResult.Role != "tool" || len(toolResult.Content) != 1 || toolResult.Content[0].Type != "tool_result" || toolResult.Content[0].ToolUseID != want.callID {
+			t.Fatalf("tool result turn %d = %+v", i, toolResult)
+		}
+		if got := toolResult.Content[0].ToolResultContent[0].Text; got != want.outcome {
+			t.Fatalf("tool result text turn %d = %q, want %q", i, got, want.outcome)
+		}
+	}
+
+	if result.Messages[9].Role != "assistant" || len(result.Messages[9].Content) != 1 || result.Messages[9].Content[0].Text != "after tools" {
+		t.Fatalf("messages[9]=%+v, want trailing assistant text", result.Messages[9])
+	}
+}
+
 func TestFromCoreStream_NoDuplicateDoneForToolUse(t *testing.T) {
 	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
 	coreReq := &format.CoreRequest{Model: "gpt-4o"}

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -3,6 +3,7 @@ package openai_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"moonbridge/internal/format"
@@ -127,5 +128,75 @@ func TestToCoreRequest_NilInput(t *testing.T) {
 	_, err := adapter.ToCoreRequest(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestToCoreRequest_ReasoningModelInjectsEmptyReasoningBeforeFunctionCall(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	req := &openai.ResponsesRequest{
+		Model: "o3-mini",
+		Input: json.RawMessage(`[
+			{"type":"function_call","id":"fc_1","call_id":"call_1","name":"get_weather","arguments":"{\"city\":\"Paris\"}"}
+		]`),
+	}
+	result, err := adapter.ToCoreRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("messages len=%d, want 1", len(result.Messages))
+	}
+	if len(result.Messages[0].Content) < 2 {
+		t.Fatalf("assistant content len=%d, want >=2", len(result.Messages[0].Content))
+	}
+	if result.Messages[0].Content[0].Type != "reasoning" {
+		t.Fatalf("first content type=%q, want reasoning", result.Messages[0].Content[0].Type)
+	}
+	if result.Messages[0].Content[1].Type != "tool_use" {
+		t.Fatalf("second content type=%q, want tool_use", result.Messages[0].Content[1].Type)
+	}
+}
+
+func TestFromCoreStream_NoDuplicateDoneForToolUse(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	coreReq := &format.CoreRequest{Model: "gpt-4o"}
+	evCh := make(chan format.CoreStreamEvent, 8)
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockStarted,
+		Index: 5,
+		ContentBlock: &format.CoreContentBlock{
+			Type:      "tool_use",
+			ToolUseID: "call_1",
+			ToolName:  "exec_command",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreToolCallArgsDelta, Index: 5, Delta: `{"cmd":"ls"}`}
+	evCh <- format.CoreStreamEvent{Type: format.CoreToolCallArgsDone, Index: 5, Delta: `{"cmd":"ls"}`}
+	evCh <- format.CoreStreamEvent{Type: format.CoreContentBlockDone, Index: 5}
+	evCh <- format.CoreStreamEvent{Type: format.CoreEventCompleted, Status: "completed"}
+	close(evCh)
+
+	streamAny, err := adapter.FromCoreStream(context.Background(), coreReq, evCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := streamAny.(<-chan openai.StreamEvent)
+	var argsDone int
+	var itemDone int
+	for ev := range stream {
+		if ev.Event == "response.function_call_arguments.done" {
+			argsDone++
+		}
+		if ev.Event == "response.output_item.done" {
+			if data, ok := ev.Data.(openai.OutputItemEvent); ok && strings.HasPrefix(data.Item.CallID, "call_") {
+				itemDone++
+			}
+		}
+	}
+	if argsDone != 1 {
+		t.Fatalf("function_call_arguments.done count=%d, want 1", argsDone)
+	}
+	if itemDone != 1 {
+		t.Fatalf("output_item.done (tool) count=%d, want 1", itemDone)
 	}
 }

--- a/internal/service/api/helpers.go
+++ b/internal/service/api/helpers.go
@@ -49,10 +49,10 @@ func parsePagination(r *http.Request) paginationParams {
 }
 
 type paginatedResponse struct {
-	Data   any    `json:"data"`
-	Total  int    `json:"total"`
-	Limit  int    `json:"limit"`
-	Offset int    `json:"offset"`
+	Data   any `json:"data"`
+	Total  int `json:"total"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
 }
 
 // ---- Auth middleware ----
@@ -118,6 +118,8 @@ func maskFileConfigSecrets(fc *config.FileConfig) {
 		def.WebSearch = ws
 		fc.Providers[key] = def
 	}
+
+	fc.Server.AuthToken = maskAPIKey(fc.Server.AuthToken)
 
 	fc.Proxy.Response.APIKey = maskAPIKey(fc.Proxy.Response.APIKey)
 	fc.Proxy.Anthropic.APIKey = maskAPIKey(fc.Proxy.Anthropic.APIKey)

--- a/internal/service/app/app.go
+++ b/internal/service/app/app.go
@@ -316,6 +316,10 @@ type webSearchProber interface {
 	ProbeWebSearch(context.Context, string) (bool, error)
 }
 
+type webSearchCandidateProber interface {
+	ProbeWebSearchCandidate(context.Context, string, string) (bool, error)
+}
+
 // resolvePerProviderWebSearch resolves web_search support for each provider and
 // each model that has a model-level override.
 func resolvePerProviderWebSearch(ctx context.Context, cfg config.Config, pm *provider.ProviderManager, errors io.Writer) {
@@ -368,29 +372,32 @@ func resolvePerProviderWebSearch(ctx context.Context, cfg config.Config, pm *pro
 	}
 	// 2. Resolve model-level overrides for provider catalog slugs and route aliases.
 	for providerKey, def := range cfg.ProviderDefs {
-		providerWS := cfg.WebSearchForProvider(providerKey)
 		for modelName := range def.Models {
 			alias := providerKey + "/" + modelName
 			newAlias := modelName + "(" + providerKey + ")"
 			modelWS := cfg.WebSearchForModel(alias)
-			resolveModelWebSearch(ctx, alias, modelWS, providerWS, pm, errors)
-			resolveModelWebSearch(ctx, newAlias, modelWS, providerWS, pm, errors)
+			resolveModelWebSearch(ctx, alias, providerKey, modelName, modelWS, pm, cfg, errors)
+			resolveModelWebSearch(ctx, newAlias, providerKey, modelName, modelWS, pm, cfg, errors)
 			pureWS := cfg.WebSearchForModel(modelName)
-			resolveModelWebSearch(ctx, modelName, pureWS, providerWS, pm, errors)
+			resolveModelWebSearch(ctx, modelName, providerKey, modelName, pureWS, pm, cfg, errors)
 		}
 	}
 	for alias, route := range cfg.Routes {
 		modelWS := cfg.WebSearchForModel(alias)
-		providerWS := cfg.WebSearchForProvider(route.Provider)
-		resolveModelWebSearch(ctx, alias, modelWS, providerWS, pm, errors)
+		providerKey := route.Provider
+		if providerKey == "" {
+			providerKey = pm.DefaultKey()
+		}
+		resolveModelWebSearch(ctx, alias, providerKey, route.Model, modelWS, pm, cfg, errors)
 	}
 }
 
-func resolveModelWebSearch(ctx context.Context, alias string, modelWS config.WebSearchSupport, providerWS config.WebSearchSupport, pm *provider.ProviderManager, errors io.Writer) {
-	if modelWS == providerWS {
+func resolveModelWebSearch(ctx context.Context, alias, providerKey, upstreamModel string, modelWS config.WebSearchSupport, pm *provider.ProviderManager, cfg config.Config, errors io.Writer) {
+	if alias == "" || providerKey == "" || upstreamModel == "" {
 		return
 	}
 	modelKey := "model:" + alias
+	candidateKey := provider.WebSearchCandidateKey(providerKey, upstreamModel)
 	protocol := pm.ProtocolForModel(alias)
 	switch protocol {
 	case config.ProtocolAnthropic:
@@ -398,30 +405,37 @@ func resolveModelWebSearch(ctx context.Context, alias string, modelWS config.Web
 		switch modelWS {
 		case config.WebSearchSupportDisabled, config.WebSearchSupportInjected:
 			pm.SetResolvedWebSearch(modelKey, "disabled")
+			pm.SetResolvedWebSearch(candidateKey, "disabled")
 			slog.Info("模型禁用响应端网页搜索", "model", alias, "config", modelWS)
 		default:
 			pm.SetResolvedWebSearch(modelKey, "enabled")
+			pm.SetResolvedWebSearch(candidateKey, "enabled")
 			slog.Info("模型启用响应端网页搜索", "model", alias)
 		}
 		return
 	default:
 		pm.SetResolvedWebSearch(modelKey, "disabled")
+		pm.SetResolvedWebSearch(candidateKey, "disabled")
 		slog.Info("跳过模型级网页搜索：不支持的协议", "model", alias, "protocol", protocol)
 		return
 	}
 	switch modelWS {
 	case config.WebSearchSupportDisabled:
 		pm.SetResolvedWebSearch(modelKey, "disabled")
+		pm.SetResolvedWebSearch(candidateKey, "disabled")
 		slog.Info("模型配置禁用网页搜索", "model", alias)
 	case config.WebSearchSupportEnabled:
 		pm.SetResolvedWebSearch(modelKey, "enabled")
+		pm.SetResolvedWebSearch(candidateKey, "enabled")
 		slog.Info("模型配置强制启用网页搜索", "model", alias)
 	case config.WebSearchSupportInjected:
 		pm.SetResolvedWebSearch(modelKey, "injected")
+		pm.SetResolvedWebSearch(candidateKey, "injected")
 		slog.Info("模型配置启用网页搜索注入模式", "model", alias)
 	default:
-		resolved := probeModelWebSearch(ctx, alias, pm, errors)
+		resolved := resolveModelWebSearchWithProber(ctx, alias, providerKey, upstreamModel, modelWS, pm, cfg, errors, pm)
 		pm.SetResolvedWebSearch(modelKey, resolved)
+		pm.SetResolvedWebSearch(candidateKey, resolved)
 	}
 }
 
@@ -492,6 +506,61 @@ func probeModelWebSearch(ctx context.Context, modelAlias string, pm *provider.Pr
 	}
 	slog.Info("模型支持网页搜索", "model", modelAlias)
 	return "enabled"
+}
+
+func probeModelWebSearchCandidate(ctx context.Context, modelAlias, providerKey, upstreamModel string, pm *provider.ProviderManager, cfg config.Config, errors io.Writer) string {
+	return resolveModelWebSearchWithProber(ctx, modelAlias, providerKey, upstreamModel, config.WebSearchSupportAuto, pm, cfg, errors, pm)
+}
+
+func resolveModelWebSearchWithProber(ctx context.Context, modelAlias, providerKey, upstreamModel string, modelWS config.WebSearchSupport, pm *provider.ProviderManager, cfg config.Config, errors io.Writer, prober webSearchCandidateProber) string {
+	switch modelWS {
+	case config.WebSearchSupportDisabled:
+		return "disabled"
+	case config.WebSearchSupportEnabled:
+		return "enabled"
+	case config.WebSearchSupportInjected:
+		return "injected"
+	}
+	if prober == nil {
+		if injectedSearchConfigured(cfg, modelAlias, providerKey) {
+			return "injected"
+		}
+		return "disabled"
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	supported, err := prober.ProbeWebSearchCandidate(probeCtx, providerKey, upstreamModel)
+	if err != nil {
+		slog.Warn("网页搜索模型探测失败", "model", modelAlias, "provider", providerKey, "upstream_model", upstreamModel, "error", err)
+		fmt.Fprintf(errors, "网页搜索模型探测失败（%s via %s/%s）: %v\n", modelAlias, providerKey, upstreamModel, err)
+		if injectedSearchConfigured(cfg, modelAlias, providerKey) {
+			slog.Info("网页搜索模型探测失败，回退到注入模式", "model", modelAlias, "provider", providerKey, "upstream_model", upstreamModel)
+			return "injected"
+		}
+		return "disabled"
+	}
+	if supported {
+		slog.Info("模型支持网页搜索", "model", modelAlias, "provider", providerKey, "upstream_model", upstreamModel)
+		return "enabled"
+	}
+	if injectedSearchConfigured(cfg, modelAlias, providerKey) {
+		slog.Info("模型不支持原生网页搜索，回退到注入模式", "model", modelAlias, "provider", providerKey, "upstream_model", upstreamModel)
+		return "injected"
+	}
+	slog.Warn("模型不支持网页搜索", "model", modelAlias, "provider", providerKey, "upstream_model", upstreamModel)
+	fmt.Fprintf(errors, "模型 %s（%s/%s）不支持网页搜索\n", modelAlias, providerKey, upstreamModel)
+	return "disabled"
+}
+
+func injectedSearchConfigured(cfg config.Config, modelAlias, providerKey string) bool {
+	if cfg.WebSearchTavilyKeyForModel(modelAlias) != "" || cfg.WebSearchFirecrawlKeyForModel(modelAlias) != "" {
+		return true
+	}
+	if providerKey == "" {
+		return false
+	}
+	return cfg.WebSearchTavilyKeyForProvider(providerKey) != "" || cfg.WebSearchFirecrawlKeyForProvider(providerKey) != ""
 }
 
 func runCaptureResponse(ctx context.Context, cfg config.Config, errors io.Writer) error {

--- a/internal/service/app/app.go
+++ b/internal/service/app/app.go
@@ -58,6 +58,8 @@ func RunServer(ctx context.Context, cfg config.Config, errors io.Writer) error {
 }
 
 func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) error {
+	var rt *runtime.Runtime
+
 	// Construct domain configs from global config.
 	serverCfg := config.ServerFromGlobalConfig(&cfg)
 	cacheCfg := config.CacheFromGlobalConfig(&cfg)
@@ -103,6 +105,12 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 
 	// Register plugins.
 	plugins := BuiltinExtensions().NewRegistry(slog.Default(), cfg)
+	plugins.SetCurrentConfigProvider(func() config.Config {
+		if rt != nil && rt.Current() != nil {
+			return rt.Current().Config
+		}
+		return cfg
+	})
 	if err := plugins.InitAll(&cfg); err != nil {
 		return fmt.Errorf("init plugins: %w", err)
 	}
@@ -115,9 +123,12 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 
 	// Initialize persistence layer (db.Registry).
 	dbRegistry := db.NewRegistry(slog.Default())
-	for _, p := range plugins.DBProviders() {
+	dbProviders := plugins.DBProviders()
+	providers := make([]db.Provider, 0, len(dbProviders))
+	for _, p := range dbProviders {
 		if prov := p.DBProvider(); prov != nil {
 			dbRegistry.RegisterProvider(prov)
+			providers = append(providers, prov)
 		}
 	}
 	for _, c := range plugins.DBConsumers() {
@@ -129,7 +140,8 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 	configStoreConsumer := store.NewConfigStoreConsumer(logger.L())
 	configStoreConsumer.SetExtensionSpecs(BuiltinExtensions().ConfigSpecs())
 	dbRegistry.RegisterConsumer(configStoreConsumer)
-	if err := dbRegistry.Init(ctx, cfg.Persistence.ActiveProvider); err != nil {
+	activePersistenceProvider := ResolvePersistenceActiveProvider(cfg.Persistence.ActiveProvider, providers)
+	if err := dbRegistry.Init(ctx, activePersistenceProvider); err != nil {
 		return fmt.Errorf("init persistence: %w", err)
 	}
 	defer dbRegistry.Shutdown()
@@ -181,7 +193,7 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 	}
 
 	// === Phase 3: Build Runtime ===
-	rt := runtime.NewRuntime(cfg, providerMgr, pricing)
+	rt = runtime.NewRuntime(cfg, providerMgr, pricing)
 
 	// === Phase 4: Build Server with Runtime ===
 	// Create shared cache registry (used by both Bridge and Adapter paths).

--- a/internal/service/app/app.go
+++ b/internal/service/app/app.go
@@ -12,13 +12,12 @@ import (
 	"log/slog"
 	"moonbridge/internal/config"
 	"moonbridge/internal/db"
-	"moonbridge/internal/service/store"
+	"moonbridge/internal/format"
 	"moonbridge/internal/logger"
 	"moonbridge/internal/protocol/anthropic"
-	"moonbridge/internal/protocol/google"
-	"moonbridge/internal/protocol/chat"
 	"moonbridge/internal/protocol/cache"
-	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/chat"
+	"moonbridge/internal/protocol/google"
 	"moonbridge/internal/protocol/openai"
 	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/proxy"
@@ -28,6 +27,7 @@ import (
 	"moonbridge/internal/service/server/trace"
 	"moonbridge/internal/service/server/usage"
 	"moonbridge/internal/service/stats"
+	"moonbridge/internal/service/store"
 	mbtrace "moonbridge/internal/service/trace"
 )
 
@@ -65,11 +65,11 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 	storeCfg := config.StoreFromGlobalConfig(&cfg)
 	persistCfg := config.PersistenceFromGlobalConfig(&cfg)
 	providerCfg := config.ProviderFromGlobalConfig(&cfg)
-	_ = persistCfg   // used in db init
-	_ = storeCfg     // used in config store
-	_ = proxyCfg     // used in proxy mode
+	_ = persistCfg // used in db init
+	_ = storeCfg   // used in config store
+	_ = proxyCfg   // used in proxy mode
 
-		// === Phase 1: Bootstrap from YAML ===
+	// === Phase 1: Bootstrap from YAML ===
 
 	// Build multi-provider infrastructure from YAML config.
 	providerDefs := provider.BuildProviderDefsFromConfig(providerCfg)
@@ -161,6 +161,7 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 				if len(pricing) > 0 {
 					sessionStats.SetPricing(pricing)
 				}
+				serverCfg = config.ServerFromGlobalConfig(&cfg)
 			} else {
 				// DB is empty: seed from YAML config.
 				logger.Info("持久化存储为空，从 YAML 导入种子配置")
@@ -179,7 +180,7 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 		logger.Warn("config store 不可用，跳过持久化引导")
 	}
 
-		// === Phase 3: Build Runtime ===
+	// === Phase 3: Build Runtime ===
 	rt := runtime.NewRuntime(cfg, providerMgr, pricing)
 
 	// === Phase 4: Build Server with Runtime ===
@@ -203,19 +204,19 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 	_ = adapterReg.RegisterProviderStream(anthAdapter)
 
 	// Upstream: Google GenAI provider adapter.
-		googleCfg := &cache.PlanCacheConfig{
-			Mode:                     cacheCfg.Mode,
-			TTL:                      cacheCfg.TTL,
-			PromptCaching:            cacheCfg.PromptCaching,
-			AutomaticPromptCache:     cacheCfg.AutomaticPromptCache,
-			ExplicitCacheBreakpoints: cacheCfg.ExplicitCacheBreakpoints,
-			AllowRetentionDowngrade:  cacheCfg.AllowRetentionDowngrade,
-			MaxBreakpoints:           cacheCfg.MaxBreakpoints,
-			MinCacheTokens:           cacheCfg.MinCacheTokens,
-			ExpectedReuse:            cacheCfg.ExpectedReuse,
-			MinimumValueScore:        cacheCfg.MinimumValueScore,
-			MinBreakpointTokens:      cacheCfg.MinBreakpointTokens,
-		}
+	googleCfg := &cache.PlanCacheConfig{
+		Mode:                     cacheCfg.Mode,
+		TTL:                      cacheCfg.TTL,
+		PromptCaching:            cacheCfg.PromptCaching,
+		AutomaticPromptCache:     cacheCfg.AutomaticPromptCache,
+		ExplicitCacheBreakpoints: cacheCfg.ExplicitCacheBreakpoints,
+		AllowRetentionDowngrade:  cacheCfg.AllowRetentionDowngrade,
+		MaxBreakpoints:           cacheCfg.MaxBreakpoints,
+		MinCacheTokens:           cacheCfg.MinCacheTokens,
+		ExpectedReuse:            cacheCfg.ExpectedReuse,
+		MinimumValueScore:        cacheCfg.MinimumValueScore,
+		MinBreakpointTokens:      cacheCfg.MinBreakpointTokens,
+	}
 	googleAdapter := google.NewGeminiProviderAdapter(cfg.DefaultMaxTokens, nil, coreHooks, googleCfg, cacheReg)
 	_ = adapterReg.RegisterProvider(googleAdapter)
 	_ = adapterReg.RegisterProviderStream(googleAdapter)
@@ -252,14 +253,13 @@ func runTransform(ctx context.Context, cfg config.Config, errors io.Writer) erro
 		}
 	}
 
-
 	// Create sub-package managers for session, usage, and trace.
-	sessMgr := session.NewInMemoryManager(server.NewSessionConfigAdapter(serverCfg), plugins)
+	sessMgr := session.NewInMemoryManager(server.NewSessionConfigAdapterFromRuntime(rt, serverCfg), plugins)
 	usageTrk := usage.NewStatsTracker(sessionStats)
 	traceWtr := trace.NewFileWriter(tracer, errors)
 
 	handler := server.New(server.Config{
-		ServerCfg:      serverCfg,
+		ServerCfg:       serverCfg,
 		Provider:        fallbackProvider,
 		ProviderMgr:     providerMgr,
 		ChatClients:     chatClients,

--- a/internal/service/app/app_test.go
+++ b/internal/service/app/app_test.go
@@ -12,6 +12,12 @@ import (
 	mbtrace "moonbridge/internal/service/trace"
 )
 
+type probeWebSearchCandidateFunc func(context.Context, string, string) (bool, error)
+
+func (fn probeWebSearchCandidateFunc) ProbeWebSearchCandidate(ctx context.Context, providerKey, upstreamModel string) (bool, error) {
+	return fn(ctx, providerKey, upstreamModel)
+}
+
 func TestWelcomeMessage(t *testing.T) {
 	want := "欢迎使用 Moon Bridge!"
 
@@ -173,6 +179,81 @@ func TestResolvePerProviderWebSearchAppliesProviderCatalogModelOverride(t *testi
 	}
 	if got := pm.ResolvedWebSearchForModel("main/claude-test"); got != "enabled" {
 		t.Fatalf("ResolvedWebSearchForModel(main/claude-test) = %q, want enabled", got)
+	}
+}
+
+func TestResolveModelWebSearchCandidateFallsBackToInjectedWhenUnsupported(t *testing.T) {
+	cfg := config.Config{
+		TavilyAPIKey: "tavily-key",
+	}
+	pm, err := provider.NewProviderManager(
+		map[string]provider.ProviderConfig{
+			"opencode": {
+				BaseURL: "https://opencode.example.test",
+				APIKey:  "key-opencode",
+			},
+		},
+		map[string]provider.ModelRoute{
+			"deepseek-v4-pro": {Provider: "opencode", Name: "deepseek-v4-pro"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var errors bytes.Buffer
+	resolved := resolveModelWebSearchWithProber(
+		context.Background(),
+		"deepseek-v4-pro",
+		"opencode",
+		"deepseek-v4-pro",
+		config.WebSearchSupportAuto,
+		pm,
+		cfg,
+		&errors,
+		probeWebSearchCandidateFunc(func(context.Context, string, string) (bool, error) {
+			return false, nil
+		}),
+	)
+
+	if resolved != "injected" {
+		t.Fatalf("resolveModelWebSearchWithProber() = %q, want injected", resolved)
+	}
+}
+
+func TestResolveModelWebSearchCandidateKeepsEnabledWhenSupported(t *testing.T) {
+	cfg := config.Config{}
+	pm, err := provider.NewProviderManager(
+		map[string]provider.ProviderConfig{
+			"deepseek": {
+				BaseURL: "https://deepseek.example.test",
+				APIKey:  "key-deepseek",
+			},
+		},
+		map[string]provider.ModelRoute{
+			"deepseek-v4-flash": {Provider: "deepseek", Name: "deepseek-v4-flash"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolved := resolveModelWebSearchWithProber(
+		context.Background(),
+		"deepseek-v4-flash",
+		"deepseek",
+		"deepseek-v4-flash",
+		config.WebSearchSupportAuto,
+		pm,
+		cfg,
+		&bytes.Buffer{},
+		probeWebSearchCandidateFunc(func(context.Context, string, string) (bool, error) {
+			return true, nil
+		}),
+	)
+
+	if resolved != "enabled" {
+		t.Fatalf("resolveModelWebSearchWithProber() = %q, want enabled", resolved)
 	}
 }
 

--- a/internal/service/app/extensions_test.go
+++ b/internal/service/app/extensions_test.go
@@ -1,11 +1,20 @@
 package app
 
 import (
+	"context"
+	"database/sql"
 	"log/slog"
 	"testing"
 
 	"moonbridge/internal/config"
+	"moonbridge/internal/db"
+	dbd1 "moonbridge/internal/extension/db/d1"
+	dbsqlite "moonbridge/internal/extension/db/sqlite"
 	"moonbridge/internal/extension/deepseek_v4"
+	kimiworkaround "moonbridge/internal/extension/kimi_workaround"
+	"moonbridge/internal/extension/plugin"
+	"moonbridge/internal/extension/visual"
+	"moonbridge/internal/format"
 )
 
 func ptrBool(v bool) *bool { return &v }
@@ -58,3 +67,154 @@ func TestDeepSeekPlugin_EnabledForModelViaResolver(t *testing.T) {
 		t.Error("EnabledForModel('unknown-model') = true, want false")
 	}
 }
+
+func TestPluginsReadCurrentRuntimeConfig(t *testing.T) {
+	initialCfg := config.Config{
+		ProviderDefs: map[string]config.ProviderDef{
+			"anthropic": {
+				BaseURL: "https://anthropic.example.test",
+				APIKey:  "test-key",
+				Models: map[string]config.ModelMeta{
+					"claude-3-5-sonnet": {},
+				},
+			},
+			"vision": {
+				BaseURL: "https://vision.example.test",
+				APIKey:  "vision-key",
+				Models: map[string]config.ModelMeta{
+					"vision-model": {},
+				},
+			},
+		},
+		Routes: map[string]config.RouteEntry{
+			"moonbridge": {
+				Provider: "anthropic",
+				Model:    "claude-3-5-sonnet",
+				Extensions: map[string]config.ExtensionSettings{
+					deepseekv4.PluginName:     {Enabled: ptrBool(false)},
+					kimiworkaround.PluginName: {Enabled: ptrBool(false)},
+					visual.PluginName:         {Enabled: ptrBool(false)},
+				},
+			},
+		},
+		Extensions: map[string]config.ExtensionSettings{
+			deepseekv4.PluginName:     {Enabled: ptrBool(false)},
+			kimiworkaround.PluginName: {Enabled: ptrBool(false)},
+			visual.PluginName:         {Enabled: ptrBool(false)},
+		},
+	}
+	runtimeCfg := initialCfg
+	runtimeCfg.Routes["moonbridge"] = config.RouteEntry{
+		Provider: "anthropic",
+		Model:    "claude-3-5-sonnet",
+		Extensions: map[string]config.ExtensionSettings{
+			deepseekv4.PluginName: {
+				Enabled: ptrBool(true),
+				RawConfig: map[string]any{
+					"reinforce_instructions": true,
+					"reinforce_prompt":       "runtime reinforce",
+				},
+			},
+			kimiworkaround.PluginName: {
+				Enabled: ptrBool(true),
+				RawConfig: map[string]any{
+					"max_tool_rounds":    3,
+					"convergence_margin": 0.5,
+				},
+			},
+			visual.PluginName: {
+				Enabled: ptrBool(true),
+				RawConfig: map[string]any{
+					"provider":   "vision",
+					"model":      "vision-model",
+					"max_rounds": 6,
+					"max_tokens": 4096,
+				},
+			},
+		},
+	}
+
+	reg := BuiltinExtensions().NewRegistry(slog.Default(), initialCfg)
+	reg.SetCurrentConfigProvider(func() config.Config { return runtimeCfg })
+	if err := reg.InitAll(&initialCfg); err != nil {
+		t.Fatalf("InitAll() error = %v", err)
+	}
+
+	dsPlugin, ok := reg.Plugin(deepseekv4.PluginName).(*deepseekv4.DSPlugin)
+	if !ok {
+		t.Fatalf("plugin %q is not *DSPlugin", deepseekv4.PluginName)
+	}
+	if !dsPlugin.EnabledForModel("moonbridge") {
+		t.Fatal("deepseek_v4 should read enabled state from current config")
+	}
+	rewritten := dsPlugin.RewriteMessages(&plugin.RequestContext{ModelAlias: "moonbridge"}, []format.CoreMessage{{
+		Role:    "user",
+		Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}},
+	}})
+	if len(rewritten) != 2 || rewritten[0].Content[0].Text != "runtime reinforce" {
+		t.Fatalf("deepseek rewrite did not use runtime prompt: %+v", rewritten)
+	}
+
+	kimiPlugin, ok := reg.Plugin(kimiworkaround.PluginName).(*kimiworkaround.Plugin)
+	if !ok {
+		t.Fatalf("plugin %q is not *Plugin", kimiworkaround.PluginName)
+	}
+	if !kimiPlugin.EnabledForModel("moonbridge") {
+		t.Fatal("kimi_workaround should read enabled state from current config")
+	}
+	kimiMsgs := []format.CoreMessage{
+		{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}},
+		{Role: "assistant", Content: []format.CoreContentBlock{{Type: "tool_use", ToolUseID: "call_1", ToolName: "exec"}}},
+		{Role: "tool", Content: []format.CoreContentBlock{{Type: "tool_result", ToolUseID: "call_1", ToolResultContent: []format.CoreContentBlock{{Type: "text", Text: "ok"}}}}},
+		{Role: "assistant", Content: []format.CoreContentBlock{{Type: "tool_use", ToolUseID: "call_2", ToolName: "exec"}}},
+		{Role: "tool", Content: []format.CoreContentBlock{{Type: "tool_result", ToolUseID: "call_2", ToolResultContent: []format.CoreContentBlock{{Type: "text", Text: "ok"}}}}},
+	}
+	limited := kimiPlugin.RewriteMessages(&plugin.RequestContext{ModelAlias: "moonbridge"}, kimiMsgs)
+	lastResult := limited[len(limited)-1].Content[0].ToolResultContent
+	if len(lastResult) != 3 || lastResult[2].Text != kimiworkaround.DefaultLimitPrompt {
+		t.Fatalf("kimi rewrite did not use runtime limit config: %+v", lastResult)
+	}
+
+	visualPlugin, ok := reg.Plugin(visual.PluginName).(*visual.Plugin)
+	if !ok {
+		t.Fatalf("plugin %q is not *Plugin", visual.PluginName)
+	}
+	if !visualPlugin.EnabledForModel("moonbridge") {
+		t.Fatal("visual should read enabled state from current config")
+	}
+	visCfg, enabled := visual.ConfigForModelFromResolvedConfig(runtimeCfg, "moonbridge")
+	if !enabled || visCfg.Provider != "vision" || visCfg.Model != "vision-model" {
+		t.Fatalf("visual runtime config = %+v, enabled=%v", visCfg, enabled)
+	}
+}
+
+func TestResolvePersistenceActiveProvider(t *testing.T) {
+	sqliteProvider := &stubDBProvider{name: dbsqlite.PluginName, workerBound: false}
+	d1Provider := &stubDBProvider{name: dbd1.PluginName, workerBound: true}
+
+	if got := ResolvePersistenceActiveProvider("custom", []db.Provider{sqliteProvider, d1Provider}); got != "custom" {
+		t.Fatalf("explicit active provider = %q, want custom", got)
+	}
+	if got := ResolvePersistenceActiveProvider("", []db.Provider{sqliteProvider}); got != dbsqlite.PluginName {
+		t.Fatalf("single provider auto-select = %q", got)
+	}
+	if got := ResolvePersistenceActiveProvider("", []db.Provider{sqliteProvider, d1Provider}); got != dbd1.PluginName {
+		t.Fatalf("worker-bound provider auto-select = %q", got)
+	}
+	if got := ResolvePersistenceActiveProvider("", []db.Provider{sqliteProvider, &stubDBProvider{name: "other", workerBound: false}}); got != "" {
+		t.Fatalf("ambiguous providers should stay empty, got %q", got)
+	}
+}
+
+type stubDBProvider struct {
+	name        string
+	workerBound bool
+}
+
+func (p *stubDBProvider) Name() string               { return p.name }
+func (p *stubDBProvider) Dialect() db.Dialect        { return "" }
+func (p *stubDBProvider) Open(context.Context) error { return nil }
+func (p *stubDBProvider) DB() *sql.DB                { return nil }
+func (p *stubDBProvider) Ping(context.Context) error { return nil }
+func (p *stubDBProvider) Close() error               { return nil }
+func (p *stubDBProvider) Features() db.Features      { return db.Features{WorkerBound: p.workerBound} }

--- a/internal/service/app/persistence.go
+++ b/internal/service/app/persistence.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"strings"
+
+	"moonbridge/internal/db"
+)
+
+// ResolvePersistenceActiveProvider chooses the provider name that should be
+// passed into db.Registry.Init. It preserves explicit configuration and only
+// auto-selects when the startup environment makes the choice deterministic.
+func ResolvePersistenceActiveProvider(configured string, providers []db.Provider) string {
+	configured = strings.TrimSpace(configured)
+	if configured != "" {
+		return configured
+	}
+	if len(providers) == 1 {
+		return providers[0].Name()
+	}
+	var workerBound db.Provider
+	for _, provider := range providers {
+		if provider == nil || !provider.Features().WorkerBound {
+			continue
+		}
+		if workerBound != nil {
+			return ""
+		}
+		workerBound = provider
+	}
+	if workerBound != nil {
+		return workerBound.Name()
+	}
+	return ""
+}

--- a/internal/service/provider/manager.go
+++ b/internal/service/provider/manager.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sync"
 	"sort"
+	"sync"
 	"time"
 
 	"moonbridge/internal/config"
@@ -27,16 +27,16 @@ type ModelMeta = config.ModelMeta
 
 // ProviderConfig defines how to connect to a single upstream provider.
 type ProviderConfig struct {
-	BaseURL          string                 `yaml:"base_url"`
-	APIKey           string                 `yaml:"api_key"`
-	Version          string                 `yaml:"version"`
-	UserAgent        string                 `yaml:"user_agent"`
-	Protocol         string                 // "anthropic" (default) or "openai-response"
-	HTTP             HTTPConfig             `yaml:"http"`
-	WebSearchSupport string                 // "auto", "enabled", "disabled", "injected", or "" (inherit global)
-	ModelNames       []string               // upstream model names for this provider
-	Models           map[string]ModelMeta   // full model metadata (upstream name -> meta) [deprecated: use Offers]
-	Offers           []config.OfferEntry    // model offerings with pricing (replaces Models)
+	BaseURL          string               `yaml:"base_url"`
+	APIKey           string               `yaml:"api_key"`
+	Version          string               `yaml:"version"`
+	UserAgent        string               `yaml:"user_agent"`
+	Protocol         string               // "anthropic" (default) or "openai-response"
+	HTTP             HTTPConfig           `yaml:"http"`
+	WebSearchSupport string               // "auto", "enabled", "disabled", "injected", or "" (inherit global)
+	ModelNames       []string             // upstream model names for this provider
+	Models           map[string]ModelMeta // full model metadata (upstream name -> meta) [deprecated: use Offers]
+	Offers           []config.OfferEntry  // model offerings with pricing (replaces Models)
 }
 
 // modelProviderEntry is a reverse-index entry: provider key + offer priority.
@@ -51,13 +51,12 @@ type ModelRoute struct {
 	Name     string `yaml:"name"`     // upstream model name
 }
 
-
 // ProviderCandidate represents a candidate provider for a resolved model.
 type ProviderCandidate struct {
 	ProviderKey   string
 	UpstreamModel string
 	Protocol      string // "anthropic" | "openai-response"
-	Client ProviderClient
+	Client        ProviderClient
 }
 
 // ResolvedRoute contains the result of model resolution.
@@ -135,15 +134,13 @@ func NewAnthropicClientAdapter(client *anthropic.Client) ProviderClient {
 	return &anthropicClientAdapter{client: client}
 }
 
-
-
 type ProviderManager struct {
-	mu        sync.Mutex               // guards field replacement during Reload
-	clients    map[string]ProviderClient
-	providers  map[string]ProviderConfig    // provider key -> config (for inspection)
-	routes     map[string]ModelRoute        // model alias -> route
-	defaultK   string                       // default provider key
-	resolvedWS map[string]string            // provider key -> resolved web search support
+	mu             sync.Mutex // guards field replacement during Reload
+	clients        map[string]ProviderClient
+	providers      map[string]ProviderConfig       // provider key -> config (for inspection)
+	routes         map[string]ModelRoute           // model alias -> route
+	defaultK       string                          // default provider key
+	resolvedWS     map[string]string               // provider key -> resolved web search support
 	modelProviders map[string][]modelProviderEntry // upstream model name -> (provider key, priority) (reverse index)
 }
 
@@ -308,9 +305,10 @@ func (pm *ProviderManager) ClientFor(modelAlias string) (string, ProviderClient,
 
 // ResolveModel resolves a model name to a ResolvedRoute with candidate providers.
 // Priority:
-//	1. Route alias (explicit routes map)
-//	2. Direct ref (provider/model or model(provider))
-//	3. Dynamic model (reverse index from provider catalog ModelNames)
+//  1. Route alias (explicit routes map)
+//  2. Direct ref (provider/model or model(provider))
+//  3. Dynamic model (reverse index from provider catalog ModelNames)
+//
 // Returns error if no candidates are found.
 func (pm *ProviderManager) ResolveModel(modelName string) (*ResolvedRoute, error) {
 	// 1. Route alias (highest priority)
@@ -351,16 +349,16 @@ func (pm *ProviderManager) ResolveModel(modelName string) (*ResolvedRoute, error
 
 	// 3. Dynamic model: look up reverse index (provider catalog)
 	if providerEntries, ok := pm.modelProviders[modelName]; ok && len(providerEntries) > 0 {
-			sorted := make([]modelProviderEntry, len(providerEntries))
-			copy(sorted, providerEntries)
-			sort.Slice(sorted, func(i, j int) bool {
-				pi := sorted[i].priority
-				pj := sorted[j].priority
-				if pi != pj {
-					return pi < pj // lower priority = higher precedence (0 is highest)
-				}
-				return sorted[i].providerKey < sorted[j].providerKey // tiebreaker: provider key dictionary order
-			})
+		sorted := make([]modelProviderEntry, len(providerEntries))
+		copy(sorted, providerEntries)
+		sort.Slice(sorted, func(i, j int) bool {
+			pi := sorted[i].priority
+			pj := sorted[j].priority
+			if pi != pj {
+				return pi < pj // lower priority = higher precedence (0 is highest)
+			}
+			return sorted[i].providerKey < sorted[j].providerKey // tiebreaker: provider key dictionary order
+		})
 
 		candidates := make([]ProviderCandidate, 0, len(sorted))
 		for _, entry := range sorted {
@@ -394,6 +392,25 @@ func (pm *ProviderManager) ProbeWebSearch(ctx context.Context, modelAlias string
 	accessor, ok := client.(AnthropicClientAccessor)
 	if !ok {
 		return false, fmt.Errorf("provider client for %q does not support web search probing", modelAlias)
+	}
+	return accessor.AnthropicClient().ProbeWebSearch(ctx, upstreamModel)
+}
+
+// ProbeWebSearchCandidate probes web_search support for a specific provider/model pair.
+func (pm *ProviderManager) ProbeWebSearchCandidate(ctx context.Context, providerKey, upstreamModel string) (bool, error) {
+	if providerKey == "" {
+		return false, fmt.Errorf("provider key is required")
+	}
+	if upstreamModel == "" {
+		return false, fmt.Errorf("upstream model is required")
+	}
+	client, err := pm.ClientForKey(providerKey)
+	if err != nil {
+		return false, err
+	}
+	accessor, ok := client.(AnthropicClientAccessor)
+	if !ok {
+		return false, fmt.Errorf("provider client for %q does not support web search probing", providerKey)
 	}
 	return accessor.AnthropicClient().ProbeWebSearch(ctx, upstreamModel)
 }
@@ -435,8 +452,6 @@ func newHTTPClient(cfg HTTPConfig) *http.Client {
 		},
 	}
 }
-
-
 
 func valueOrDefault(value, fallback string) string {
 	if value == "" {
@@ -537,6 +552,11 @@ func (pm *ProviderManager) ProviderKeyForModel(modelAlias string) string {
 	return route.Provider
 }
 
+// WebSearchCandidateKey returns the runtime key for a resolved provider/model pair.
+func WebSearchCandidateKey(providerKey, upstreamModel string) string {
+	return "candidate:" + providerKey + "/" + upstreamModel
+}
+
 // SetResolvedWebSearch stores the resolved web search support for a provider key.
 // Also accepts model aliases for per-model resolution.
 func (pm *ProviderManager) SetResolvedWebSearch(key string, support string) {
@@ -575,8 +595,27 @@ func (pm *ProviderManager) ResolvedWebSearchForModel(modelAlias string) string {
 	if v, ok := pm.resolvedWS["model:"+modelAlias]; ok {
 		return v
 	}
+	if providerKey, upstreamModel, ok := pm.ProviderAndUpstreamForModel(modelAlias); ok {
+		if v, ok := pm.resolvedWS[WebSearchCandidateKey(providerKey, upstreamModel)]; ok {
+			return v
+		}
+	}
 	// Fall back to provider-level.
 	return pm.resolvedWS[pm.ProviderKeyForModel(modelAlias)]
+}
+
+// ResolvedWebSearchForCandidate returns the resolved web search support for a provider/model pair.
+// Falls back to provider-level support when no candidate-specific resolution exists.
+func (pm *ProviderManager) ResolvedWebSearchForCandidate(providerKey, upstreamModel string) string {
+	if providerKey == "" {
+		return ""
+	}
+	if upstreamModel != "" {
+		if v, ok := pm.resolvedWS[WebSearchCandidateKey(providerKey, upstreamModel)]; ok {
+			return v
+		}
+	}
+	return pm.resolvedWS[providerKey]
 }
 
 // WebSearchConfigForKey returns the configured web search support for a provider key.
@@ -607,6 +646,27 @@ func (pm *ProviderManager) FirstUpstreamModelForKey(key string) string {
 		return cfg.ModelNames[0]
 	}
 	return ""
+}
+
+// ProviderAndUpstreamForModel resolves the provider key and upstream model for a model alias.
+func (pm *ProviderManager) ProviderAndUpstreamForModel(modelAlias string) (providerKey string, upstreamModel string, ok bool) {
+	// Direct provider/model reference.
+	if provider, upstream := ParseModelRef(modelAlias); provider != "" {
+		if _, exists := pm.clients[provider]; exists {
+			return provider, upstream, true
+		}
+	}
+	if route, exists := pm.routes[modelAlias]; exists {
+		providerKey = route.Provider
+		if providerKey == "" {
+			providerKey = pm.defaultK
+		}
+		return providerKey, route.Name, true
+	}
+	if pm.defaultK == "" {
+		return "", "", false
+	}
+	return pm.defaultK, modelAlias, true
 }
 
 // ParseModelRef parses a model reference that may be in "provider/model" or "model(provider)" format.

--- a/internal/service/provider/manager.go
+++ b/internal/service/provider/manager.go
@@ -81,18 +81,32 @@ type anthropicClientAdapter struct {
 	client *anthropic.Client
 }
 
+func normalizeAnthropicMessageRequest(req any) (anthropic.MessageRequest, error) {
+	switch v := req.(type) {
+	case anthropic.MessageRequest:
+		return v, nil
+	case *anthropic.MessageRequest:
+		if v == nil {
+			return anthropic.MessageRequest{}, fmt.Errorf("expected anthropic.MessageRequest, got nil *anthropic.MessageRequest")
+		}
+		return *v, nil
+	default:
+		return anthropic.MessageRequest{}, fmt.Errorf("expected anthropic.MessageRequest, got %T", req)
+	}
+}
+
 func (a *anthropicClientAdapter) CreateMessage(ctx context.Context, req any) (any, error) {
-	msgReq, ok := req.(anthropic.MessageRequest)
-	if !ok {
-		return nil, fmt.Errorf("expected anthropic.MessageRequest, got %T", req)
+	msgReq, err := normalizeAnthropicMessageRequest(req)
+	if err != nil {
+		return nil, err
 	}
 	return a.client.CreateMessage(ctx, msgReq)
 }
 
 func (a *anthropicClientAdapter) StreamMessage(ctx context.Context, req any) (<-chan any, error) {
-	msgReq, ok := req.(anthropic.MessageRequest)
-	if !ok {
-		return nil, fmt.Errorf("expected anthropic.MessageRequest, got %T", req)
+	msgReq, err := normalizeAnthropicMessageRequest(req)
+	if err != nil {
+		return nil, err
 	}
 	stream, err := a.client.StreamMessage(ctx, msgReq)
 	if err != nil {

--- a/internal/service/provider/manager_test.go
+++ b/internal/service/provider/manager_test.go
@@ -2,11 +2,11 @@ package provider
 
 import (
 	"context"
+	"moonbridge/internal/protocol/anthropic"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"moonbridge/internal/protocol/anthropic"
 
 	"moonbridge/internal/config"
 )
@@ -257,6 +257,30 @@ func TestResolveModel_Preferred(t *testing.T) {
 	}
 }
 
+func TestResolvedWebSearchForCandidatePrefersCandidateKey(t *testing.T) {
+	manager, err := NewProviderManager(map[string]ProviderConfig{
+		"deepseek": {
+			BaseURL: "https://deepseek.test",
+			APIKey:  "key-deepseek",
+		},
+	}, map[string]ModelRoute{
+		"deepseek-v4-flash": {Provider: "deepseek", Name: "deepseek-v4-flash"},
+	})
+	if err != nil {
+		t.Fatalf("NewProviderManager() error = %v", err)
+	}
+
+	manager.SetResolvedWebSearch("deepseek", "disabled")
+	manager.SetResolvedWebSearch(WebSearchCandidateKey("deepseek", "deepseek-v4-flash"), "enabled")
+
+	if got := manager.ResolvedWebSearchForCandidate("deepseek", "deepseek-v4-flash"); got != "enabled" {
+		t.Fatalf("ResolvedWebSearchForCandidate() = %q, want enabled", got)
+	}
+	if got := manager.ResolvedWebSearchForModel("deepseek-v4-flash"); got != "enabled" {
+		t.Fatalf("ResolvedWebSearchForModel() = %q, want enabled", got)
+	}
+}
+
 func TestResolveModel_OffersPriorityOverridesModelNames(t *testing.T) {
 	manager, err := NewProviderManager(map[string]ProviderConfig{
 		"low-priority": {
@@ -301,22 +325,22 @@ func TestResolveModel_OffersPriorityOverridesModelNames(t *testing.T) {
 func TestResolveModel_ProviderPriority(t *testing.T) {
 	manager, err := NewProviderManager(map[string]ProviderConfig{
 		"cheap": {
-			BaseURL:    "https://cheap.test",
-			APIKey:     "key-cheap",
+			BaseURL: "https://cheap.test",
+			APIKey:  "key-cheap",
 			Offers: []config.OfferEntry{
 				{Model: "shared-model", Priority: 10},
 			},
 		},
 		"fast": {
-			BaseURL:    "https://fast.test",
-			APIKey:     "key-fast",
+			BaseURL: "https://fast.test",
+			APIKey:  "key-fast",
 			Offers: []config.OfferEntry{
 				{Model: "shared-model", Priority: 5},
 			},
 		},
 		"zulu": {
-			BaseURL:    "https://z.test",
-			APIKey:     "key-z",
+			BaseURL: "https://z.test",
+			APIKey:  "key-z",
 			Offers: []config.OfferEntry{
 				{Model: "shared-model"},
 			},

--- a/internal/service/provider/manager_test.go
+++ b/internal/service/provider/manager_test.go
@@ -2,6 +2,9 @@ package provider
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"moonbridge/internal/protocol/anthropic"
 
@@ -512,4 +515,108 @@ func TestAnthropicClientAdapter_ImplementsAccessor(t *testing.T) {
 	_ = context.Background()
 	_ = client
 	_ = inner
+}
+
+func TestAnthropicClientAdapter_CreateMessageAcceptsPointerRequest(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"id": "msg_ptr_create",
+			"type": "message",
+			"role": "assistant",
+			"model": "kimi-test",
+			"content": [{"type": "text", "text": "ok"}],
+			"stop_reason": "end_turn",
+			"usage": {"input_tokens": 3, "output_tokens": 2}
+		}`))
+	}))
+	defer mockSrv.Close()
+
+	adapter := &anthropicClientAdapter{client: anthropic.NewClient(anthropic.ClientConfig{
+		BaseURL: mockSrv.URL,
+		APIKey:  "test-key",
+		Client:  mockSrv.Client(),
+	})}
+
+	resp, err := adapter.CreateMessage(context.Background(), &anthropic.MessageRequest{
+		Model:     "kimi-test",
+		MaxTokens: 16,
+		Messages: []anthropic.Message{{
+			Role: "user",
+			Content: []anthropic.ContentBlock{{
+				Type: "text",
+				Text: "hello",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessage() error = %v", err)
+	}
+
+	msgResp, ok := resp.(anthropic.MessageResponse)
+	if !ok {
+		t.Fatalf("CreateMessage() type = %T, want anthropic.MessageResponse", resp)
+	}
+	if msgResp.ID != "msg_ptr_create" {
+		t.Fatalf("CreateMessage() response ID = %q", msgResp.ID)
+	}
+}
+
+func TestAnthropicClientAdapter_StreamMessageAcceptsPointerRequest(t *testing.T) {
+	mockSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Join([]string{
+			"event: message_start",
+			"data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ptr_stream\",\"type\":\"message\",\"role\":\"assistant\"}}",
+			"",
+		}, "\n")))
+	}))
+	defer mockSrv.Close()
+
+	adapter := &anthropicClientAdapter{client: anthropic.NewClient(anthropic.ClientConfig{
+		BaseURL: mockSrv.URL,
+		APIKey:  "test-key",
+		Client:  mockSrv.Client(),
+	})}
+
+	stream, err := adapter.StreamMessage(context.Background(), &anthropic.MessageRequest{
+		Model:     "kimi-test",
+		MaxTokens: 16,
+		Messages: []anthropic.Message{{
+			Role: "user",
+			Content: []anthropic.ContentBlock{{
+				Type: "text",
+				Text: "hello",
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("StreamMessage() error = %v", err)
+	}
+
+	first, ok := <-stream
+	if !ok {
+		t.Fatal("StreamMessage() returned closed channel")
+	}
+	event, ok := first.(anthropic.StreamEvent)
+	if !ok {
+		t.Fatalf("stream event type = %T, want anthropic.StreamEvent", first)
+	}
+	if event.Type != "message_start" {
+		t.Fatalf("stream event type = %q, want message_start", event.Type)
+	}
+	if event.Message == nil || event.Message.ID != "msg_ptr_stream" {
+		t.Fatalf("stream event message = %+v", event.Message)
+	}
 }

--- a/internal/service/server/adapter_core_provider_test.go
+++ b/internal/service/server/adapter_core_provider_test.go
@@ -137,9 +137,9 @@ type fakeStrictAnthropicClient struct {
 }
 
 func (c *fakeStrictAnthropicClient) CreateMessage(_ context.Context, req any) (any, error) {
-	msgReq, ok := req.(anthropic.MessageRequest)
-	if !ok {
-		return nil, fmt.Errorf("expected anthropic.MessageRequest, got %T", req)
+	msgReq, err := normalizeAnthropicRequest(req)
+	if err != nil {
+		return nil, err
 	}
 	c.got = msgReq
 	return anthropic.MessageResponse{
@@ -268,8 +268,15 @@ func TestAdapterCoreProviderPrependsDeepSeekThinkingBeforeAnthropicUpstream(t *t
 	sess.InitExtensions(map[string]any{
 		"deepseek_v4": deepseekv4.NewState(),
 	})
-	provider := newAdapterCoreProvider(fakeAnthropicToolUseAdapter{}, client)
-	provider.session = sess
+	provider := newFinalizingAdapterCoreProvider(fakeAnthropicToolUseAdapter{}, client,
+		func(_ context.Context, upstream any) (any, error) {
+			msgReq, err := normalizeAnthropicRequest(upstream)
+			if err != nil {
+				return nil, err
+			}
+			prependCachedThinking(&msgReq, sess)
+			return &msgReq, nil
+		})
 
 	_, err := provider.CreateCore(context.Background(), &format.CoreRequest{Model: "deepseek-v4-pro"})
 	if err != nil {

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -173,6 +173,7 @@ func (s *Server) handleWithAdapters(
 	// Inject web search tools at Core level if mode is "injected".
 	// This replaces web_search with tavily_search/firecrawl_fetch tools.
 	wsInjected := s.injectCoreWebSearch(ctx, coreReq, preferred, openAIReq)
+	searchCfg := s.resolvedSearchConfig(preferred.ProviderKey, openAIReq.Model)
 
 	upstreamAny, err := providerAdapter.FromCoreRequest(ctx, coreReq)
 	if err != nil {
@@ -245,11 +246,10 @@ func (s *Server) handleWithAdapters(
 
 		// Wrap provider with search orchestrator if web search is "injected".
 		if wsInjected {
-			if acc, ok := effectiveProvider.(provider.AnthropicClientAccessor); ok && s.runtime != nil {
-				cfgC := s.runtime.Current().Config
+			if acc, ok := effectiveProvider.(provider.AnthropicClientAccessor); ok {
 				wrapped := websearchinjected.WrapProvider(
 					acc.AnthropicClient(),
-					cfgC.TavilyAPIKey, cfgC.FirecrawlAPIKey, s.maxSearchRounds(),
+					searchCfg.tavilyKey, searchCfg.firecrawlKey, searchCfg.maxRounds,
 				)
 				effectiveProvider = &searchProviderAdapter{wrapped: wrapped}
 			}
@@ -356,7 +356,7 @@ func (s *Server) handleWithAdapters(
 		record.ChatRequest = chatReq
 		var chatResp *chat.ChatResponse
 		if wsInjected {
-			chatResp, err = s.executeChatSearchLoop(ctx, chatClient, chatReq, s.runtime.Current().Config.TavilyAPIKey, s.runtime.Current().Config.FirecrawlAPIKey, s.maxSearchRounds())
+			chatResp, err = s.executeChatSearchLoop(ctx, chatClient, chatReq, searchCfg.tavilyKey, searchCfg.firecrawlKey, searchCfg.maxRounds)
 		} else {
 			chatResp, err = chatClient.CreateChat(ctx, chatReq)
 		}
@@ -463,7 +463,7 @@ func (s *Server) handleWithAdapters(
 		record.UpstreamRequest = googleReq
 		var googleResp *google.GenerateContentResponse
 		if wsInjected {
-			googleResp, err = s.executeGoogleSearchLoop(ctx, googleClient, preferred.UpstreamModel, googleReq, s.runtime.Current().Config.TavilyAPIKey, s.runtime.Current().Config.FirecrawlAPIKey, s.maxSearchRounds())
+			googleResp, err = s.executeGoogleSearchLoop(ctx, googleClient, preferred.UpstreamModel, googleReq, searchCfg.tavilyKey, searchCfg.firecrawlKey, searchCfg.maxRounds)
 		} else {
 			googleResp, err = googleClient.GenerateContent(ctx, preferred.UpstreamModel, googleReq)
 		}
@@ -876,7 +876,8 @@ func (s *Server) handleAdapterStream(
 		var chatStream <-chan chat.ChatStreamChunk
 		var err error
 		if wsInjected {
-			chatStream, err = s.chatSearchBufferedStream(ctx, chatClient, chatReq, s.runtime.Current().Config.TavilyAPIKey, s.runtime.Current().Config.FirecrawlAPIKey, s.maxSearchRounds())
+			searchCfg := s.resolvedSearchConfig(candidate.ProviderKey, openAIReq.Model)
+			chatStream, err = s.chatSearchBufferedStream(ctx, chatClient, chatReq, searchCfg.tavilyKey, searchCfg.firecrawlKey, searchCfg.maxRounds)
 		} else {
 			chatStream, err = chatClient.StreamChat(ctx, chatReq)
 		}
@@ -975,6 +976,74 @@ func (s *Server) handleAdapterStream(
 		}
 
 		streamRecord.UpstreamRequest = googleReq
+		if wsInjected {
+			searchCfg := s.resolvedSearchConfig(candidate.ProviderKey, openAIReq.Model)
+			googleResp, err := s.executeGoogleSearchLoop(ctx, googleClient, candidate.UpstreamModel, googleReq, searchCfg.tavilyKey, searchCfg.firecrawlKey, searchCfg.maxRounds)
+			if err != nil {
+				log.Error("adapter stream: injected google search loop failed", "error", err)
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: fmt.Sprintf("google stream error: %v", err),
+						Type:    "server_error",
+						Code:    "provider_error",
+					},
+				}
+				streamRecord.Error = traceError("stream_google_injected", err)
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusBadGateway, payload)
+				return
+			}
+			streamRecord.UpstreamResponse = googleResp
+			googleProvAdapter, ok := s.adapterRegistry.GetProvider(config.ProtocolGoogleGenAI)
+			if !ok {
+				log.Error("adapter stream: no google provider adapter for injected path")
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: "google stream adapter not available",
+						Type:    "server_error",
+						Code:    "adapter_fallback",
+					},
+				}
+				streamRecord.Error = traceError("stream_google_adapter", fmt.Errorf("no google provider adapter"))
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusInternalServerError, payload)
+				return
+			}
+			googleAdapter, ok := googleProvAdapter.(interface {
+				ToCoreResponse(context.Context, any) (*format.CoreResponse, error)
+			})
+			if !ok {
+				log.Error("adapter stream: google adapter lacks ToCoreResponse for injected path")
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: "google stream conversion failed",
+						Type:    "server_error",
+						Code:    "conversion_error",
+					},
+				}
+				streamRecord.Error = traceError("stream_google_injected_type", fmt.Errorf("google adapter type mismatch"))
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusInternalServerError, payload)
+				return
+			}
+			coreFinal, convErr := googleAdapter.ToCoreResponse(ctx, googleResp)
+			if convErr != nil {
+				log.Error("adapter stream: injected google ToCoreResponse failed", "error", convErr)
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: fmt.Sprintf("google stream conversion failed: %v", convErr),
+						Type:    "server_error",
+						Code:    "conversion_error",
+					},
+				}
+				streamRecord.Error = traceError("stream_google_injected_tocore", convErr)
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusInternalServerError, payload)
+				return
+			}
+			coreEvents = coreResponseToCoreStream(ctx, coreFinal)
+			break
+		}
 		googleStream, err := googleClient.StreamGenerateContent(ctx, candidate.UpstreamModel, googleReq)
 		if err != nil {
 			log.Error("adapter stream: StreamGenerateContent failed", "error", err)
@@ -1633,6 +1702,54 @@ func (a *searchProviderAdapter) StreamMessage(ctx context.Context, req any) (<-c
 }
 
 func (a *searchProviderAdapter) AnthropicClient() *anthropic.Client { return nil }
+
+type searchConfig struct {
+	tavilyKey    string
+	firecrawlKey string
+	maxRounds    int
+}
+
+func (s *Server) resolvedSearchConfig(providerKey, modelAlias string) searchConfig {
+	// Keep a conservative fallback to existing global/runtime behavior.
+	cfg := searchConfig{
+		tavilyKey:    "",
+		firecrawlKey: "",
+		maxRounds:    s.maxSearchRounds(),
+	}
+	if s.runtime == nil {
+		return cfg
+	}
+	fullCfg := s.runtime.Current().Config
+	cfg.tavilyKey = fullCfg.TavilyAPIKey
+	cfg.firecrawlKey = fullCfg.FirecrawlAPIKey
+
+	// Prefer model-level resolved config; then provider-level fallback.
+	if modelAlias != "" {
+		if key := fullCfg.WebSearchTavilyKeyForModel(modelAlias); key != "" {
+			cfg.tavilyKey = key
+		}
+		if key := fullCfg.WebSearchFirecrawlKeyForModel(modelAlias); key != "" {
+			cfg.firecrawlKey = key
+		}
+		if rounds := fullCfg.WebSearchMaxRoundsForModel(modelAlias); rounds > 0 {
+			cfg.maxRounds = rounds
+		}
+		return cfg
+	}
+
+	if providerKey != "" {
+		if key := fullCfg.WebSearchTavilyKeyForProvider(providerKey); key != "" {
+			cfg.tavilyKey = key
+		}
+		if key := fullCfg.WebSearchFirecrawlKeyForProvider(providerKey); key != "" {
+			cfg.firecrawlKey = key
+		}
+		if rounds := fullCfg.WebSearchMaxRoundsForProvider(providerKey); rounds > 0 {
+			cfg.maxRounds = rounds
+		}
+	}
+	return cfg
+}
 
 // injectAnthropicWebSearch adds the Anthropic web_search_20250305 server tool
 // to an anthropic.MessageRequest if not already present.

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -697,7 +697,20 @@ func (s *Server) handleAdapterStream(
 
 	if candidate.Protocol == config.ProtocolAnthropic && coreRequestHasImage(coreReq) {
 		if providerAdapter := s.adapterRegistryProvider(config.ProtocolAnthropic); providerAdapter != nil {
-			if visProv := s.wrapWithVisual(ctx, openAIReq.Model, candidate, providerAdapter, sess); visProv != nil {
+			finalizeAnthropicUpstream := func(_ context.Context, upstream any) (any, error) {
+				msgReq, err := normalizeAnthropicRequest(upstream)
+				if err != nil {
+					return nil, err
+				}
+				if wsMode == "enabled" {
+					injectAnthropicWebSearch(&msgReq)
+				}
+				if s.pluginRegistry != nil && sess != nil {
+					prependCachedThinking(&msgReq, sess)
+				}
+				return &msgReq, nil
+			}
+			if visProv := s.wrapWithVisual(ctx, openAIReq.Model, candidate, providerAdapter, finalizeAnthropicUpstream); visProv != nil {
 				coreResp, err := visProv.CreateCore(ctx, coreReq)
 				if err != nil {
 					log.Error("adapter stream visual fallback: CreateCore failed", "error", err)
@@ -1617,8 +1630,8 @@ func coreBlockHasImage(block format.CoreContentBlock) bool {
 // CoreProvider so the visual orchestrator can operate on format.CoreRequest
 // without knowing the underlying protocol.
 type adapterCoreProvider struct {
-	adapter format.ProviderAdapter
-	client  provider.ProviderClient
+	adapter  format.ProviderAdapter
+	client   provider.ProviderClient
 	finalize func(ctx context.Context, upstream any) (any, error)
 }
 

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -718,6 +718,13 @@ func (s *Server) handleAdapterStream(
 			return
 		}
 
+		var visCoreProvider visualpkg.CoreProvider
+		if provAdapter, ok := s.adapterRegistry.GetProvider(candidate.Protocol); ok {
+			if visProv := s.wrapWithVisual(ctx, openAIReq.Model, candidate, provAdapter); visProv != nil {
+				visCoreProvider = visProv
+			}
+		}
+
 		// StreamMessage on ProviderClient returns <-chan any, losing the concrete type.
 		// Get the inner anthropic.Client directly so ToCoreStream receives anthropic.Stream.
 		acc, ok := effectiveProvider.(provider.AnthropicClientAccessor)
@@ -745,52 +752,71 @@ func (s *Server) handleAdapterStream(
 				anthReq = &strippedReq
 			}
 		}
-		stream, err := acc.AnthropicClient().StreamMessage(ctx, *anthReq)
-		if err != nil {
-			log.Error("adapter stream: StreamMessage failed", "error", err)
-			payload := openai.ErrorResponse{
-				Error: openai.ErrorObject{
-					Message: fmt.Sprintf("upstream stream error: %v", err),
-					Type:    "server_error",
-					Code:    "provider_error",
-				},
+		if visCoreProvider != nil {
+			coreResp, err := visCoreProvider.CreateCore(ctx, coreReq)
+			if err != nil {
+				log.Error("adapter stream: visual CreateCore failed", "error", err)
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: fmt.Sprintf("visual stream orchestration failed: %v", err),
+						Type:    "server_error",
+						Code:    "provider_error",
+					},
+				}
+				streamRecord.Error = traceError("stream_visual_core", err)
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusBadGateway, payload)
+				return
 			}
-			streamRecord.Error = traceError("stream_message", err)
-			streamRecord.OpenAIResponse = payload
-			writeOpenAIError(w, http.StatusBadGateway, payload)
-			return
-		}
-		_ = stream
+			coreEvents = coreResponseToCoreStream(ctx, coreResp)
+		} else {
+			stream, err := acc.AnthropicClient().StreamMessage(ctx, *anthReq)
+			if err != nil {
+				log.Error("adapter stream: StreamMessage failed", "error", err)
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: fmt.Sprintf("upstream stream error: %v", err),
+						Type:    "server_error",
+						Code:    "provider_error",
+					},
+				}
+				streamRecord.Error = traceError("stream_message", err)
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusBadGateway, payload)
+				return
+			}
+			_ = stream
 
-		providerStream, ok = s.adapterRegistry.GetProviderStream(config.ProtocolAnthropic)
-		if !ok {
-			log.Warn("adapter stream: no anthropic provider stream adapter")
-			payload := openai.ErrorResponse{
-				Error: openai.ErrorObject{
-					Message: "adapter stream fallback not available",
-					Type:    "server_error",
-					Code:    "adapter_fallback",
-				},
+			providerStream, ok = s.adapterRegistry.GetProviderStream(config.ProtocolAnthropic)
+			if !ok {
+				log.Warn("adapter stream: no anthropic provider stream adapter")
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: "adapter stream fallback not available",
+						Type:    "server_error",
+						Code:    "adapter_fallback",
+					},
+				}
+				streamRecord.Error = traceError("stream_provider_adapter", fmt.Errorf("no anthropic provider stream adapter"))
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusInternalServerError, payload)
+				return
 			}
-			streamRecord.Error = traceError("stream_provider_adapter", fmt.Errorf("no anthropic provider stream adapter"))
-			streamRecord.OpenAIResponse = payload
-			writeOpenAIError(w, http.StatusInternalServerError, payload)
-			return
-		}
-		coreEvents, err = providerStream.ToCoreStream(ctx, stream)
-		if err != nil {
-			log.Error("adapter stream: ToCoreStream failed", "error", err)
-			payload := openai.ErrorResponse{
-				Error: openai.ErrorObject{
-					Message: fmt.Sprintf("stream conversion failed: %v", err),
-					Type:    "server_error",
-					Code:    "conversion_error",
-				},
+			coreEvents, err = providerStream.ToCoreStream(ctx, stream)
+			if err != nil {
+				log.Error("adapter stream: ToCoreStream failed", "error", err)
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: fmt.Sprintf("stream conversion failed: %v", err),
+						Type:    "server_error",
+						Code:    "conversion_error",
+					},
+				}
+				streamRecord.Error = traceError("stream_to_core", err)
+				streamRecord.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusInternalServerError, payload)
+				return
 			}
-			streamRecord.Error = traceError("stream_to_core", err)
-			streamRecord.OpenAIResponse = payload
-			writeOpenAIError(w, http.StatusInternalServerError, payload)
-			return
 		}
 
 	case config.ProtocolOpenAIChat:
@@ -1279,6 +1305,180 @@ func (p *adapterCoreProvider) CreateCore(ctx context.Context, req *format.CoreRe
 		return nil, err
 	}
 	return p.adapter.ToCoreResponse(ctx, rawResp)
+}
+
+// coreResponseToCoreStream converts a CoreResponse into a synthetic Core stream.
+// This keeps the stream output contract when a plugin path only provides
+// non-streaming CreateCore semantics.
+func coreResponseToCoreStream(ctx context.Context, resp *format.CoreResponse) <-chan format.CoreStreamEvent {
+	out := make(chan format.CoreStreamEvent)
+	go func() {
+		defer close(out)
+
+		send := func(ev format.CoreStreamEvent) bool {
+			select {
+			case <-ctx.Done():
+				return false
+			case out <- ev:
+				return true
+			}
+		}
+
+		if resp == nil {
+			send(format.CoreStreamEvent{
+				Type:   format.CoreEventFailed,
+				Status: "failed",
+				Error:  &format.CoreError{Message: "nil core response"},
+			})
+			return
+		}
+
+		if !send(format.CoreStreamEvent{
+			Type:   format.CoreEventCreated,
+			Status: "in_progress",
+			Model:  resp.Model,
+			ItemID: resp.ID,
+		}) {
+			return
+		}
+		if !send(format.CoreStreamEvent{
+			Type:   format.CoreEventInProgress,
+			Status: "in_progress",
+			Model:  resp.Model,
+		}) {
+			return
+		}
+
+		blockIndex := 0
+		for _, msg := range resp.Messages {
+			if msg.Role != "assistant" {
+				continue
+			}
+			for _, block := range msg.Content {
+				switch block.Type {
+				case "reasoning":
+					if !send(format.CoreStreamEvent{
+						Type:  format.CoreContentBlockStarted,
+						Index: blockIndex,
+						ContentBlock: &format.CoreContentBlock{
+							Type: "reasoning",
+						},
+					}) {
+						return
+					}
+					if block.ReasoningText != "" {
+						if !send(format.CoreStreamEvent{
+							Type:  format.CoreTextDelta,
+							Index: blockIndex,
+							Delta: block.ReasoningText,
+						}) {
+							return
+						}
+					}
+					if !send(format.CoreStreamEvent{
+						Type:  format.CoreContentBlockDone,
+						Index: blockIndex,
+						ContentBlock: &format.CoreContentBlock{
+							Type:               "reasoning",
+							ReasoningSignature: block.ReasoningSignature,
+						},
+					}) {
+						return
+					}
+				case "tool_use":
+					if !send(format.CoreStreamEvent{
+						Type:  format.CoreContentBlockStarted,
+						Index: blockIndex,
+						ContentBlock: &format.CoreContentBlock{
+							Type:      "tool_use",
+							ToolUseID: block.ToolUseID,
+							ToolName:  block.ToolName,
+						},
+					}) {
+						return
+					}
+					if !send(format.CoreStreamEvent{
+						Type:  format.CoreToolCallArgsDone,
+						Index: blockIndex,
+						Delta: string(block.ToolInput),
+					}) {
+						return
+					}
+					if !send(format.CoreStreamEvent{
+						Type:  format.CoreContentBlockDone,
+						Index: blockIndex,
+					}) {
+						return
+					}
+				default:
+					text := block.Text
+					if block.Type != "text" && text == "" {
+						// Unknown non-text block without textual payload.
+						blockIndex++
+						continue
+					}
+					if !send(format.CoreStreamEvent{
+						Type:  format.CoreContentBlockStarted,
+						Index: blockIndex,
+						ContentBlock: &format.CoreContentBlock{
+							Type: "text",
+						},
+					}) {
+						return
+					}
+					if text != "" {
+						if !send(format.CoreStreamEvent{
+							Type:  format.CoreTextDelta,
+							Index: blockIndex,
+							Delta: text,
+						}) {
+							return
+						}
+					}
+					if !send(format.CoreStreamEvent{
+						Type:  format.CoreContentBlockDone,
+						Index: blockIndex,
+					}) {
+						return
+					}
+				}
+				blockIndex++
+			}
+		}
+
+		usage := resp.Usage
+		usage.TotalTokens = usage.InputTokens + usage.OutputTokens
+		status := resp.Status
+		if status == "" {
+			status = "completed"
+		}
+		switch status {
+		case "failed":
+			send(format.CoreStreamEvent{
+				Type:   format.CoreEventFailed,
+				Status: "failed",
+				Model:  resp.Model,
+				Error:  resp.Error,
+			})
+		case "incomplete":
+			send(format.CoreStreamEvent{
+				Type:       format.CoreEventIncomplete,
+				Status:     "incomplete",
+				Model:      resp.Model,
+				StopReason: resp.StopReason,
+				Usage:      &usage,
+			})
+		default:
+			send(format.CoreStreamEvent{
+				Type:       format.CoreEventCompleted,
+				Status:     "completed",
+				Model:      resp.Model,
+				StopReason: resp.StopReason,
+				Usage:      &usage,
+			})
+		}
+	}()
+	return out
 }
 
 // wrapWithVisual returns a CoreProvider that wraps the upstream provider with

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -1085,6 +1085,44 @@ func (s *Server) handleAdapterStream(
 
 	// Record usage statistics after stream completes.
 
+	// Remember reasoning content for DeepSeek thinking replay via StreamInterceptor.
+	// This must not depend on trace being enabled.
+	if s.pluginRegistry != nil && sess != nil {
+		if anthProvider, ok := s.adapterRegistry.GetProvider(config.ProtocolAnthropic); ok {
+			if anthAdapter, ok := anthProvider.(*anthropic.AnthropicProviderAdapter); ok {
+				events := anthAdapter.StreamBuffer()
+				if len(events) > 0 {
+					states := s.pluginRegistry.NewStreamStates(openAIReq.Model)
+					for _, ev := range events {
+						pluginType := ""
+						switch {
+						case ev.Type == "content_block_start":
+							pluginType = "block_start"
+						case ev.Type == "content_block_delta":
+							pluginType = "block_delta"
+						case ev.Type == "content_block_stop":
+							pluginType = "block_stop"
+						}
+						if pluginType == "" {
+							continue
+						}
+						s.pluginRegistry.OnStreamEvent(openAIReq.Model, plugin.StreamEvent{
+							Type:  pluginType,
+							Index: ev.Index,
+							Block: anthropicContentBlockPtrToFormat(ev.ContentBlock),
+							Delta: ev.Delta,
+						}, states)
+					}
+					outputText := ""
+					if finalResp != nil {
+						outputText = finalResp.OutputText
+					}
+					s.pluginRegistry.OnStreamComplete(openAIReq.Model, states, outputText, sess.ExtensionData)
+				}
+			}
+		}
+	}
+
 	// Capture stream events for trace.
 	if s.tracer != nil && s.tracer.Enabled() {
 		// OpenAI stream events from client adapter
@@ -1102,42 +1140,6 @@ func (s *Server) handleAdapterStream(
 					streamRecord.AnthropicStreamEvents = events
 				}
 
-				// Remember reasoning content for DeepSeek thinking replay via StreamInterceptor.
-				if anthProvider2, ok := s.adapterRegistry.GetProvider(config.ProtocolAnthropic); ok {
-					if anthAdapter2, ok := anthProvider2.(*anthropic.AnthropicProviderAdapter); ok {
-						if s.pluginRegistry != nil && sess != nil {
-							events := anthAdapter2.StreamBuffer()
-							if len(events) > 0 {
-								states := s.pluginRegistry.NewStreamStates(openAIReq.Model)
-								for _, ev := range events {
-									pluginType := ""
-									switch {
-									case ev.Type == "content_block_start":
-										pluginType = "block_start"
-									case ev.Type == "content_block_delta":
-										pluginType = "block_delta"
-									case ev.Type == "content_block_stop":
-										pluginType = "block_stop"
-									}
-									if pluginType == "" {
-										continue
-									}
-									s.pluginRegistry.OnStreamEvent(openAIReq.Model, plugin.StreamEvent{
-										Type:  pluginType,
-										Index: ev.Index,
-										Block: anthropicContentBlockPtrToFormat(ev.ContentBlock),
-										Delta: ev.Delta,
-									}, states)
-								}
-								outputText := ""
-								if finalResp != nil {
-									outputText = finalResp.OutputText
-								}
-								s.pluginRegistry.OnStreamComplete(openAIReq.Model, states, outputText, sess.ExtensionData)
-							}
-						}
-					}
-				}
 				// Chat stream events from provider adapter
 				if chatProvider, ok := s.adapterRegistry.GetProvider(config.ProtocolOpenAIChat); ok {
 					if chatAdapter, ok := chatProvider.(*chat.ChatProviderAdapter); ok {
@@ -1452,6 +1454,9 @@ func injectAnthropicWebSearch(req *anthropic.MessageRequest) {
 // contains the tool_use, because in follow-up requests the last message
 // is typically a user tool_result.
 func prependCachedThinking(upstreamReq *anthropic.MessageRequest, sess *session.Session) {
+	if upstreamReq == nil || sess == nil || sess.ExtensionData == nil {
+		return
+	}
 	stateRaw, ok := sess.ExtensionData["deepseek_v4"]
 	if !ok {
 		return
@@ -1467,23 +1472,37 @@ func prependCachedThinking(upstreamReq *anthropic.MessageRequest, sess *session.
 		if msg.Role != "assistant" || len(msg.Content) == 0 {
 			continue
 		}
+		// Only tool-call assistant messages require thinking replay fallback.
+		hasToolUse := false
+		for _, block := range msg.Content {
+			if block.Type == "tool_use" {
+				hasToolUse = true
+				break
+			}
+		}
+		if !hasToolUse {
+			continue
+		}
 		// Check if the message already has a thinking block.
 		if hasThinkingBlock(msg.Content) {
 			continue
 		}
 		// Try to prepend cached thinking by tool call ID (for tool_use messages).
+		foundCachedThinking := false
 		for _, block := range msg.Content {
-			if block.Type == "tool_use" && block.ID != "" {
-				if cached, ok := state.CachedForToolCall(block.ID); ok {
-					// Prepend thinking block directly to this message, not to the last message.
-					msg.Content = append([]anthropic.ContentBlock{normalizeThinkingBlock(cached)}, msg.Content...)
-				}
+			if block.Type != "tool_use" || block.ID == "" {
+				continue
+			}
+			if cached, ok := state.CachedForToolCall(block.ID); ok {
+				// Prepend thinking block directly to this message, not to the last message.
+				msg.Content = append([]anthropic.ContentBlock{normalizeThinkingBlock(cached)}, msg.Content...)
+				foundCachedThinking = true
 				break
 			}
 		}
 		// Fallback: prepend empty thinking block as response boundary.
 		// Prevents model from continuing previous response text.
-		if !hasThinkingBlock(msg.Content) {
+		if !foundCachedThinking && !hasThinkingBlock(msg.Content) {
 			prepended, _ := deepseekv4.PrependRequiredThinkingForAssistantText(anthropicContentSliceToFormat(msg.Content))
 			msg.Content = formatContentSliceToAnthropic(prepended)
 		}
@@ -1558,6 +1577,7 @@ func prependCachedReasoningForChat(chatReq *chat.ChatRequest, sess *session.Sess
 		// that the field is present on every assistant message.
 		if msg.ReasoningContent == "" && len(msg.ToolCalls) > 0 {
 			msg.ReasoningContent = ""
+			msg.EmitEmptyReasoningContent = true
 		}
 	}
 }

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -170,9 +170,11 @@ func (s *Server) handleWithAdapters(
 	// the upstream provider receives the correct model identifier.
 	coreReq.Model = preferred.UpstreamModel
 
+	wsMode := resolvedWebSearchMode(pm, openAIReq.Model, preferred)
+
 	// Inject web search tools at Core level if mode is "injected".
-	// This replaces web_search with tavily_search/firecrawl_fetch tools.
-	wsInjected := s.injectCoreWebSearch(ctx, coreReq, preferred, openAIReq)
+	// This replaces web_search/web_search_preview with tavily_search/firecrawl_fetch tools.
+	wsInjected := s.injectCoreWebSearch(ctx, coreReq, preferred, openAIReq, wsMode)
 	searchCfg := s.resolvedSearchConfig(preferred.ProviderKey, openAIReq.Model)
 
 	upstreamAny, err := providerAdapter.FromCoreRequest(ctx, coreReq)
@@ -210,8 +212,8 @@ func (s *Server) handleWithAdapters(
 			return
 		}
 
-		// Inject web_search tool if enabled for this model.
-		if pm != nil && pm.ResolvedWebSearch(preferred.ProviderKey) == "enabled" {
+		// Inject native web_search tool when the resolved candidate supports it.
+		if wsMode == "enabled" {
 			injectAnthropicWebSearch(upstreamReq)
 		}
 
@@ -1600,44 +1602,29 @@ func (s *Server) wrapWithVisual(
 }
 
 // injectCoreWebSearch replaces web_search tools in coreReq.Tools with injected
-// tavily_search/firecrawl_fetch tools when the provider's web search mode is "injected".
+// tavily_search/firecrawl_fetch tools when the resolved web search mode is "injected".
 // Returns true if injection was applied.
-func (s *Server) injectCoreWebSearch(ctx context.Context, coreReq *format.CoreRequest, preferred provider.ProviderCandidate, openAIReq openai.ResponsesRequest) bool {
-	pm := s.activeProviderManager()
-	if pm == nil {
+func (s *Server) injectCoreWebSearch(ctx context.Context, coreReq *format.CoreRequest, preferred provider.ProviderCandidate, openAIReq openai.ResponsesRequest, wsMode string) bool {
+	_ = ctx
+	if wsMode != "injected" {
 		return false
 	}
-	wsMode := pm.ResolvedWebSearch(preferred.ProviderKey)
-	if wsMode != "injected" && wsMode != "auto" {
+	if s.runtime == nil {
 		return false
 	}
-	// For "auto" mode, check if keys are configured (fallback to injected).
-	if wsMode == "auto" && s.runtime != nil {
-		cfg := s.runtime.Current().Config
-		if cfg.TavilyAPIKey == "" && cfg.FirecrawlAPIKey == "" {
-			return false // no keys configured for "auto" fallback
-		}
-	}
-	// Check if the request has a web_search tool.
-	hasWebSearch := false
-	for _, t := range openAIReq.Tools {
-		if t.Type == "web_search" || t.Type == "web_search_preview" {
-			hasWebSearch = true
-			break
-		}
-	}
-	if !hasWebSearch {
+	searchCfg := s.resolvedSearchConfig(preferred.ProviderKey, openAIReq.Model)
+	if searchCfg.tavilyKey == "" && searchCfg.firecrawlKey == "" {
 		return false
 	}
+
 	// Replace coreReq.Tools: keep non-web_search tools, add injected search tools.
 	filtered := make([]format.CoreTool, 0, len(coreReq.Tools)+2)
 	for _, t := range coreReq.Tools {
-		if t.Name != "web_search" {
+		if t.Name != "web_search" && t.Name != "web_search_preview" {
 			filtered = append(filtered, t)
 		}
 	}
-	cfg := s.runtime.Current().Config
-	injected := websearchinjected.CoreTools(cfg.FirecrawlAPIKey)
+	injected := websearchinjected.CoreTools(searchCfg.firecrawlKey)
 	filtered = append(filtered, injected...)
 	coreReq.Tools = filtered
 	// Set tool_choice to auto so the model has freedom to call tavily_search.
@@ -1645,6 +1632,21 @@ func (s *Server) injectCoreWebSearch(ctx context.Context, coreReq *format.CoreRe
 		coreReq.ToolChoice = &format.CoreToolChoice{Mode: "auto"}
 	}
 	return true
+}
+
+func resolvedWebSearchMode(pm *provider.ProviderManager, modelAlias string, preferred provider.ProviderCandidate) string {
+	if pm == nil {
+		return ""
+	}
+	if preferred.ProviderKey != "" && preferred.UpstreamModel != "" {
+		if mode := pm.ResolvedWebSearchForCandidate(preferred.ProviderKey, preferred.UpstreamModel); mode != "" {
+			return mode
+		}
+	}
+	if modelAlias != "" {
+		return pm.ResolvedWebSearchForModel(modelAlias)
+	}
+	return ""
 }
 
 // searchProvider wraps the websearchinjected orchestrator's behavior.

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -1123,6 +1123,40 @@ func (s *Server) handleAdapterStream(
 		}
 	}
 
+	// Cache reasoning from Chat stream for DeepSeek thinking replay.
+	// This must not depend on trace being enabled.
+	if sess != nil {
+		if chatProvider, ok := s.adapterRegistry.GetProvider(config.ProtocolOpenAIChat); ok {
+			if chatAdapter, ok := chatProvider.(*chat.ChatProviderAdapter); ok {
+				if events := chatAdapter.StreamBuffer(); len(events) > 0 {
+					var streamReasoning string
+					seenToolCallIDs := make(map[string]struct{})
+					streamToolCallIDs := make([]string, 0, 4)
+					for _, ev := range events {
+						for _, sc := range ev.Choices {
+							if sc.Delta.ReasoningContent != "" {
+								streamReasoning += sc.Delta.ReasoningContent
+							}
+							for _, tc := range sc.Delta.ToolCalls {
+								if tc.ID == "" {
+									continue
+								}
+								if _, ok := seenToolCallIDs[tc.ID]; ok {
+									continue
+								}
+								seenToolCallIDs[tc.ID] = struct{}{}
+								streamToolCallIDs = append(streamToolCallIDs, tc.ID)
+							}
+						}
+					}
+					if streamReasoning != "" && len(streamToolCallIDs) > 0 {
+						cacheReasoningForChat(sess, streamToolCallIDs, streamReasoning)
+					}
+				}
+			}
+		}
+	}
+
 	// Capture stream events for trace.
 	if s.tracer != nil && s.tracer.Enabled() {
 		// OpenAI stream events from client adapter
@@ -1145,27 +1179,6 @@ func (s *Server) handleAdapterStream(
 					if chatAdapter, ok := chatProvider.(*chat.ChatProviderAdapter); ok {
 						if events := chatAdapter.StreamBuffer(); len(events) > 0 {
 							streamRecord.ChatStreamEvents = events
-
-							// Cache reasoning from Chat stream for DeepSeek thinking replay.
-							if sess != nil {
-								var streamReasoning string
-								var streamToolCallIDs []string
-								for _, ev := range events {
-									for _, sc := range ev.Choices {
-										if sc.Delta.ReasoningContent != "" {
-											streamReasoning = sc.Delta.ReasoningContent
-										}
-										for _, tc := range sc.Delta.ToolCalls {
-											if tc.ID != "" {
-												streamToolCallIDs = append(streamToolCallIDs, tc.ID)
-											}
-										}
-									}
-								}
-								if streamReasoning != "" && len(streamToolCallIDs) > 0 {
-									cacheReasoningForChat(sess, streamToolCallIDs, streamReasoning)
-								}
-							}
 						}
 					}
 				}

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -222,9 +222,23 @@ func (s *Server) handleWithAdapters(
 			prependCachedThinking(upstreamReq, sess)
 		}
 
+		finalizeAnthropicUpstream := func(_ context.Context, upstream any) (any, error) {
+			msgReq, err := normalizeAnthropicRequest(upstream)
+			if err != nil {
+				return nil, err
+			}
+			if wsMode == "enabled" {
+				injectAnthropicWebSearch(&msgReq)
+			}
+			if s.pluginRegistry != nil && sess != nil {
+				prependCachedThinking(&msgReq, sess)
+			}
+			return &msgReq, nil
+		}
+
 		// If streaming, use streaming path.
 		if openAIReq.Stream {
-			s.handleAdapterStream(w, r, ctx, openAIReq, coreReq, upstreamReq, preferred, wsInjected)
+			s.handleAdapterStream(w, r, ctx, openAIReq, coreReq, upstreamReq, preferred, wsMode, wsInjected)
 			record.OpenAIRequest = nil
 			return
 		}
@@ -259,7 +273,7 @@ func (s *Server) handleWithAdapters(
 
 		// Wrap with visual orchestrator at Core level if enabled for this model.
 		// This uses CoreProvider, which is protocol-agnostic.
-		if visProv := s.wrapWithVisual(ctx, openAIReq.Model, preferred, providerAdapter); visProv != nil {
+		if visProv := s.wrapWithVisual(ctx, openAIReq.Model, preferred, providerAdapter, finalizeAnthropicUpstream); visProv != nil {
 			var coreRespApi *format.CoreResponse
 			coreRespApi, err = visProv.CreateCore(ctx, coreReq)
 			if err == nil {
@@ -319,7 +333,7 @@ func (s *Server) handleWithAdapters(
 		}
 
 		if openAIReq.Stream {
-			s.handleAdapterStream(w, r, ctx, openAIReq, coreReq, chatReq, preferred, wsInjected)
+			s.handleAdapterStream(w, r, ctx, openAIReq, coreReq, chatReq, preferred, wsMode, wsInjected)
 			record.OpenAIRequest = nil
 			return
 		}
@@ -426,7 +440,7 @@ func (s *Server) handleWithAdapters(
 		}
 
 		if openAIReq.Stream {
-			s.handleAdapterStream(w, r, ctx, openAIReq, coreReq, googleReq, preferred, wsInjected)
+			s.handleAdapterStream(w, r, ctx, openAIReq, coreReq, googleReq, preferred, wsMode, wsInjected)
 			record.OpenAIRequest = nil
 			return
 		}
@@ -657,6 +671,7 @@ func (s *Server) handleAdapterStream(
 	coreReq *format.CoreRequest,
 	upstreamReq any,
 	candidate provider.ProviderCandidate,
+	wsMode string,
 	wsInjected bool,
 ) {
 	log := slog.Default().With("model", openAIReq.Model, "path", "adapter_stream")
@@ -722,7 +737,20 @@ func (s *Server) handleAdapterStream(
 
 		var visCoreProvider visualpkg.CoreProvider
 		if provAdapter, ok := s.adapterRegistry.GetProvider(candidate.Protocol); ok {
-			if visProv := s.wrapWithVisual(ctx, openAIReq.Model, candidate, provAdapter); visProv != nil {
+			finalizeAnthropicUpstream := func(_ context.Context, upstream any) (any, error) {
+				msgReq, err := normalizeAnthropicRequest(upstream)
+				if err != nil {
+					return nil, err
+				}
+				if wsMode == "enabled" {
+					injectAnthropicWebSearch(&msgReq)
+				}
+				if s.pluginRegistry != nil && sess != nil {
+					prependCachedThinking(&msgReq, sess)
+				}
+				return &msgReq, nil
+			}
+			if visProv := s.wrapWithVisual(ctx, openAIReq.Model, candidate, provAdapter, finalizeAnthropicUpstream); visProv != nil {
 				visCoreProvider = visProv
 			}
 		}
@@ -1360,16 +1388,31 @@ func (s *Server) handleAdapterStream(
 type adapterCoreProvider struct {
 	adapter format.ProviderAdapter
 	client  provider.ProviderClient
+	finalize func(ctx context.Context, upstream any) (any, error)
 }
 
 func newAdapterCoreProvider(adapter format.ProviderAdapter, client provider.ProviderClient) *adapterCoreProvider {
 	return &adapterCoreProvider{adapter: adapter, client: client}
 }
 
+func newFinalizingAdapterCoreProvider(
+	adapter format.ProviderAdapter,
+	client provider.ProviderClient,
+	finalize func(ctx context.Context, upstream any) (any, error),
+) *adapterCoreProvider {
+	return &adapterCoreProvider{adapter: adapter, client: client, finalize: finalize}
+}
+
 func (p *adapterCoreProvider) CreateCore(ctx context.Context, req *format.CoreRequest) (*format.CoreResponse, error) {
 	upstreamAny, err := p.adapter.FromCoreRequest(ctx, req)
 	if err != nil {
 		return nil, err
+	}
+	if p.finalize != nil {
+		upstreamAny, err = p.finalize(ctx, upstreamAny)
+		if err != nil {
+			return nil, err
+		}
 	}
 	rawResp, err := p.client.CreateMessage(ctx, upstreamAny)
 	if err != nil {
@@ -1559,6 +1602,7 @@ func (s *Server) wrapWithVisual(
 	modelAlias string,
 	preferred provider.ProviderCandidate,
 	providerAdapter format.ProviderAdapter,
+	finalizeUpstream func(ctx context.Context, upstream any) (any, error),
 ) visualpkg.CoreProvider {
 	pm := s.activeProviderManager()
 	if s.pluginRegistry == nil || s.runtime == nil || modelAlias == "" || pm == nil {
@@ -1578,7 +1622,7 @@ func (s *Server) wrapWithVisual(
 	}
 
 	// Upstream CoreProvider = adapter + client.
-	upstreamCP := newAdapterCoreProvider(providerAdapter, effectiveClient)
+	upstreamCP := newFinalizingAdapterCoreProvider(providerAdapter, effectiveClient, finalizeUpstream)
 
 	// Visual provider CoreProvider.
 	visClient, err := pm.ClientForKey(visCfg.Provider)
@@ -1599,6 +1643,20 @@ func (s *Server) wrapWithVisual(
 	visCP := newAdapterCoreProvider(visAdapter, visClient)
 
 	return visualpkg.NewCoreBridge(upstreamCP, visCP, visCfg.Model, visCfg.MaxRounds, visCfg.MaxTokens)
+}
+
+func normalizeAnthropicRequest(upstream any) (anthropic.MessageRequest, error) {
+	switch v := upstream.(type) {
+	case anthropic.MessageRequest:
+		return v, nil
+	case *anthropic.MessageRequest:
+		if v == nil {
+			return anthropic.MessageRequest{}, fmt.Errorf("expected anthropic.MessageRequest, got nil *anthropic.MessageRequest")
+		}
+		return *v, nil
+	default:
+		return anthropic.MessageRequest{}, fmt.Errorf("expected anthropic.MessageRequest, got %T", upstream)
+	}
 }
 
 // injectCoreWebSearch replaces web_search tools in coreReq.Tools with injected

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -9,20 +9,20 @@ import (
 	"net/http"
 	"time"
 
+	"moonbridge/internal/config"
 	deepseekv4 "moonbridge/internal/extension/deepseek_v4"
 	"moonbridge/internal/extension/plugin"
+	visualpkg "moonbridge/internal/extension/visual"
 	"moonbridge/internal/extension/websearchinjected"
-	"moonbridge/internal/config"
-	"moonbridge/internal/session"
-	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/format"
-	openai "moonbridge/internal/protocol/openai"
+	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/protocol/chat"
 	"moonbridge/internal/protocol/google"
+	openai "moonbridge/internal/protocol/openai"
 	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/stats"
 	mbtrace "moonbridge/internal/service/trace"
-	visualpkg "moonbridge/internal/extension/visual"
+	"moonbridge/internal/session"
 )
 
 // ============================================================================
@@ -57,6 +57,7 @@ func (s *Server) handleWithAdapters(
 ) {
 	ctx := r.Context()
 	log := slog.Default().With("model", openAIReq.Model, "path", "adapter")
+	pm := s.activeProviderManager()
 
 	// Defense-in-depth: ensure model is non-empty.
 	if openAIReq.Model == "" {
@@ -209,7 +210,7 @@ func (s *Server) handleWithAdapters(
 		}
 
 		// Inject web_search tool if enabled for this model.
-		if s.providerMgr.ResolvedWebSearch(preferred.ProviderKey) == "enabled" {
+		if pm != nil && pm.ResolvedWebSearch(preferred.ProviderKey) == "enabled" {
 			injectAnthropicWebSearch(upstreamReq)
 		}
 
@@ -242,42 +243,42 @@ func (s *Server) handleWithAdapters(
 			return
 		}
 
-			// Wrap provider with search orchestrator if web search is "injected".
-			if wsInjected {
-				if acc, ok := effectiveProvider.(provider.AnthropicClientAccessor); ok && s.runtime != nil {
-					cfgC := s.runtime.Current().Config
-					wrapped := websearchinjected.WrapProvider(
-						acc.AnthropicClient(),
-						cfgC.TavilyAPIKey, cfgC.FirecrawlAPIKey, s.maxSearchRounds(),
-					)
-					effectiveProvider = &searchProviderAdapter{wrapped: wrapped}
-				}
+		// Wrap provider with search orchestrator if web search is "injected".
+		if wsInjected {
+			if acc, ok := effectiveProvider.(provider.AnthropicClientAccessor); ok && s.runtime != nil {
+				cfgC := s.runtime.Current().Config
+				wrapped := websearchinjected.WrapProvider(
+					acc.AnthropicClient(),
+					cfgC.TavilyAPIKey, cfgC.FirecrawlAPIKey, s.maxSearchRounds(),
+				)
+				effectiveProvider = &searchProviderAdapter{wrapped: wrapped}
 			}
+		}
 
-			// Wrap with visual orchestrator at Core level if enabled for this model.
-			// This uses CoreProvider, which is protocol-agnostic.
-			if visProv := s.wrapWithVisual(ctx, openAIReq.Model, preferred, providerAdapter); visProv != nil {
-				var coreRespApi *format.CoreResponse
-				coreRespApi, err = visProv.CreateCore(ctx, coreReq)
-				if err == nil {
-					coreResp = coreRespApi
-				}
-			} else {
-				var upstreamRespMsg anthropic.MessageResponse
-				var rawResp any
-				rawResp, err = effectiveProvider.CreateMessage(ctx, *upstreamReq)
-				if err == nil {
-					var okt bool
-					upstreamRespMsg, okt = rawResp.(anthropic.MessageResponse)
-					if !okt {
-						err = fmt.Errorf("unexpected anthropic response type %T", rawResp)
-					} else {
-						// Normal path: convert back to CoreResponse.
-						msgResp := upstreamRespMsg
-						coreResp, err = providerAdapter.ToCoreResponse(ctx, &msgResp)
-					}
+		// Wrap with visual orchestrator at Core level if enabled for this model.
+		// This uses CoreProvider, which is protocol-agnostic.
+		if visProv := s.wrapWithVisual(ctx, openAIReq.Model, preferred, providerAdapter); visProv != nil {
+			var coreRespApi *format.CoreResponse
+			coreRespApi, err = visProv.CreateCore(ctx, coreReq)
+			if err == nil {
+				coreResp = coreRespApi
+			}
+		} else {
+			var upstreamRespMsg anthropic.MessageResponse
+			var rawResp any
+			rawResp, err = effectiveProvider.CreateMessage(ctx, *upstreamReq)
+			if err == nil {
+				var okt bool
+				upstreamRespMsg, okt = rawResp.(anthropic.MessageResponse)
+				if !okt {
+					err = fmt.Errorf("unexpected anthropic response type %T", rawResp)
+				} else {
+					// Normal path: convert back to CoreResponse.
+					msgResp := upstreamRespMsg
+					coreResp, err = providerAdapter.ToCoreResponse(ctx, &msgResp)
 				}
 			}
+		}
 		if err != nil {
 			log.Error("adapter path: CreateMessage failed", "error", err)
 			payload := openai.ErrorResponse{
@@ -321,8 +322,8 @@ func (s *Server) handleWithAdapters(
 			return
 		}
 
-		chatClientRaw, ok := s.chatClients[preferred.ProviderKey]
-		if !ok {
+		chatClientRaw := s.activeChatClient(preferred.ProviderKey)
+		if chatClientRaw == nil {
 			log.Error("adapter path: no chat client for provider", "provider", preferred.ProviderKey)
 			payload := openai.ErrorResponse{
 				Error: openai.ErrorObject{
@@ -428,8 +429,8 @@ func (s *Server) handleWithAdapters(
 			return
 		}
 
-		googleClientRaw, ok := s.googleClients[preferred.ProviderKey]
-		if !ok {
+		googleClientRaw := s.activeGoogleClient(preferred.ProviderKey)
+		if googleClientRaw == nil {
 			log.Error("adapter path: no google client for provider", "provider", preferred.ProviderKey)
 			payload := openai.ErrorResponse{
 				Error: openai.ErrorObject{
@@ -529,7 +530,6 @@ func (s *Server) handleWithAdapters(
 
 	// ------------------------------------------------------------------
 
-
 	// Propagate codex_tool_map from CoreRequest to CoreResponse.
 	if coreReq != nil && coreResp != nil && coreReq.Extensions != nil {
 		if tm, ok := coreReq.Extensions["codex_tool_map"]; ok {
@@ -613,7 +613,7 @@ func (s *Server) handleWithAdapters(
 			CacheCreationInputTokens: 0,
 			CacheReadInputTokens:     cachedInput,
 		}
-		reqCost := computeCostWithProviderPricing(s.providerMgr, s.stats, openAIReq.Model, preferred.UpstreamModel, preferred.ProviderKey, billingUsage)
+		reqCost := computeCostWithProviderPricing(pm, s.stats, openAIReq.Model, preferred.UpstreamModel, preferred.ProviderKey, billingUsage)
 		log.Info("请求完成",
 			"request_model", openAIReq.Model,
 			"actual_model", preferred.UpstreamModel,
@@ -658,6 +658,7 @@ func (s *Server) handleAdapterStream(
 	wsInjected bool,
 ) {
 	log := slog.Default().With("model", openAIReq.Model, "path", "adapter_stream")
+	pm := s.activeProviderManager()
 
 	// Track when the request started for latency measurement.
 	requestStart := time.Now()
@@ -738,8 +739,7 @@ func (s *Server) handleAdapterStream(
 		// This prevents base64 image data from being sent to text-only models.
 		if s.pluginRegistry != nil && s.runtime != nil && openAIReq.Model != "" {
 			cfgV := s.runtime.Current().Config
-			pluginCfg := config.PluginFromGlobalConfig(&cfgV)
-			visCfg, visOk := visualpkg.ConfigForModel(pluginCfg, openAIReq.Model)
+			visCfg, visOk := visualpkg.ConfigForModelFromResolvedConfig(cfgV, openAIReq.Model)
 			if visOk && visCfg.Provider != "" && visCfg.Model != "" {
 				strippedReq, _ := visualpkg.StripImagesFromAnthropic(*anthReq)
 				anthReq = &strippedReq
@@ -815,8 +815,8 @@ func (s *Server) handleAdapterStream(
 			prependCachedReasoningForChat(chatReq, sess)
 		}
 
-		chatClientRaw, ok := s.chatClients[candidate.ProviderKey]
-		if !ok {
+		chatClientRaw := s.activeChatClient(candidate.ProviderKey)
+		if chatClientRaw == nil {
 			log.Error("adapter stream: no chat client", "provider", candidate.ProviderKey)
 			payload := openai.ErrorResponse{
 				Error: openai.ErrorObject{
@@ -832,7 +832,7 @@ func (s *Server) handleAdapterStream(
 		}
 		chatClient, ok := chatClientRaw.(*chat.Client)
 		if !ok {
-			log.Error("adapter stream: chat client type assertion failed", "provider", candidate.ProviderKey)
+			log.Error("adapter stream: invalid chat client type", "provider", candidate.ProviderKey)
 			payload := openai.ErrorResponse{
 				Error: openai.ErrorObject{
 					Message: fmt.Sprintf("invalid chat client for provider %q", candidate.ProviderKey),
@@ -840,7 +840,7 @@ func (s *Server) handleAdapterStream(
 					Code:    "internal_error",
 				},
 			}
-			streamRecord.Error = traceError("stream_chat_type", fmt.Errorf("invalid chat client for %q", candidate.ProviderKey))
+			streamRecord.Error = traceError("stream_chat_client_type", fmt.Errorf("invalid chat client for %q", candidate.ProviderKey))
 			streamRecord.OpenAIResponse = payload
 			writeOpenAIError(w, http.StatusInternalServerError, payload)
 			return
@@ -917,8 +917,8 @@ func (s *Server) handleAdapterStream(
 			return
 		}
 
-		googleClientRaw, ok := s.googleClients[candidate.ProviderKey]
-		if !ok {
+		googleClientRaw := s.activeGoogleClient(candidate.ProviderKey)
+		if googleClientRaw == nil {
 			log.Error("adapter stream: no google client", "provider", candidate.ProviderKey)
 			payload := openai.ErrorResponse{
 				Error: openai.ErrorObject{
@@ -934,7 +934,7 @@ func (s *Server) handleAdapterStream(
 		}
 		googleClient, ok := googleClientRaw.(*google.Client)
 		if !ok {
-			log.Error("adapter stream: google client type assertion failed", "provider", candidate.ProviderKey)
+			log.Error("adapter stream: invalid google client type", "provider", candidate.ProviderKey)
 			payload := openai.ErrorResponse{
 				Error: openai.ErrorObject{
 					Message: fmt.Sprintf("invalid google client for provider %q", candidate.ProviderKey),
@@ -942,7 +942,7 @@ func (s *Server) handleAdapterStream(
 					Code:    "internal_error",
 				},
 			}
-			streamRecord.Error = traceError("stream_google_type", fmt.Errorf("invalid google client for %q", candidate.ProviderKey))
+			streamRecord.Error = traceError("stream_google_client_type", fmt.Errorf("invalid google client for %q", candidate.ProviderKey))
 			streamRecord.OpenAIResponse = payload
 			writeOpenAIError(w, http.StatusInternalServerError, payload)
 			return
@@ -1134,40 +1134,40 @@ func (s *Server) handleAdapterStream(
 									outputText = finalResp.OutputText
 								}
 								s.pluginRegistry.OnStreamComplete(openAIReq.Model, states, outputText, sess.ExtensionData)
-				}
-			}
-		}
-	}
-		// Chat stream events from provider adapter
-		if chatProvider, ok := s.adapterRegistry.GetProvider(config.ProtocolOpenAIChat); ok {
-			if chatAdapter, ok := chatProvider.(*chat.ChatProviderAdapter); ok {
-				if events := chatAdapter.StreamBuffer(); len(events) > 0 {
-					streamRecord.ChatStreamEvents = events
-
-					// Cache reasoning from Chat stream for DeepSeek thinking replay.
-					if sess != nil {
-						var streamReasoning string
-						var streamToolCallIDs []string
-						for _, ev := range events {
-							for _, sc := range ev.Choices {
-								if sc.Delta.ReasoningContent != "" {
-									streamReasoning = sc.Delta.ReasoningContent
-								}
-								for _, tc := range sc.Delta.ToolCalls {
-									if tc.ID != "" {
-										streamToolCallIDs = append(streamToolCallIDs, tc.ID)
-									}
-								}
 							}
 						}
-						if streamReasoning != "" && len(streamToolCallIDs) > 0 {
-							cacheReasoningForChat(sess, streamToolCallIDs, streamReasoning)
+					}
+				}
+				// Chat stream events from provider adapter
+				if chatProvider, ok := s.adapterRegistry.GetProvider(config.ProtocolOpenAIChat); ok {
+					if chatAdapter, ok := chatProvider.(*chat.ChatProviderAdapter); ok {
+						if events := chatAdapter.StreamBuffer(); len(events) > 0 {
+							streamRecord.ChatStreamEvents = events
+
+							// Cache reasoning from Chat stream for DeepSeek thinking replay.
+							if sess != nil {
+								var streamReasoning string
+								var streamToolCallIDs []string
+								for _, ev := range events {
+									for _, sc := range ev.Choices {
+										if sc.Delta.ReasoningContent != "" {
+											streamReasoning = sc.Delta.ReasoningContent
+										}
+										for _, tc := range sc.Delta.ToolCalls {
+											if tc.ID != "" {
+												streamToolCallIDs = append(streamToolCallIDs, tc.ID)
+											}
+										}
+									}
+								}
+								if streamReasoning != "" && len(streamToolCallIDs) > 0 {
+									cacheReasoningForChat(sess, streamToolCallIDs, streamReasoning)
+								}
+							}
 						}
 					}
 				}
 			}
-		}
-	}
 		}
 	}
 	if s.stats != nil && (finalUsage.InputTokens > 0 || finalUsage.OutputTokens > 0) {
@@ -1198,7 +1198,7 @@ func (s *Server) handleAdapterStream(
 		CacheCreationInputTokens: 0,
 		CacheReadInputTokens:     cachedInput,
 	}
-	reqCost := computeCostWithProviderPricing(s.providerMgr, s.stats, openAIReq.Model, candidate.UpstreamModel, candidate.ProviderKey, billingUsage)
+	reqCost := computeCostWithProviderPricing(pm, s.stats, openAIReq.Model, candidate.UpstreamModel, candidate.ProviderKey, billingUsage)
 	log.Info("流式请求完成",
 		"model", openAIReq.Model,
 		"actual_model", candidate.UpstreamModel,
@@ -1229,7 +1229,7 @@ func (s *Server) handleAdapterStream(
 				CachedInputTokens: finalUsage.InputTokensDetails.CachedTokens,
 			}, true) // input tokens now include cache (normalized at adapter level)
 		}
-		reqCost := computeCostWithProviderPricing(s.providerMgr, s.stats, openAIReq.Model, candidate.UpstreamModel, candidate.ProviderKey, billingUsage)
+		reqCost := computeCostWithProviderPricing(pm, s.stats, openAIReq.Model, candidate.UpstreamModel, candidate.ProviderKey, billingUsage)
 		s.onRequestCompleted(
 			openAIReq.Model, candidate.UpstreamModel, candidate.ProviderKey,
 			requestStart, usage,
@@ -1274,13 +1274,13 @@ func (s *Server) wrapWithVisual(
 	preferred provider.ProviderCandidate,
 	providerAdapter format.ProviderAdapter,
 ) visualpkg.CoreProvider {
-	if s.pluginRegistry == nil || s.runtime == nil || modelAlias == "" || s.providerMgr == nil {
+	pm := s.activeProviderManager()
+	if s.pluginRegistry == nil || s.runtime == nil || modelAlias == "" || pm == nil {
 		return nil
 	}
 
 	cfg := s.runtime.Current().Config
-	pluginCfg := config.PluginFromGlobalConfig(&cfg)
-	visCfg, ok := visualpkg.ConfigForModel(pluginCfg, modelAlias)
+	visCfg, ok := visualpkg.ConfigForModelFromResolvedConfig(cfg, modelAlias)
 	if !ok || visCfg.Provider == "" || visCfg.Model == "" {
 		return nil
 	}
@@ -1295,12 +1295,12 @@ func (s *Server) wrapWithVisual(
 	upstreamCP := newAdapterCoreProvider(providerAdapter, effectiveClient)
 
 	// Visual provider CoreProvider.
-	visClient, err := s.providerMgr.ClientForKey(visCfg.Provider)
+	visClient, err := pm.ClientForKey(visCfg.Provider)
 	if err != nil || visClient == nil {
 		slog.Default().Warn("visual: provider not found", "visual_provider", visCfg.Provider, "model", modelAlias)
 		return nil
 	}
-	visProtocol := s.providerMgr.ProtocolForKey(visCfg.Provider)
+	visProtocol := pm.ProtocolForKey(visCfg.Provider)
 	if visProtocol == "" {
 		slog.Default().Warn("visual: cannot resolve visual provider protocol")
 		return nil
@@ -1315,15 +1315,15 @@ func (s *Server) wrapWithVisual(
 	return visualpkg.NewCoreBridge(upstreamCP, visCP, visCfg.Model, visCfg.MaxRounds, visCfg.MaxTokens)
 }
 
-
 // injectCoreWebSearch replaces web_search tools in coreReq.Tools with injected
 // tavily_search/firecrawl_fetch tools when the provider's web search mode is "injected".
 // Returns true if injection was applied.
 func (s *Server) injectCoreWebSearch(ctx context.Context, coreReq *format.CoreRequest, preferred provider.ProviderCandidate, openAIReq openai.ResponsesRequest) bool {
-	if s.providerMgr == nil {
+	pm := s.activeProviderManager()
+	if pm == nil {
 		return false
 	}
-	wsMode := s.providerMgr.ResolvedWebSearch(preferred.ProviderKey)
+	wsMode := pm.ResolvedWebSearch(preferred.ProviderKey)
 	if wsMode != "injected" && wsMode != "auto" {
 		return false
 	}
@@ -1419,7 +1419,6 @@ func (a *searchProviderAdapter) StreamMessage(ctx context.Context, req any) (<-c
 
 func (a *searchProviderAdapter) AnthropicClient() *anthropic.Client { return nil }
 
-
 // injectAnthropicWebSearch adds the Anthropic web_search_20250305 server tool
 // to an anthropic.MessageRequest if not already present.
 func injectAnthropicWebSearch(req *anthropic.MessageRequest) {
@@ -1510,7 +1509,6 @@ func hasThinkingBlock(content []anthropic.ContentBlock) bool {
 	return false
 }
 
-
 // prependCachedReasoningForChat restores reasoning_content on assistant messages
 // for DeepSeek thinking chain replay across conversation turns.
 // It looks up cached thinking blocks from the session state and sets them
@@ -1545,10 +1543,10 @@ func prependCachedReasoningForChat(chatReq *chat.ChatRequest, sess *session.Sess
 					continue
 				}
 				if cached, ok := state.CachedForToolCall(tc.ID); ok {
-						thinking := cached.ReasoningText
-						if thinking == "" {
-							thinking = cached.Text
-						}
+					thinking := cached.ReasoningText
+					if thinking == "" {
+						thinking = cached.Text
+					}
 					if thinking != "" {
 						msg.ReasoningContent = thinking
 						break
@@ -1563,7 +1561,6 @@ func prependCachedReasoningForChat(chatReq *chat.ChatRequest, sess *session.Sess
 		}
 	}
 }
-
 
 // cacheReasoningForChat stores reasoning content from a Chat response
 // into the session extension data for replay on subsequent turns.
@@ -1648,4 +1645,3 @@ func formatContentSliceToAnthropic(blocks []format.CoreContentBlock) []anthropic
 	}
 	return result
 }
-

--- a/internal/service/server/adapter_dispatch_test.go
+++ b/internal/service/server/adapter_dispatch_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"moonbridge/internal/config"
 	"moonbridge/internal/format"
+	"moonbridge/internal/service/runtime"
 )
 
 func TestCoreResponseToCoreStreamEmitsUsageOnCompleted(t *testing.T) {
@@ -78,5 +80,73 @@ func TestCoreResponseToCoreStreamEmitsUsageOnCompleted(t *testing.T) {
 	}
 	if !sawToolArgsDone {
 		t.Fatal("missing tool args done event")
+	}
+}
+
+func TestResolvedSearchConfig_UsesModelOverrides(t *testing.T) {
+	rt := runtime.NewRuntime(config.Config{
+		SearchMaxRounds: 4,
+		TavilyAPIKey:    "global-tv",
+		FirecrawlAPIKey: "global-fc",
+		ProviderDefs: map[string]config.ProviderDef{
+			"main": {
+				SearchMaxRounds: 6,
+				TavilyAPIKey:    "provider-tv",
+				FirecrawlAPIKey: "provider-fc",
+				Models: map[string]config.ModelMeta{
+					"gpt-4o-mini": {
+						WebSearch: config.WebSearchConfig{
+							Support:         config.WebSearchSupportInjected,
+							TavilyAPIKey:    "model-tv",
+							FirecrawlAPIKey: "model-fc",
+							SearchMaxRounds: 9,
+						},
+					},
+				},
+			},
+		},
+		Routes: map[string]config.RouteEntry{
+			"assistant-mini": {Provider: "main", Model: "gpt-4o-mini"},
+		},
+	}, nil, nil)
+	srv := &Server{runtime: rt}
+
+	cfg := srv.resolvedSearchConfig("main", "assistant-mini")
+	if cfg.tavilyKey != "model-tv" {
+		t.Fatalf("tavily=%q, want model-tv", cfg.tavilyKey)
+	}
+	if cfg.firecrawlKey != "model-fc" {
+		t.Fatalf("firecrawl=%q, want model-fc", cfg.firecrawlKey)
+	}
+	if cfg.maxRounds != 9 {
+		t.Fatalf("maxRounds=%d, want 9", cfg.maxRounds)
+	}
+}
+
+func TestResolvedSearchConfig_FallsBackToProvider(t *testing.T) {
+	rt := runtime.NewRuntime(config.Config{
+		SearchMaxRounds: 5,
+		TavilyAPIKey:    "global-tv",
+		FirecrawlAPIKey: "global-fc",
+		ProviderDefs: map[string]config.ProviderDef{
+			"main": {
+				SearchMaxRounds:  8,
+				TavilyAPIKey:     "provider-tv",
+				FirecrawlAPIKey:  "provider-fc",
+				WebSearchSupport: config.WebSearchSupportInjected,
+			},
+		},
+	}, nil, nil)
+	srv := &Server{runtime: rt}
+
+	cfg := srv.resolvedSearchConfig("main", "")
+	if cfg.tavilyKey != "provider-tv" {
+		t.Fatalf("tavily=%q, want provider-tv", cfg.tavilyKey)
+	}
+	if cfg.firecrawlKey != "provider-fc" {
+		t.Fatalf("firecrawl=%q, want provider-fc", cfg.firecrawlKey)
+	}
+	if cfg.maxRounds != 8 {
+		t.Fatalf("maxRounds=%d, want 8", cfg.maxRounds)
 	}
 }

--- a/internal/service/server/adapter_dispatch_test.go
+++ b/internal/service/server/adapter_dispatch_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"moonbridge/internal/format"
+)
+
+func TestCoreResponseToCoreStreamEmitsUsageOnCompleted(t *testing.T) {
+	resp := &format.CoreResponse{
+		ID:     "resp_test",
+		Status: "completed",
+		Model:  "claude-test",
+		Messages: []format.CoreMessage{
+			{
+				Role: "assistant",
+				Content: []format.CoreContentBlock{
+					{Type: "text", Text: "hello"},
+					{Type: "tool_use", ToolUseID: "call_1", ToolName: "exec_command", ToolInput: []byte(`{"cmd":"ls"}`)},
+					{Type: "reasoning", ReasoningText: "think", ReasoningSignature: "sig_1"},
+				},
+			},
+		},
+		Usage: format.CoreUsage{
+			InputTokens:       11,
+			OutputTokens:      7,
+			CachedInputTokens: 3,
+		},
+		StopReason: "end_turn",
+	}
+
+	stream := coreResponseToCoreStream(context.Background(), resp)
+	var events []format.CoreStreamEvent
+	for ev := range stream {
+		events = append(events, ev)
+	}
+
+	if len(events) == 0 {
+		t.Fatal("no stream events emitted")
+	}
+	if events[0].Type != format.CoreEventCreated {
+		t.Fatalf("first event type = %s, want %s", events[0].Type, format.CoreEventCreated)
+	}
+
+	var completed *format.CoreStreamEvent
+	for i := range events {
+		if events[i].Type == format.CoreEventCompleted {
+			completed = &events[i]
+			break
+		}
+	}
+	if completed == nil {
+		t.Fatal("missing core.completed event")
+	}
+	if completed.Usage == nil {
+		t.Fatal("completed usage is nil")
+	}
+	if completed.Usage.InputTokens != 11 || completed.Usage.OutputTokens != 7 || completed.Usage.CachedInputTokens != 3 {
+		t.Fatalf("completed usage = %+v", completed.Usage)
+	}
+	if completed.Usage.TotalTokens != 18 {
+		t.Fatalf("completed usage total_tokens = %d, want 18", completed.Usage.TotalTokens)
+	}
+
+	var sawToolStarted bool
+	var sawToolArgsDone bool
+	for _, ev := range events {
+		if ev.Type == format.CoreContentBlockStarted && ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
+			sawToolStarted = true
+		}
+		if ev.Type == format.CoreToolCallArgsDone && ev.Delta == `{"cmd":"ls"}` {
+			sawToolArgsDone = true
+		}
+	}
+	if !sawToolStarted {
+		t.Fatal("missing tool_use block start event")
+	}
+	if !sawToolArgsDone {
+		t.Fatal("missing tool args done event")
+	}
+}

--- a/internal/service/server/adapter_dispatch_test.go
+++ b/internal/service/server/adapter_dispatch_test.go
@@ -2,10 +2,13 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"moonbridge/internal/config"
 	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/openai"
+	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/runtime"
 )
 
@@ -148,5 +151,117 @@ func TestResolvedSearchConfig_FallsBackToProvider(t *testing.T) {
 	}
 	if cfg.maxRounds != 8 {
 		t.Fatalf("maxRounds=%d, want 8", cfg.maxRounds)
+	}
+}
+
+func TestResolvedWebSearchModePrefersCandidateOverProvider(t *testing.T) {
+	pm, err := provider.NewProviderManager(
+		map[string]provider.ProviderConfig{
+			"deepseek": {
+				BaseURL: "https://deepseek.example.test",
+				APIKey:  "key-deepseek",
+			},
+		},
+		map[string]provider.ModelRoute{
+			"deepseek-v4-flash": {Provider: "deepseek", Name: "deepseek-v4-flash"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewProviderManager() error = %v", err)
+	}
+	pm.SetResolvedWebSearch("deepseek", "disabled")
+	pm.SetResolvedWebSearch(provider.WebSearchCandidateKey("deepseek", "deepseek-v4-flash"), "enabled")
+
+	mode := resolvedWebSearchMode(pm, "deepseek-v4-flash", provider.ProviderCandidate{
+		ProviderKey:   "deepseek",
+		UpstreamModel: "deepseek-v4-flash",
+	})
+	if mode != "enabled" {
+		t.Fatalf("resolvedWebSearchMode() = %q, want enabled", mode)
+	}
+}
+
+func TestInjectCoreWebSearchAutoInjectedAddsToolsWithoutExplicitRequestTools(t *testing.T) {
+	pm, err := provider.NewProviderManager(
+		map[string]provider.ProviderConfig{
+			"opencode": {
+				BaseURL: "https://opencode.example.test",
+				APIKey:  "key-opencode",
+			},
+		},
+		map[string]provider.ModelRoute{
+			"deepseek-v4-pro": {Provider: "opencode", Name: "deepseek-v4-pro"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewProviderManager() error = %v", err)
+	}
+	rt := runtime.NewRuntime(config.Config{
+		TavilyAPIKey: "tavily-key",
+		ProviderDefs: map[string]config.ProviderDef{
+			"opencode": {
+				TavilyAPIKey: "tavily-key",
+			},
+		},
+		Routes: map[string]config.RouteEntry{
+			"deepseek-v4-pro": {Provider: "opencode", Model: "deepseek-v4-pro"},
+		},
+	}, pm, nil)
+	srv := &Server{providerMgr: pm, runtime: rt}
+
+	coreReq := &format.CoreRequest{Model: "deepseek-v4-pro"}
+	openAIReq := openai.ResponsesRequest{
+		Model: "deepseek-v4-pro",
+		Input: json.RawMessage(`"搜索互联网获取今天的日期"`),
+	}
+	ok := srv.injectCoreWebSearch(context.Background(), coreReq, provider.ProviderCandidate{
+		ProviderKey:   "opencode",
+		UpstreamModel: "deepseek-v4-pro",
+	}, openAIReq, "injected")
+	if !ok {
+		t.Fatal("injectCoreWebSearch() = false, want true")
+	}
+	if len(coreReq.Tools) != 1 {
+		t.Fatalf("len(coreReq.Tools) = %d, want 1", len(coreReq.Tools))
+	}
+	if coreReq.Tools[0].Name != "tavily_search" {
+		t.Fatalf("tool[0].Name = %q, want tavily_search", coreReq.Tools[0].Name)
+	}
+	if coreReq.ToolChoice == nil || coreReq.ToolChoice.Mode != "auto" {
+		t.Fatalf("tool_choice = %+v, want auto", coreReq.ToolChoice)
+	}
+}
+
+func TestInjectCoreWebSearchSkipsWhenCandidateHasNativeSearch(t *testing.T) {
+	pm, err := provider.NewProviderManager(
+		map[string]provider.ProviderConfig{
+			"deepseek": {
+				BaseURL: "https://deepseek.example.test",
+				APIKey:  "key-deepseek",
+			},
+		},
+		map[string]provider.ModelRoute{
+			"deepseek-v4-flash": {Provider: "deepseek", Name: "deepseek-v4-flash"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewProviderManager() error = %v", err)
+	}
+	srv := &Server{providerMgr: pm}
+
+	coreReq := &format.CoreRequest{Model: "deepseek-v4-flash"}
+	openAIReq := openai.ResponsesRequest{
+		Model: "deepseek-v4-flash",
+		Input: json.RawMessage(`"搜索互联网获取今天的日期"`),
+	}
+	ok := srv.injectCoreWebSearch(context.Background(), coreReq, provider.ProviderCandidate{
+		ProviderKey:   "deepseek",
+		UpstreamModel: "deepseek-v4-flash",
+	}, openAIReq, "enabled")
+	if ok {
+		t.Fatal("injectCoreWebSearch() = true, want false for native search candidate")
+	}
+	if len(coreReq.Tools) != 0 {
+		t.Fatalf("len(coreReq.Tools) = %d, want 0", len(coreReq.Tools))
 	}
 }

--- a/internal/service/server/candidate_routing_test.go
+++ b/internal/service/server/candidate_routing_test.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	deepseekv4 "moonbridge/internal/extension/deepseek_v4"
+	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/anthropic"
 	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/stats"
+	"moonbridge/internal/session"
 )
 
 func TestRequestHasImage(t *testing.T) {
@@ -69,5 +73,84 @@ func TestComputeCostWithProviderPricingNilStats(t *testing.T) {
 	cost := computeCostWithProviderPricing(nil, nil, "model", "model", "provider", stats.BillingUsage{})
 	if cost != 0 {
 		t.Fatalf("nil stats should return 0, got %f", cost)
+	}
+}
+
+func TestPrependCachedThinkingSkipsAssistantTextAndFallsBackForToolUse(t *testing.T) {
+	sess := session.New()
+	state := deepseekv4.NewState()
+	sess.InitExtensions(map[string]any{
+		"deepseek_v4": state,
+	})
+
+	req := &anthropic.MessageRequest{
+		Messages: []anthropic.Message{
+			{
+				Role: "assistant",
+				Content: []anthropic.ContentBlock{
+					{Type: "text", Text: "plain assistant text"},
+				},
+			},
+			{
+				Role: "assistant",
+				Content: []anthropic.ContentBlock{
+					{Type: "tool_use", ID: "call-miss", Name: "exec_command", Input: json.RawMessage(`{}`)},
+				},
+			},
+		},
+	}
+
+	prependCachedThinking(req, sess)
+
+	if len(req.Messages[0].Content) != 1 || req.Messages[0].Content[0].Type != "text" {
+		t.Fatalf("assistant text message should remain unchanged, got %+v", req.Messages[0].Content)
+	}
+
+	if len(req.Messages[1].Content) < 2 {
+		t.Fatalf("tool_use message should receive fallback thinking block, got %+v", req.Messages[1].Content)
+	}
+	if req.Messages[1].Content[0].Type != "thinking" {
+		t.Fatalf("first block should be thinking fallback, got %+v", req.Messages[1].Content[0])
+	}
+	if req.Messages[1].Content[1].Type != "tool_use" || req.Messages[1].Content[1].ID != "call-miss" {
+		t.Fatalf("tool_use block misplaced after fallback prepend, got %+v", req.Messages[1].Content)
+	}
+}
+
+func TestPrependCachedThinkingChecksAllToolUseBlocks(t *testing.T) {
+	sess := session.New()
+	state := deepseekv4.NewState()
+	state.RememberForToolCalls(
+		[]string{"call-hit"},
+		format.CoreContentBlock{
+			Type:               "reasoning",
+			ReasoningText:      "replayed",
+			ReasoningSignature: "sig-hit",
+		},
+	)
+	sess.InitExtensions(map[string]any{
+		"deepseek_v4": state,
+	})
+
+	req := &anthropic.MessageRequest{
+		Messages: []anthropic.Message{
+			{
+				Role: "assistant",
+				Content: []anthropic.ContentBlock{
+					{Type: "tool_use", ID: "call-miss", Name: "exec_command", Input: json.RawMessage(`{}`)},
+					{Type: "tool_use", ID: "call-hit", Name: "exec_command", Input: json.RawMessage(`{}`)},
+				},
+			},
+		},
+	}
+
+	prependCachedThinking(req, sess)
+
+	if len(req.Messages[0].Content) < 3 {
+		t.Fatalf("assistant message should prepend cached thinking, got %+v", req.Messages[0].Content)
+	}
+	head := req.Messages[0].Content[0]
+	if head.Type != "thinking" || head.Thinking != "replayed" || head.Signature != "sig-hit" {
+		t.Fatalf("cached thinking block mismatch, got %+v", head)
 	}
 }

--- a/internal/service/server/dispatch.go
+++ b/internal/service/server/dispatch.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/logger"
 	"moonbridge/internal/protocol/openai"
 	"moonbridge/internal/service/provider"
@@ -98,7 +98,9 @@ func (server *Server) handleResponses(writer http.ResponseWriter, request *http.
 	if resolveErr == nil {
 		var candidateInfo string
 		for i, c := range resolvedRoute.Candidates {
-			if i > 0 { candidateInfo += ", " }
+			if i > 0 {
+				candidateInfo += ", "
+			}
 			candidateInfo += c.ProviderKey + "=" + c.UpstreamModel + "(p" + fmt.Sprint(i) + ")"
 		}
 		log.Debug("路由解析结果", "model", responsesRequest.Model, "candidates", candidateInfo)
@@ -194,12 +196,12 @@ func (server *Server) writeTrace(record mbtrace.Record) {
 	// Chat 分类：openai-chat 协议的请求/响应
 	if shouldWriteChatTrace(record) {
 		server.writeTraceCategory("Chat", requestNumber, mbtrace.Record{
-			HTTPRequest:        record.HTTPRequest,
-			Model:              record.Model,
-			ChatRequest:        record.ChatRequest,
-			ChatResponse:       record.ChatResponse,
-			ChatStreamEvents:   record.ChatStreamEvents,
-			Error:              record.Error,
+			HTTPRequest:      record.HTTPRequest,
+			Model:            record.Model,
+			ChatRequest:      record.ChatRequest,
+			ChatResponse:     record.ChatResponse,
+			ChatStreamEvents: record.ChatStreamEvents,
+			Error:            record.Error,
 		})
 	}
 
@@ -276,6 +278,7 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 	var hookErr string
 	var lastErr error
 	actualModel := "" // updated with the successfully used upstream model
+	pm := server.activeProviderManager()
 	defer func() {
 		if hookErr != "" {
 			server.onRequestCompleted(
@@ -285,7 +288,7 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 		}
 	}()
 	log := slog.Default().With("path", request.URL.Path, "method", request.Method)
-	if server.providerMgr == nil {
+	if pm == nil {
 		log.Error("未配置 OpenAI Responses 直通的提供商管理器")
 		payload := openai.ErrorResponse{Error: openai.ErrorObject{
 			Message: "提供商路由未配置",
@@ -326,9 +329,14 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 		providerKey := candidate.ProviderKey
 		isLast := i == len(openaiCandidates)-1
 		log := logger.L().With("provider", providerKey, "attempt", i+1)
+		if candidate.Client == nil {
+			if dynamicClient, err := pm.ClientForKey(providerKey); err == nil {
+				candidate.Client = dynamicClient
+			}
+		}
 
-		baseURL := server.providerMgr.ProviderBaseURL(providerKey)
-		apiKey := server.providerMgr.ProviderAPIKey(providerKey)
+		baseURL := pm.ProviderBaseURL(providerKey)
+		apiKey := pm.ProviderAPIKey(providerKey)
 		if baseURL == "" {
 			if isLast {
 				log.Error("OpenAI 提供商缺少 base_url")
@@ -363,7 +371,7 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 		actualModel = candidate.UpstreamModel
 
 		// Inject web_search tool if enabled for this model.
-		if server.providerMgr.ResolvedWebSearchForModel(responsesRequest.Model) == "enabled" {
+		if pm.ResolvedWebSearchForModel(responsesRequest.Model) == "enabled" {
 			upstreamRequest.Tools = InjectWebSearchTool(upstreamRequest.Tools)
 		}
 
@@ -520,7 +528,7 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 		}
 		cost := float64(0)
 		if server.stats != nil {
-			cost = computeCostWithProviderPricing(server.providerMgr, server.stats, responsesRequest.Model, actualModel, providerKey, billingUsage)
+			cost = computeCostWithProviderPricing(pm, server.stats, responsesRequest.Model, actualModel, providerKey, billingUsage)
 		}
 		server.onRequestCompleted(
 			responsesRequest.Model, actualModel, providerKey, proxyStart,

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -9,11 +9,13 @@ import (
 	"sync"
 	"time"
 
-	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/config"
-	"moonbridge/internal/logger"
-	"moonbridge/internal/protocol/openai"
+	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/format"
+	"moonbridge/internal/logger"
+	"moonbridge/internal/protocol/chat"
+	"moonbridge/internal/protocol/google"
+	"moonbridge/internal/protocol/openai"
 	"moonbridge/internal/service/api"
 	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/runtime"
@@ -32,48 +34,95 @@ import (
 type Config struct {
 	// ServerCfg is the scoped domain config for the server layer.
 	// Used alongside AppConfig for the full config.
-	ServerCfg config.ServerConfig
-	AdapterRegistry   *format.Registry    // adapter dispatch path (format registry)
-	Provider          provider.ProviderClient // fallback provider for non-adapter path
-	ProviderMgr       *provider.ProviderManager
-	OpenAIHTTPClient  *http.Client
-	ChatClients       map[string]any
-	GoogleClients     map[string]any
-	Tracer            *mbtrace.Tracer
-	TraceErrors       io.Writer
-	Stats             *stats.SessionStats
-	PluginRegistry    *plugin.Registry
-	AppConfig         config.ServerConfig
-	Runtime           *runtime.Runtime
-	Store             store.ConfigStore
-	SessionManager    session.Manager
-	UsageTracker      usage.Tracker
-	TraceWriter       trace.Writer
+	ServerCfg        config.ServerConfig
+	AdapterRegistry  *format.Registry        // adapter dispatch path (format registry)
+	Provider         provider.ProviderClient // fallback provider for non-adapter path
+	ProviderMgr      *provider.ProviderManager
+	OpenAIHTTPClient *http.Client
+	ChatClients      map[string]any
+	GoogleClients    map[string]any
+	Tracer           *mbtrace.Tracer
+	TraceErrors      io.Writer
+	Stats            *stats.SessionStats
+	PluginRegistry   *plugin.Registry
+	AppConfig        config.ServerConfig
+	Runtime          *runtime.Runtime
+	Store            store.ConfigStore
+	SessionManager   session.Manager
+	UsageTracker     usage.Tracker
+	TraceWriter      trace.Writer
 }
 
 type Server struct {
-	adapterRegistry   *format.Registry
-	provider          provider.ProviderClient
-	providerMgr       *provider.ProviderManager
-	openAIHTTP        *http.Client
-	chatClients       map[string]any
-	googleClients     map[string]any
-	tracer            *mbtrace.Tracer
-	traceErrors       io.Writer
-	stats             *stats.SessionStats
-	pluginRegistry    *plugin.Registry
-	mux               *http.ServeMux
-	sessionsMu        sync.Mutex
-	sessions          map[string]serverSession
-	sessionPruneStop  chan struct{}
-	onceClose         sync.Once
-	appConfig         config.ServerConfig
-	serverCfg         config.ServerConfig
-	runtime           *runtime.Runtime
-	store             store.ConfigStore
-	sessionManager    session.Manager
-	usageTracker      usage.Tracker
-	traceWriter       trace.Writer
+	adapterRegistry *format.Registry
+	provider        provider.ProviderClient
+	providerMgr     *provider.ProviderManager
+	openAIHTTP      *http.Client
+	chatClients     map[string]any
+	googleClients   map[string]any
+	tracer          *mbtrace.Tracer
+	traceErrors     io.Writer
+	stats           *stats.SessionStats
+	pluginRegistry  *plugin.Registry
+	mux             *http.ServeMux
+	onceClose       sync.Once
+	appConfig       config.ServerConfig
+	serverCfg       config.ServerConfig
+	runtime         *runtime.Runtime
+	store           store.ConfigStore
+	sessionManager  session.Manager
+	usageTracker    usage.Tracker
+	traceWriter     trace.Writer
+}
+
+func (s *Server) runtimeSnapshot() *runtime.ConfigSnapshot {
+	if s.runtime == nil {
+		return nil
+	}
+	return s.runtime.Current()
+}
+
+func (s *Server) activeProviderManager() *provider.ProviderManager {
+	if snap := s.runtimeSnapshot(); snap != nil && snap.ProviderMgr != nil {
+		return snap.ProviderMgr
+	}
+	return s.providerMgr
+}
+
+func (s *Server) activeProviderDefs() map[string]config.ProviderDef {
+	if snap := s.runtimeSnapshot(); snap != nil {
+		return snap.Config.ProviderDefs
+	}
+	return nil
+}
+
+func (s *Server) activeChatClient(providerKey string) any {
+	if snap := s.runtimeSnapshot(); snap != nil {
+		if def, ok := snap.Config.ProviderDefs[providerKey]; ok && def.Protocol == config.ProtocolOpenAIChat {
+			return chat.NewClient(chat.ClientConfig{
+				BaseURL:   def.BaseURL,
+				APIKey:    def.APIKey,
+				UserAgent: def.UserAgent,
+			})
+		}
+	}
+	return s.chatClients[providerKey]
+}
+
+func (s *Server) activeGoogleClient(providerKey string) any {
+	if snap := s.runtimeSnapshot(); snap != nil {
+		if def, ok := snap.Config.ProviderDefs[providerKey]; ok && def.Protocol == config.ProtocolGoogleGenAI {
+			return google.NewClient(google.ClientConfig{
+				BaseURL:   def.BaseURL,
+				APIKey:    def.APIKey,
+				Project:   def.Project,
+				Location:  def.Location,
+				Version:   def.APIVersion,
+				UserAgent: def.UserAgent,
+			})
+		}
+	}
+	return s.googleClients[providerKey]
 }
 
 func New(cfg Config) *Server {
@@ -81,32 +130,29 @@ func New(cfg Config) *Server {
 		cfg.SessionManager = newDefaultSessionManager(cfg)
 	}
 	s := &Server{
-		adapterRegistry:  cfg.AdapterRegistry,
-		provider:         cfg.Provider,
-		providerMgr:      cfg.ProviderMgr,
-		openAIHTTP:       cfg.OpenAIHTTPClient,
-		tracer:           cfg.Tracer,
-		traceErrors:      cfg.TraceErrors,
-		stats:            cfg.Stats,
-		pluginRegistry:   cfg.PluginRegistry,
-		mux:              http.NewServeMux(),
-		sessions:         map[string]serverSession{},
-		sessionPruneStop: make(chan struct{}),
-	appConfig:        cfg.AppConfig,
-	serverCfg:        cfg.ServerCfg,
-	chatClients:      cfg.ChatClients,
-		googleClients:    cfg.GoogleClients,
-		runtime:          cfg.Runtime,
-		store:            cfg.Store,
-		sessionManager:   cfg.SessionManager,
-		usageTracker:     cfg.UsageTracker,
-		traceWriter:      cfg.TraceWriter,
+		adapterRegistry: cfg.AdapterRegistry,
+		provider:        cfg.Provider,
+		providerMgr:     cfg.ProviderMgr,
+		openAIHTTP:      cfg.OpenAIHTTPClient,
+		tracer:          cfg.Tracer,
+		traceErrors:     cfg.TraceErrors,
+		stats:           cfg.Stats,
+		pluginRegistry:  cfg.PluginRegistry,
+		mux:             http.NewServeMux(),
+		appConfig:       cfg.AppConfig,
+		serverCfg:       cfg.ServerCfg,
+		chatClients:     cfg.ChatClients,
+		googleClients:   cfg.GoogleClients,
+		runtime:         cfg.Runtime,
+		store:           cfg.Store,
+		sessionManager:  cfg.SessionManager,
+		usageTracker:    cfg.UsageTracker,
+		traceWriter:     cfg.TraceWriter,
 	}
 	s.mux.HandleFunc("/v1/responses", s.handleResponses)
 	s.mux.HandleFunc("/responses", s.handleResponses)
 	s.mux.HandleFunc("/v1/models", s.handleModels)
 	s.mux.HandleFunc("/models", s.handleModels)
-	go s.startSessionPruning()
 	s.registerPluginRoutes()
 	if cfg.Runtime != nil && cfg.Store != nil {
 		apiRouter := api.NewRouter(s.store, s.runtime, s.stats, s.pluginRegistry, s)
@@ -192,6 +238,9 @@ func (s *Server) listModels() []map[string]any {
 }
 
 func (s *Server) currentConfig() config.ServerConfig {
+	if snap := s.runtimeSnapshot(); snap != nil {
+		return config.ServerFromGlobalConfig(&snap.Config)
+	}
 	return s.serverCfg
 }
 
@@ -229,7 +278,6 @@ func (s *Server) Close() error {
 		if s.sessionManager != nil {
 			s.sessionManager.Stop()
 		}
-		close(s.sessionPruneStop)
 	})
 	return nil
 }
@@ -256,8 +304,6 @@ func computeCostWithProviderPricing(pm *provider.ProviderManager, stats *stats.S
 	return stats.ComputeBillingCost(requestModel, usage)
 }
 
-
-
 // slugDisplayName converts a route alias slug to a human-readable display name.
 // e.g. "gpt-5.4" -> "GPT 5.4", "codex-auto-review" -> "Codex Auto Review"
 func slugDisplayName(slug string) string {
@@ -283,8 +329,8 @@ func checkAuth(r *http.Request, expectedToken string) bool {
 }
 
 func (s *Server) resolveModelOrFallback(modelName string) (*provider.ResolvedRoute, error) {
-	if s.providerMgr != nil {
-		return s.providerMgr.ResolveModel(modelName)
+	if pm := s.activeProviderManager(); pm != nil {
+		return pm.ResolveModel(modelName)
 	}
 	if s.provider != nil {
 		return &provider.ResolvedRoute{
@@ -319,7 +365,8 @@ func requestHasImage(input json.RawMessage) bool {
 }
 
 func (s *Server) filterCandidatesByInput(candidates []provider.ProviderCandidate, input json.RawMessage) ([]provider.ProviderCandidate, string) {
-	if s.providerMgr == nil {
+	pm := s.activeProviderManager()
+	if pm == nil {
 		return candidates, ""
 	}
 	hasImage := requestHasImage(input)
@@ -329,7 +376,7 @@ func (s *Server) filterCandidatesByInput(candidates []provider.ProviderCandidate
 	filtered := make([]provider.ProviderCandidate, 0, len(candidates))
 	removedCount := 0
 	for _, c := range candidates {
-		meta, ok := s.providerMgr.ModelMetaFor(c.UpstreamModel, c.ProviderKey)
+		meta, ok := pm.ModelMetaFor(c.UpstreamModel, c.ProviderKey)
 		if !ok || !hasModalityImage(meta.InputModalities) {
 			removedCount++
 			logger.L().Debug("过滤掉不支持图片的提供商候选", "provider", c.ProviderKey, "model", c.UpstreamModel)
@@ -354,15 +401,26 @@ func hasModalityImage(modalities []string) bool {
 }
 
 func newDefaultSessionManager(cfg Config) session.Manager {
-	return session.NewInMemoryManager(&sessionConfigAdapter{serverCfg: cfg.AppConfig}, cfg.PluginRegistry)
+	return session.NewInMemoryManager(&sessionConfigAdapter{runtime: cfg.Runtime, fallback: cfg.AppConfig}, cfg.PluginRegistry)
 }
 
 type sessionConfigAdapter struct {
-	serverCfg config.ServerConfig
+	runtime  *runtime.Runtime
+	fallback config.ServerConfig
+}
+
+func (a *sessionConfigAdapter) currentServerConfig() config.ServerConfig {
+	if a.runtime != nil {
+		snap := a.runtime.Current()
+		if snap != nil {
+			return config.ServerFromGlobalConfig(&snap.Config)
+		}
+	}
+	return a.fallback
 }
 
 func (a *sessionConfigAdapter) SessionTTL() time.Duration {
-	raw := a.serverCfg.SessionTTL
+	raw := a.currentServerConfig().SessionTTL
 	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
 		return d
 	}
@@ -370,9 +428,13 @@ func (a *sessionConfigAdapter) SessionTTL() time.Duration {
 }
 
 func (a *sessionConfigAdapter) MaxSessions() int {
-	return a.serverCfg.MaxSessions
+	return a.currentServerConfig().MaxSessions
 }
 
 func NewSessionConfigAdapter(cfg config.ServerConfig) session.ConfigAccessor {
-	return &sessionConfigAdapter{serverCfg: cfg}
+	return &sessionConfigAdapter{fallback: cfg}
+}
+
+func NewSessionConfigAdapterFromRuntime(rt *runtime.Runtime, fallback config.ServerConfig) session.ConfigAccessor {
+	return &sessionConfigAdapter{runtime: rt, fallback: fallback}
 }

--- a/internal/service/server/session.go
+++ b/internal/service/server/session.go
@@ -5,117 +5,26 @@ import (
 	"strings"
 	"time"
 
-	"moonbridge/internal/session"
 	"moonbridge/internal/service/api"
+	"moonbridge/internal/session"
 )
 
-type serverSession struct {
-	sess     *session.Session
-	lastUsed time.Time
-}
-
-// sessionTTL returns the configured session TTL duration.
-// Defaults to 24 hours if unset or unparseable.
-func (server *Server) sessionTTL() time.Duration {
-	raw := server.currentConfig().SessionTTL
-	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
-		return d
-	}
-	return 24 * time.Hour
-}
-
-// maxSessions returns the configured maximum number of active sessions.
-// 0 means unlimited.
-func (server *Server) maxSessions() int {
-	return server.currentConfig().MaxSessions
-}
-
 func (server *Server) ListSessions() []api.SessionInfo {
-	server.sessionsMu.Lock()
-	defer server.sessionsMu.Unlock()
-	result := make([]api.SessionInfo, 0, len(server.sessions))
-	for key, entry := range server.sessions {
-		result = append(result, api.SessionInfo{
-			Key:       key,
-			CreatedAt: entry.sess.CreatedAt.Format(time.RFC3339),
-			LastUsed:  entry.lastUsed.Format(time.RFC3339),
-		})
+	if server.sessionManager == nil {
+		return nil
 	}
-	return result
+	return server.sessionManager.List()
 }
 
 func (server *Server) sessionForRequest(request *http.Request) *session.Session {
+	if server.sessionManager == nil {
+		return nil
+	}
 	key := sessionKeyFromRequest(request)
 	if key == "" {
-		sess := session.New()
-		// Without a stable session key, we intentionally isolate state per request.
-		// Still, plugins expect ExtensionData to be initialized (even for single-request sessions),
-		// so that per-session caches (e.g. DeepSeek thinking replay) can function when a key is provided.
-		if server.pluginRegistry != nil {
-			sess.InitExtensions(server.pluginRegistry.NewSessionData())
-		} else {
-			sess.InitExtensions(nil)
-		}
-		return sess
+		return server.sessionManager.NewEphemeral()
 	}
-
-	now := time.Now()
-	server.sessionsMu.Lock()
-	defer server.sessionsMu.Unlock()
-
-	server.pruneSessionsLocked(now)
-	if entry, ok := server.sessions[key]; ok {
-		entry.lastUsed = now
-		server.sessions[key] = entry
-		// Backfill ExtensionData if the session was created before plugins were initialized
-		// or before session extension initialization was wired up.
-		if entry.sess != nil && entry.sess.ExtensionData == nil && server.pluginRegistry != nil {
-			entry.sess.InitExtensions(server.pluginRegistry.NewSessionData())
-		}
-		return entry.sess
-	}
-
-	// Enforce max sessions limit when creating a new session.
-	if maxSessions := server.maxSessions(); maxSessions > 0 && len(server.sessions) >= maxSessions {
-		// Evict the LRU (least recently used) session.
-		server.evictLRUSessionLocked()
-	}
-
-	sess := session.NewWithID(key)
-	if server.pluginRegistry != nil {
-		sess.InitExtensions(server.pluginRegistry.NewSessionData())
-	} else {
-		sess.InitExtensions(nil)
-	}
-	server.sessions[key] = serverSession{sess: sess, lastUsed: now}
-	return sess
-}
-
-func (server *Server) pruneSessionsLocked(now time.Time) {
-	ttl := server.sessionTTL()
-	for key, entry := range server.sessions {
-		if now.Sub(entry.lastUsed) > ttl {
-			delete(server.sessions, key)
-		}
-	}
-}
-
-// evictLRUSessionLocked removes the session with the oldest lastUsed timestamp.
-// Must be called with server.sessionsMu held.
-func (server *Server) evictLRUSessionLocked() {
-	var oldestKey string
-	var oldestTime time.Time
-	first := true
-	for key, entry := range server.sessions {
-		if first || entry.lastUsed.Before(oldestTime) {
-			oldestKey = key
-			oldestTime = entry.lastUsed
-			first = false
-		}
-	}
-	if oldestKey != "" {
-		delete(server.sessions, oldestKey)
-	}
+	return server.sessionManager.GetOrCreate(key, time.Now())
 }
 
 func sessionKeyFromRequest(request *http.Request) string {
@@ -126,29 +35,4 @@ func sessionKeyFromRequest(request *http.Request) string {
 		return "codex-window:" + value
 	}
 	return ""
-}
-
-func (server *Server) startSessionPruning() {
-	ticker := time.NewTicker(time.Hour) // prune every hour
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			server.pruneSessions()
-		case <-server.sessionPruneStop:
-			return
-		}
-	}
-}
-
-func (server *Server) pruneSessions() {
-	now := time.Now()
-	server.sessionsMu.Lock()
-	defer server.sessionsMu.Unlock()
-	ttl := server.sessionTTL()
-	for key, entry := range server.sessions {
-		if now.Sub(entry.lastUsed) > ttl {
-			delete(server.sessions, key)
-		}
-	}
 }

--- a/internal/service/server/session/manager.go
+++ b/internal/service/server/session/manager.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"moonbridge/internal/session"
 	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/service/api"
+	"moonbridge/internal/session"
 )
 
 // Manager handles session lifecycle: lookup, creation, TTL enforcement,
@@ -28,6 +28,9 @@ type Manager interface {
 
 	// Stop signals the background pruner goroutine to exit.
 	Stop()
+
+	// NewEphemeral creates a request-scoped session not tracked in the manager.
+	NewEphemeral() *session.Session
 }
 
 // ConfigAccessor provides session-related configuration values.
@@ -84,7 +87,11 @@ func (m *InMemoryManager) GetOrCreate(key string, now time.Time) *session.Sessio
 
 	// Enforce max sessions limit.
 	if maxSessions := m.config.MaxSessions(); maxSessions > 0 && len(m.sessions) >= maxSessions {
-		m.evictLRULocked()
+		for len(m.sessions) >= maxSessions {
+			if !m.evictLRULocked() {
+				break
+			}
+		}
 	}
 
 	sess := session.NewWithID(key)
@@ -124,6 +131,18 @@ func (m *InMemoryManager) Stop() {
 	close(m.pruneStop)
 }
 
+// NewEphemeral creates a request-scoped in-memory session and initializes
+// extension state the same way as tracked sessions.
+func (m *InMemoryManager) NewEphemeral() *session.Session {
+	sess := session.New()
+	if m.pluginRegistry != nil {
+		sess.InitExtensions(m.pluginRegistry.NewSessionData())
+	} else {
+		sess.InitExtensions(nil)
+	}
+	return sess
+}
+
 // startPruning runs a background goroutine that prunes every hour.
 func (m *InMemoryManager) startPruning() {
 	ticker := time.NewTicker(time.Hour)
@@ -150,7 +169,7 @@ func (m *InMemoryManager) pruneLocked(now time.Time) {
 
 // evictLRULocked removes the session with the oldest lastUsed timestamp.
 // Must be called with m.mu held.
-func (m *InMemoryManager) evictLRULocked() {
+func (m *InMemoryManager) evictLRULocked() bool {
 	var oldestKey string
 	var oldestTime time.Time
 	first := true
@@ -163,5 +182,7 @@ func (m *InMemoryManager) evictLRULocked() {
 	}
 	if oldestKey != "" {
 		delete(m.sessions, oldestKey)
+		return true
 	}
+	return false
 }

--- a/internal/service/server/websearch_inject.go
+++ b/internal/service/server/websearch_inject.go
@@ -88,7 +88,7 @@ func injectChatSearchTools(req *chat.ChatRequest, firecrawlKey string) {
 			},
 		})
 	}
-		req.Tools = append(req.Tools, tools...)
+	req.Tools = append(req.Tools, tools...)
 }
 
 // executeChatSearchLoop implements the multi-round search loop for Chat protocol.
@@ -106,7 +106,7 @@ func (s *Server) executeChatSearchLoop(
 		firecrawl = websearch.NewFirecrawlClient(firecrawlKey)
 	}
 
-	for round := 0; round <= maxRounds; round++ {
+	for round := 0; round < maxRounds; round++ {
 		resp, err := client.CreateChat(ctx, req)
 		if err != nil {
 			return nil, err
@@ -294,7 +294,7 @@ func (s *Server) executeGoogleSearchLoop(
 		firecrawl = websearch.NewFirecrawlClient(firecrawlKey)
 	}
 
-	for round := 0; round <= maxRounds; round++ {
+	for round := 0; round < maxRounds; round++ {
 		resp, err := client.GenerateContent(ctx, model, req)
 		if err != nil {
 			return nil, err
@@ -499,7 +499,8 @@ func (s *Server) chatSearchBufferedStream(
 	}
 
 	allEvents := make([]chat.ChatStreamChunk, 0, 128)
-	for round := 0; round <= maxRounds; round++ {
+	exhausted := true
+	for round := 0; round < maxRounds; round++ {
 		stream, err := client.StreamChat(ctx, req)
 		if err != nil {
 			return nil, err
@@ -510,10 +511,11 @@ func (s *Server) chatSearchBufferedStream(
 			return nil, roundErr
 		}
 
-		// Check for tool calls in the last chunk with choices.
-		toolCalls := lastChunkToolCalls(events)
+		// Reconstruct tool calls from all streaming chunks.
+		toolCalls := collectStreamToolCalls(events)
 		if len(toolCalls) == 0 {
 			allEvents = append(allEvents, events...)
+			exhausted = false
 			break
 		}
 
@@ -531,10 +533,12 @@ func (s *Server) chatSearchBufferedStream(
 		}
 		if len(searchCalls) == 0 {
 			allEvents = append(allEvents, events...)
+			exhausted = false
 			break
 		}
 		if len(nonSearchCalls) > 0 {
 			allEvents = append(allEvents, events...)
+			exhausted = false
 			break
 		}
 
@@ -557,14 +561,17 @@ func (s *Server) chatSearchBufferedStream(
 		asstContent := collectChatStreamContent(events)
 		reasoningContent := collectChatStreamReasoning(events)
 		req.Messages = append(req.Messages, chat.ChatMessage{
-			Role:      "assistant",
-			Content:   asstContent,
-			ToolCalls: toolCalls,
+			Role:             "assistant",
+			Content:          asstContent,
+			ToolCalls:        toolCalls,
 			ReasoningContent: reasoningContent,
 		})
 		req.Messages = append(req.Messages, toolResultMsgs...)
 
 		log.Debug("Chat 流式搜索轮次", "round", round+1, "tools_executed", len(searchCalls))
+	}
+	if exhausted && maxRounds > 0 {
+		return nil, fmt.Errorf("chat streaming search loop exceeded max rounds (%d)", maxRounds)
 	}
 
 	// Return all events as a single channel.
@@ -592,17 +599,91 @@ func collectChatStream(ctx context.Context, stream <-chan chat.ChatStreamChunk) 
 	}
 }
 
-// lastChunkToolCalls extracts tool calls from the final chunk that has choices.
-func lastChunkToolCalls(events []chat.ChatStreamChunk) []chat.ToolCall {
-	// Look in reverse for the last chunk with tool calls.
-	for i := len(events) - 1; i >= 0; i-- {
-		for _, sc := range events[i].Choices {
-			if len(sc.Delta.ToolCalls) > 0 {
-				return sc.Delta.ToolCalls
+// collectStreamToolCalls reconstructs tool calls across streaming chunks.
+// Tool call fields (id/name/arguments) may arrive in separate chunks.
+func collectStreamToolCalls(events []chat.ChatStreamChunk) []chat.ToolCall {
+	choiceCalls := make(map[int][]chat.ToolCall)
+	choicePosMap := make(map[int]map[int]int) // choice -> tool call position -> slot index
+	choiceOrder := make([]int, 0, 2)
+
+	for _, ev := range events {
+		for _, sc := range ev.Choices {
+			ci := sc.Index
+			if _, ok := choicePosMap[ci]; !ok {
+				choicePosMap[ci] = make(map[int]int)
+				choiceOrder = append(choiceOrder, ci)
+			}
+			for idx, tc := range sc.Delta.ToolCalls {
+				pos := idx
+				if tc.Index != nil && *tc.Index >= 0 {
+					pos = *tc.Index
+				}
+
+				slot, exists := choicePosMap[ci][pos]
+				if !exists {
+					slot = len(choiceCalls[ci])
+					choicePosMap[ci][pos] = slot
+					choiceCalls[ci] = append(choiceCalls[ci], chat.ToolCall{
+						Type:     "function",
+						Function: chat.ToolCallFunc{},
+					})
+				}
+
+				current := choiceCalls[ci][slot]
+				if tc.ID != "" {
+					current.ID = tc.ID
+				}
+				if tc.Type != "" {
+					current.Type = tc.Type
+				}
+				if tc.Function.Name != "" {
+					current.Function.Name = tc.Function.Name
+				}
+				if len(tc.Function.Arguments) > 0 {
+					existing := string(current.Function.Arguments)
+					current.Function.Arguments = json.RawMessage(appendToolCallArgs(existing, tc.Function.Arguments))
+				}
+				choiceCalls[ci][slot] = current
 			}
 		}
 	}
+
+	for _, ci := range choiceOrder {
+		merged := choiceCalls[ci]
+		if len(merged) == 0 {
+			continue
+		}
+		return merged
+	}
 	return nil
+}
+
+// appendToolCallArgs appends delta arguments to the current accumulated JSON text.
+func appendToolCallArgs(current string, delta json.RawMessage) string {
+	if len(delta) == 0 {
+		return current
+	}
+	decoded := unquoteRawJSON(delta)
+	if len(decoded) == 0 {
+		return current
+	}
+	part := string(decoded)
+	if current == "" {
+		return part
+	}
+	// Prefer the newer payload when both sides are complete JSON values.
+	// Some providers emit snapshots instead of strict deltas.
+	if json.Valid([]byte(current)) && json.Valid([]byte(part)) {
+		return part
+	}
+	// Handle cumulative chunks (new part already contains old prefix/suffix).
+	if strings.HasPrefix(part, current) {
+		return part
+	}
+	if strings.HasSuffix(current, part) {
+		return current
+	}
+	return current + part
 }
 
 // collectChatStreamContent builds the assistant's full text content from all chunks.
@@ -627,7 +708,6 @@ func collectChatStreamReasoning(events []chat.ChatStreamChunk) string {
 	}
 	return sb.String()
 }
-
 
 // unquoteRawJSON unwraps a JSON-string-encoded value.
 // Chat API returns function.arguments as a quoted JSON string. When stored as

--- a/internal/service/server/websearch_inject_test.go
+++ b/internal/service/server/websearch_inject_test.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"moonbridge/internal/protocol/chat"
+)
+
+type wsInjectRTFunc func(*http.Request) (*http.Response, error)
+
+func (fn wsInjectRTFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func newTestChatClient(t *testing.T, rt http.RoundTripper) *chat.Client {
+	t.Helper()
+	return chat.NewClient(chat.ClientConfig{
+		BaseURL: "https://chat.example.test",
+		APIKey:  "chat-key",
+		Client:  &http.Client{Transport: rt},
+	})
+}
+
+func sseBody(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func TestCollectStreamToolCalls_ReconstructsAcrossChunks(t *testing.T) {
+	idx0 := 0
+	idx1 := 1
+	events := []chat.ChatStreamChunk{
+		{
+			Choices: []chat.StreamChoice{{
+				Index: 0,
+				Delta: chat.Delta{
+					Role: "assistant",
+					ToolCalls: []chat.ToolCall{
+						{Index: &idx0, ID: "call_a", Type: "function", Function: chat.ToolCallFunc{Name: "tool_a", Arguments: json.RawMessage(``)}},
+						{Index: &idx1, ID: "call_b", Type: "function", Function: chat.ToolCallFunc{Name: "tool_b", Arguments: json.RawMessage(``)}},
+					},
+				},
+			}},
+		},
+		{
+			Choices: []chat.StreamChoice{{
+				Index: 0,
+				Delta: chat.Delta{
+					ToolCalls: []chat.ToolCall{
+						{Index: &idx1, Function: chat.ToolCallFunc{Arguments: json.RawMessage(`"{\"b\":2}"`)}},
+						{Index: &idx0, Function: chat.ToolCallFunc{Arguments: json.RawMessage(`"{\"a\":1}"`)}},
+					},
+				},
+			}},
+		},
+		{
+			Choices: []chat.StreamChoice{{
+				Index: 0,
+				Delta: chat.Delta{
+					ToolCalls: []chat.ToolCall{
+						{Index: &idx0, Function: chat.ToolCallFunc{Arguments: json.RawMessage(`""`)}},
+					},
+				},
+			}},
+		},
+	}
+
+	got := collectStreamToolCalls(events)
+	if len(got) != 2 {
+		t.Fatalf("tool calls=%d, want 2", len(got))
+	}
+	if got[0].ID != "call_a" || got[0].Function.Name != "tool_a" {
+		t.Fatalf("tool[0]=%+v", got[0])
+	}
+	if got[1].ID != "call_b" || got[1].Function.Name != "tool_b" {
+		t.Fatalf("tool[1]=%+v", got[1])
+	}
+	var a map[string]any
+	if err := json.Unmarshal(unquoteRawJSON(got[0].Function.Arguments), &a); err != nil {
+		t.Fatalf("tool[0] args invalid json: %v (%s)", err, string(got[0].Function.Arguments))
+	}
+	var b map[string]any
+	if err := json.Unmarshal(unquoteRawJSON(got[1].Function.Arguments), &b); err != nil {
+		t.Fatalf("tool[1] args invalid json: %v (%s)", err, string(got[1].Function.Arguments))
+	}
+	if fmt.Sprint(a["a"]) != "1" {
+		t.Fatalf("tool[0] arg a=%v", a["a"])
+	}
+	if fmt.Sprint(b["b"]) != "2" {
+		t.Fatalf("tool[1] arg b=%v", b["b"])
+	}
+}
+
+func TestChatSearchBufferedStream_NoToolCallPassThrough(t *testing.T) {
+	client := newTestChatClient(t, wsInjectRTFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method=%s", r.Method)
+		}
+		body := sseBody(
+			`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`,
+			`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" world"}}]}`,
+			`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			`data: [DONE]`,
+		)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		}, nil
+	}))
+
+	srv := &Server{}
+	req := &chat.ChatRequest{
+		Model:    "gpt-test",
+		Messages: []chat.ChatMessage{{Role: "user", Content: "hi"}},
+	}
+	ch, err := srv.chatSearchBufferedStream(context.Background(), client, req, "", "", 2)
+	if err != nil {
+		t.Fatalf("chatSearchBufferedStream error: %v", err)
+	}
+	var chunks []chat.ChatStreamChunk
+	for c := range ch {
+		chunks = append(chunks, c)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("chunks=%d, want 3", len(chunks))
+	}
+	if len(req.Messages) != 1 {
+		t.Fatalf("messages should not be expanded on no-tool path, got %d", len(req.Messages))
+	}
+}
+
+func TestChatSearchBufferedStream_ExceedsMaxRounds(t *testing.T) {
+	attempt := 0
+	client := newTestChatClient(t, wsInjectRTFunc(func(r *http.Request) (*http.Response, error) {
+		attempt++
+		sse := sseBody(
+			`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"tavily_search","arguments":""}}]}}]}`,
+			`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"query\":\"\"}"}}]}}]}`,
+			`data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+			`data: [DONE]`,
+		)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(sse)),
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		}, nil
+	}))
+
+	srv := &Server{}
+	req := &chat.ChatRequest{
+		Model:    "gpt-test",
+		Messages: []chat.ChatMessage{{Role: "user", Content: "search hi"}},
+	}
+	_, err := srv.chatSearchBufferedStream(context.Background(), client, req, "", "", 1)
+	if err == nil {
+		t.Fatal("expected max-rounds error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeded max rounds") {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if attempt != 1 {
+		t.Fatalf("attempts=%d, want 1", attempt)
+	}
+}

--- a/internal/service/store/sqlite_store.go
+++ b/internal/service/store/sqlite_store.go
@@ -6,20 +6,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"moonbridge/internal/config"
 	"moonbridge/internal/db"
-
 )
 
 // SQLiteConfigStore implements ConfigStore backed by a SQLite database.
 type SQLiteConfigStore struct {
-	db      db.Store
-	logger  *slog.Logger
-	applyMu sync.Mutex
+	db             db.Store
+	logger         *slog.Logger
+	applyMu        sync.Mutex
 	extensionSpecs []config.ExtensionConfigSpec
 }
 
@@ -215,6 +215,8 @@ func buildSettings(fc config.FileConfig) map[string]string {
 		"mode":           fc.Mode,
 		"addr":           fc.Server.Addr,
 		"auth_token":     fc.Server.AuthToken,
+		"max_sessions":   fmt.Sprintf("%d", fc.Server.MaxSessions),
+		"session_ttl":    fc.Server.SessionTTL,
 		"trace_requests": jsonStr(fc.Trace.Enabled),
 		"log_level":      fc.Log.Level,
 		"log_format":     fc.Log.Format,
@@ -229,6 +231,7 @@ func buildSettings(fc config.FileConfig) map[string]string {
 	}
 	return settings
 }
+
 // --- LoadAll ---
 
 // LoadAll reads the complete configuration from the main tables.
@@ -422,6 +425,12 @@ func applySetting(fc *config.FileConfig, key, value string) {
 		fc.Server.Addr = value
 	case "auth_token":
 		fc.Server.AuthToken = value
+	case "max_sessions":
+		if v, err := strconv.Atoi(value); err == nil {
+			fc.Server.MaxSessions = v
+		}
+	case "session_ttl":
+		fc.Server.SessionTTL = value
 	case "trace_requests":
 		var enabled bool
 		if err := json.Unmarshal([]byte(value), &enabled); err == nil {
@@ -463,6 +472,7 @@ func applySetting(fc *config.FileConfig, key, value string) {
 		}
 	}
 }
+
 // --- StageChange ---
 
 func (s *SQLiteConfigStore) StageChange(ch ChangeRow) (int64, error) {
@@ -803,6 +813,7 @@ func (s *SQLiteConfigStore) deleteResourceTx(ctx context.Context, tx db.Tx, reso
 	}
 	return nil
 }
+
 // --- field helpers ---
 
 func addField(clauses *[]string, args *[]any, name string, fields map[string]any) {

--- a/internal/service/store/sqlite_store_test.go
+++ b/internal/service/store/sqlite_store_test.go
@@ -63,6 +63,12 @@ func TestSQLiteStoreSeedLoadRoundtrip(t *testing.T) {
 	if cfg.AuthToken != cfg2.AuthToken {
 		t.Fatalf("AuthToken: got %q, want %q", cfg2.AuthToken, cfg.AuthToken)
 	}
+	if cfg.MaxSessions != cfg2.MaxSessions {
+		t.Fatalf("MaxSessions: got %d, want %d", cfg2.MaxSessions, cfg.MaxSessions)
+	}
+	if cfg.SessionTTL != cfg2.SessionTTL {
+		t.Fatalf("SessionTTL: got %q, want %q", cfg2.SessionTTL, cfg.SessionTTL)
+	}
 	if cfg.Defaults.Model != cfg2.Defaults.Model {
 		t.Fatalf("Defaults.Model: got %q, want %q", cfg2.Defaults.Model, cfg.Defaults.Model)
 	}
@@ -219,6 +225,8 @@ func buildTestConfig() *config.Config {
 		Mode:             config.ModeTransform,
 		Addr:             "127.0.0.1:38440",
 		AuthToken:        "test-token",
+		MaxSessions:      42,
+		SessionTTL:       "36h",
 		TraceRequests:    true,
 		LogLevel:         "debug",
 		LogFormat:        "json",
@@ -282,8 +290,8 @@ func buildTestConfig() *config.Config {
 		},
 		Routes: map[string]config.RouteEntry{
 			"moonbridge": {
-				Provider:   "anthropic",
-				Model:      "claude-sonnet-4-20250514",
+				Provider:    "anthropic",
+				Model:       "claude-sonnet-4-20250514",
 				DisplayName: "Moonbridge Sonnet",
 			},
 			"fast": {
@@ -542,7 +550,6 @@ func TestSQLiteStoreApplyProviderCreateAndDelete(t *testing.T) {
 		t.Fatal("new provider should have been deleted")
 	}
 }
-
 
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)


### PR DESCRIPTION
# 将 `codex/bugfix` 合并到 `main`

## 概要

这个 PR 将 `codex/bugfix` 分支合并到 `main`，集中修复 Moon Bridge 在协议转换、流式输出、工具调用回放、插件运行时配置和 Web Search 等链路上的一批问题。

主要目标是提升 Codex/OpenAI Responses 兼容性，尤其是请求经过不同上游协议时，涉及 MCP/自定义工具、reasoning/thinking 块、视觉工具循环、注入式 Web Search 或运行时配置持久化的场景。

## 变更内容

- 修复 Codex 自定义工具转换与回放：
  - 在 `AnnotateCoreTool` 中保留原始工具名，避免 MCP 工具名前缀被重复拼接。
  - 从结构化代理调用中更可靠地还原 `apply_patch` 和 `exec` 的自定义工具语法。
  - 支持 custom/local 工具类型，并强化 schema fallback 处理。

- 加固 OpenAI Responses、Chat、Anthropic 和 Gemini 协议适配：
  - 保持 reasoning item 之间的 tool result 邻接关系。
  - Chat 流式工具调用按 tool-call index 维护槽位，不再假设最后一个 chunk 一定包含完整调用。
  - 在 Anthropic 风格和 Chat 风格路径中都保留 DeepSeek reasoning/thinking 回放。
  - dispatch wrapper 可接受指针形式的 Anthropic request，以及值类型的 Anthropic message response。
  - 为 Gemini 重复 function call 生成不同的 tool-use ID。

- 改进服务端分发与编排：
  - 增加 finalizing adapter core provider，使包装后的流程可以规范化上游请求/响应类型。
  - 加强非流式和流式 adapter dispatch 测试。
  - 将 model alias context 传给 Core plugin hooks，确保插件只在启用的模型上运行。
  - 视觉循环每轮克隆 Core request，减少请求对象被跨轮污染的风险。

- 修复视觉工具和 Web Search 循环：
  - 在视觉路径中保留 DeepSeek thinking replay。
  - 汇总视觉编排多轮请求的 usage。
  - 按 provider/model candidate 解析 Web Search 模式，而不是只按 provider 解析。
  - 为 Chat provider 跨 chunk 重建流式 search tool call。
  - 注入式 search loop 追加 tool result 时保留完整 assistant content。
  - 可用时使用 model/provider 级别的 Tavily、Firecrawl 和 max-round 配置。

- 修复插件、运行时配置和持久化行为：
  - 同步 runtime config 与 plugin registry 的配置访问。
  - 增加 app 持久化辅助逻辑，用于解析 active provider。
  - 确保 DB/config-store bootstrap 能一致地重建 provider manager、pricing 和 server config。
  - 扩展 plugin registry 测试，覆盖插件能力分发和运行时配置访问。

## 测试

新增或扩展了以下覆盖：

- Codex catalog 与自定义工具转换
- Plugin registry 行为
- Visual core orchestration 与 visual plugin 路由
- Web Search orchestration 与注入式 search loop
- OpenAI、Anthropic、Chat 和 Google 协议适配器
- Server adapter dispatch 与 candidate routing
- Runtime app config 与持久化路径
- Provider manager 路由与 Web Search candidate 解析
- SQLite config store 行为

合并前建议验证：

```bash
go test ./...
```

## 备注

- 这个分支触及较多请求/响应转换链路，风险较高的区域主要是流式工具调用、reasoning replay 和多轮工具循环。
- 本次 diff 主要是 bug fix 和回归测试，没有有意移除公开 API。