### PR TITLE
fix: 合并 codex/bugfix 分支 — 覆盖场景工具调用、Adapter 统一和配置持久化

### DIFF
--- a/internal/service/proxy/common.go
+++ b/internal/service/proxy/common.go
@@ -75,12 +75,24 @@ func writeTrace(tracer *mbtrace.Tracer, traceErrors io.Writer, record mbtrace.Re
 
 func copyHeaders(dst http.Header, src http.Header) {
 	for key, values := range src {
-		if isHopByHopHeader(key) || strings.EqualFold(key, "host") || strings.EqualFold(key, "accept-encoding") {
+		if isHopByHopHeader(key) || isUpstreamManagedHeader(key) ||
+			strings.EqualFold(key, "host") || strings.EqualFold(key, "accept-encoding") {
 			continue
 		}
 		for _, value := range values {
 			dst.Add(key, value)
 		}
+	}
+}
+
+func isUpstreamManagedHeader(key string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(key))
+	normalized = strings.ReplaceAll(normalized, "_", "-")
+	switch normalized {
+	case "authorization", "proxy-authorization", "x-api-key", "api-key", "apikey", "anthropic-api-key", "openai-api-key":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/service/proxy/proxy_test.go
+++ b/internal/service/proxy/proxy_test.go
@@ -24,11 +24,15 @@ func TestResponseProxyPassesHeadersThroughAndCapturesTrace(t *testing.T) {
 	var upstreamPath string
 	var upstreamAuth string
 	var upstreamAPIKey string
+	var upstreamOpenAIAPIKey string
+	var upstreamAltAPIKey string
 	var upstreamUserAgent string
 	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		upstreamPath = request.URL.RequestURI()
 		upstreamAuth = request.Header.Get("Authorization")
 		upstreamAPIKey = request.Header.Get("X-Api-Key")
+		upstreamOpenAIAPIKey = request.Header.Get("OpenAI-Api-Key")
+		upstreamAltAPIKey = request.Header.Get("Api-Key")
 		upstreamUserAgent = request.Header.Get("User-Agent")
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -51,6 +55,8 @@ func TestResponseProxyPassesHeadersThroughAndCapturesTrace(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-test","input":"hello"}`))
 	request.Header.Set("Authorization", "Bearer native-openai-key")
 	request.Header.Set("X-Api-Key", "client-side-extra-key")
+	request.Header.Set("OpenAI-Api-Key", "client-openai-api-key")
+	request.Header.Set("Api-Key", "client-generic-api-key")
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("User-Agent", "codex-test-agent")
 	recorder := httptest.NewRecorder()
@@ -66,8 +72,14 @@ func TestResponseProxyPassesHeadersThroughAndCapturesTrace(t *testing.T) {
 	if upstreamAuth != "Bearer upstream-openai-key" {
 		t.Fatalf("upstream auth = %q", upstreamAuth)
 	}
-	if upstreamAPIKey != "client-side-extra-key" {
-		t.Fatalf("upstream api key = %q", upstreamAPIKey)
+	if upstreamAPIKey != "" {
+		t.Fatalf("upstream x-api-key = %q, want empty", upstreamAPIKey)
+	}
+	if upstreamOpenAIAPIKey != "" {
+		t.Fatalf("upstream openai-api-key = %q, want empty", upstreamOpenAIAPIKey)
+	}
+	if upstreamAltAPIKey != "" {
+		t.Fatalf("upstream api-key = %q, want empty", upstreamAltAPIKey)
 	}
 	if upstreamUserAgent != "codex-test-agent" {
 		t.Fatalf("upstream user-agent = %q", upstreamUserAgent)
@@ -94,12 +106,16 @@ func TestAnthropicProxyPassesHeadersThrough(t *testing.T) {
 	var upstreamPath string
 	var upstreamAuth string
 	var upstreamAPIKey string
+	var upstreamAnthropicAPIKey string
+	var upstreamAltAPIKey string
 	var upstreamVersion string
 	var upstreamUserAgent string
 	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		upstreamPath = request.URL.RequestURI()
 		upstreamAuth = request.Header.Get("Authorization")
 		upstreamAPIKey = request.Header.Get("X-Api-Key")
+		upstreamAnthropicAPIKey = request.Header.Get("Anthropic-Api-Key")
+		upstreamAltAPIKey = request.Header.Get("Api-Key")
 		upstreamVersion = request.Header.Get("Anthropic-Version")
 		upstreamUserAgent = request.Header.Get("User-Agent")
 		return &http.Response{
@@ -122,6 +138,8 @@ func TestAnthropicProxyPassesHeadersThrough(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude","messages":[]}`))
 	request.Header.Set("Authorization", "Bearer client-placeholder-token")
 	request.Header.Set("X-Api-Key", "client-anthropic-key")
+	request.Header.Set("Anthropic-Api-Key", "client-anthropic-alias-key")
+	request.Header.Set("Api-Key", "client-generic-api-key")
 	request.Header.Set("Anthropic-Version", "2023-01-01")
 	request.Header.Set("User-Agent", "anthropic-sdk-test")
 	recorder := httptest.NewRecorder()
@@ -139,6 +157,12 @@ func TestAnthropicProxyPassesHeadersThrough(t *testing.T) {
 	}
 	if upstreamAPIKey != "upstream-anthropic-key" {
 		t.Fatalf("upstream api key = %q", upstreamAPIKey)
+	}
+	if upstreamAnthropicAPIKey != "" {
+		t.Fatalf("upstream anthropic-api-key = %q, want empty", upstreamAnthropicAPIKey)
+	}
+	if upstreamAltAPIKey != "" {
+		t.Fatalf("upstream api-key = %q, want empty", upstreamAltAPIKey)
 	}
 	if upstreamVersion != "2023-06-01" {
 		t.Fatalf("upstream version = %q", upstreamVersion)

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -588,6 +588,8 @@ func (s *Server) handleWithAdapters(
 		return
 	}
 
+	rememberAdapterResponseContent(s.pluginRegistry, sess, openAIReq.Model, coreResp)
+
 	// ------------------------------------------------------------------
 	// 8. Write the response.
 	// ------------------------------------------------------------------
@@ -660,6 +662,131 @@ func (s *Server) handleWithAdapters(
 			})
 		}
 	}
+}
+
+func rememberAdapterResponseContent(registry *plugin.Registry, sess *session.Session, model string, coreResp *format.CoreResponse) {
+	if registry == nil || sess == nil || coreResp == nil {
+		return
+	}
+	reqCtx := &plugin.RequestContext{
+		ModelAlias:  model,
+		SessionData: sess.ExtensionData,
+	}
+	for _, msg := range coreResp.Messages {
+		if msg.Role != "assistant" || len(msg.Content) == 0 {
+			continue
+		}
+		registry.RememberContent(reqCtx, msg.Content)
+	}
+}
+
+func rememberStreamResponseContent(registry *plugin.Registry, sess *session.Session, model string, resp *openai.Response) bool {
+	if registry == nil || sess == nil || resp == nil {
+		return false
+	}
+	reqCtx := &plugin.RequestContext{
+		ModelAlias:  model,
+		SessionData: sess.ExtensionData,
+	}
+	var pending []format.CoreContentBlock
+	remembered := false
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		registry.RememberContent(reqCtx, pending)
+		pending = nil
+		remembered = true
+	}
+
+	for _, item := range resp.Output {
+		blocks := streamOutputItemToCoreBlocks(item)
+		if len(blocks) == 0 {
+			continue
+		}
+		if item.Type == "reasoning" && len(pending) > 0 {
+			flush()
+		}
+		pending = append(pending, blocks...)
+	}
+	flush()
+	return remembered
+}
+
+func streamOutputItemToCoreBlocks(item openai.OutputItem) []format.CoreContentBlock {
+	switch item.Type {
+	case "reasoning":
+		return reasoningBlocksFromStreamOutput(item.Summary)
+	case "function_call", "custom_tool_call", "local_shell_call":
+		toolUseID := firstNonEmptyString(item.CallID, item.ID)
+		if toolUseID == "" {
+			return nil
+		}
+		return []format.CoreContentBlock{{
+			Type:      "tool_use",
+			ToolUseID: toolUseID,
+			ToolName:  item.Name,
+			ToolInput: streamOutputToolInput(item),
+		}}
+	case "message":
+		blocks := make([]format.CoreContentBlock, 0, len(item.Content))
+		for _, part := range item.Content {
+			if (part.Type == "text" || part.Type == "output_text") && part.Text != "" {
+				blocks = append(blocks, format.CoreContentBlock{
+					Type: "text",
+					Text: part.Text,
+				})
+			}
+		}
+		return blocks
+	default:
+		return nil
+	}
+}
+
+func reasoningBlocksFromStreamOutput(summary []openai.ReasoningItemSummary) []format.CoreContentBlock {
+	blocks := make([]format.CoreContentBlock, 0, len(summary))
+	for _, item := range summary {
+		if item.Text == "" && item.Signature == "" {
+			continue
+		}
+		if block, ok := deepseekv4.DecodeThinkingSummary(item.Text); ok {
+			if block.ReasoningSignature == "" && item.Signature != "" {
+				block.ReasoningSignature = item.Signature
+			}
+			blocks = append(blocks, block)
+			continue
+		}
+		blocks = append(blocks, format.CoreContentBlock{
+			Type:               "reasoning",
+			ReasoningText:      item.Text,
+			ReasoningSignature: item.Signature,
+		})
+	}
+	return blocks
+}
+
+func streamOutputToolInput(item openai.OutputItem) json.RawMessage {
+	if item.Arguments != "" && json.Valid([]byte(item.Arguments)) {
+		return json.RawMessage(item.Arguments)
+	}
+	if item.Input == "" {
+		return nil
+	}
+	payload, err := json.Marshal(map[string]string{"input": item.Input})
+	if err != nil {
+		return nil
+	}
+	return payload
+}
+
+func firstNonEmptyString(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // handleAdapterStream handles the streaming path through adapter dispatch.
@@ -1250,36 +1377,39 @@ func (s *Server) handleAdapterStream(
 	// Remember reasoning content for DeepSeek thinking replay via StreamInterceptor.
 	// This must not depend on trace being enabled.
 	if s.pluginRegistry != nil && sess != nil {
-		if anthProvider, ok := s.adapterRegistry.GetProvider(config.ProtocolAnthropic); ok {
-			if anthAdapter, ok := anthProvider.(*anthropic.AnthropicProviderAdapter); ok {
-				events := anthAdapter.StreamBuffer()
-				if len(events) > 0 {
-					states := s.pluginRegistry.NewStreamStates(openAIReq.Model)
-					for _, ev := range events {
-						pluginType := ""
-						switch {
-						case ev.Type == "content_block_start":
-							pluginType = "block_start"
-						case ev.Type == "content_block_delta":
-							pluginType = "block_delta"
-						case ev.Type == "content_block_stop":
-							pluginType = "block_stop"
+		remembered := rememberStreamResponseContent(s.pluginRegistry, sess, openAIReq.Model, finalResp)
+		if !remembered {
+			if anthProvider, ok := s.adapterRegistry.GetProvider(config.ProtocolAnthropic); ok {
+				if anthAdapter, ok := anthProvider.(*anthropic.AnthropicProviderAdapter); ok {
+					events := anthAdapter.StreamBuffer()
+					if len(events) > 0 {
+						states := s.pluginRegistry.NewStreamStates(openAIReq.Model)
+						for _, ev := range events {
+							pluginType := ""
+							switch {
+							case ev.Type == "content_block_start":
+								pluginType = "block_start"
+							case ev.Type == "content_block_delta":
+								pluginType = "block_delta"
+							case ev.Type == "content_block_stop":
+								pluginType = "block_stop"
+							}
+							if pluginType == "" {
+								continue
+							}
+							s.pluginRegistry.OnStreamEvent(openAIReq.Model, plugin.StreamEvent{
+								Type:  pluginType,
+								Index: ev.Index,
+								Block: anthropicContentBlockPtrToFormat(ev.ContentBlock),
+								Delta: ev.Delta,
+							}, states)
 						}
-						if pluginType == "" {
-							continue
+						outputText := ""
+						if finalResp != nil {
+							outputText = finalResp.OutputText
 						}
-						s.pluginRegistry.OnStreamEvent(openAIReq.Model, plugin.StreamEvent{
-							Type:  pluginType,
-							Index: ev.Index,
-							Block: anthropicContentBlockPtrToFormat(ev.ContentBlock),
-							Delta: ev.Delta,
-						}, states)
+						s.pluginRegistry.OnStreamComplete(openAIReq.Model, states, outputText, sess.ExtensionData)
 					}
-					outputText := ""
-					if finalResp != nil {
-						outputText = finalResp.OutputText
-					}
-					s.pluginRegistry.OnStreamComplete(openAIReq.Model, states, outputText, sess.ExtensionData)
 				}
 			}
 		}

--- a/internal/service/server/candidate_routing_test.go
+++ b/internal/service/server/candidate_routing_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	deepseekv4 "moonbridge/internal/extension/deepseek_v4"
+	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/format"
 	"moonbridge/internal/protocol/anthropic"
+	openai "moonbridge/internal/protocol/openai"
 	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/stats"
 	"moonbridge/internal/session"
@@ -152,5 +154,199 @@ func TestPrependCachedThinkingChecksAllToolUseBlocks(t *testing.T) {
 	head := req.Messages[0].Content[0]
 	if head.Type != "thinking" || head.Thinking != "replayed" || head.Signature != "sig-hit" {
 		t.Fatalf("cached thinking block mismatch, got %+v", head)
+	}
+}
+
+func TestRememberAdapterResponseContentCachesDeepSeekThinkingForLaterReplay(t *testing.T) {
+	registry := plugin.NewRegistry(nil)
+	dsPlugin := deepseekv4.NewPlugin(func(string) bool { return true })
+	registry.Register(dsPlugin)
+	if err := registry.InitAll(nil); err != nil {
+		t.Fatalf("InitAll() error = %v", err)
+	}
+
+	sess := session.New()
+	sess.InitExtensions(registry.NewSessionData())
+
+	resp := &format.CoreResponse{
+		Messages: []format.CoreMessage{{
+			Role: "assistant",
+			Content: []format.CoreContentBlock{
+				{
+					Type:               "reasoning",
+					ReasoningText:      "trace reasoning",
+					ReasoningSignature: "sig-trace",
+				},
+				{
+					Type:      "tool_use",
+					ToolUseID: "call-trace",
+					ToolName:  "exec_command",
+					ToolInput: json.RawMessage(`{"cmd":"pwd"}`),
+				},
+				{
+					Type: "text",
+					Text: "assistant tool turn",
+				},
+			},
+		}},
+	}
+
+	rememberAdapterResponseContent(registry, sess, "deepseek-v4-flash", resp)
+
+	req := &anthropic.MessageRequest{
+		Messages: []anthropic.Message{{
+			Role: "assistant",
+			Content: []anthropic.ContentBlock{
+				{Type: "tool_use", ID: "call-trace", Name: "exec_command", Input: json.RawMessage(`{"cmd":"pwd"}`)},
+			},
+		}},
+	}
+
+	prependCachedThinking(req, sess)
+
+	if len(req.Messages[0].Content) < 2 {
+		t.Fatalf("assistant message should prepend cached thinking, got %+v", req.Messages[0].Content)
+	}
+	head := req.Messages[0].Content[0]
+	if head.Type != "thinking" || head.Thinking != "trace reasoning" || head.Signature != "sig-trace" {
+		t.Fatalf("prepended thinking block mismatch, got %+v", head)
+	}
+}
+
+func TestStreamReplayCachesDeepSeekThinkingForLaterReplay(t *testing.T) {
+	registry := plugin.NewRegistry(nil)
+	dsPlugin := deepseekv4.NewPlugin(func(string) bool { return true })
+	registry.Register(dsPlugin)
+	if err := registry.InitAll(nil); err != nil {
+		t.Fatalf("InitAll() error = %v", err)
+	}
+
+	sess := session.New()
+	sess.InitExtensions(registry.NewSessionData())
+
+	states := registry.NewStreamStates("deepseek-v4-flash")
+	if states == nil {
+		t.Fatal("NewStreamStates() returned nil")
+	}
+
+	streamEvents := []plugin.StreamEvent{
+		{
+			Type:  "block_start",
+			Index: 0,
+			Block: &format.CoreContentBlock{
+				Type:               "reasoning",
+				ReasoningText:      "",
+				ReasoningSignature: "",
+			},
+		},
+		{
+			Type:  "block_delta",
+			Index: 0,
+			Delta: anthropic.StreamDelta{
+				Type:     "thinking_delta",
+				Thinking: "stream reasoning",
+			},
+		},
+		{
+			Type:  "block_delta",
+			Index: 0,
+			Delta: anthropic.StreamDelta{
+				Type:      "signature_delta",
+				Signature: "sig-stream",
+			},
+		},
+		{
+			Type:  "block_stop",
+			Index: 0,
+		},
+		{
+			Type:  "block_start",
+			Index: 1,
+			Block: &format.CoreContentBlock{
+				Type:      "tool_use",
+				ToolUseID: "call-stream",
+				ToolName:  "exec_command",
+			},
+		},
+	}
+
+	for _, ev := range streamEvents {
+		registry.OnStreamEvent("deepseek-v4-flash", ev, states)
+	}
+	registry.OnStreamComplete("deepseek-v4-flash", states, "", sess.ExtensionData)
+
+	req := &anthropic.MessageRequest{
+		Messages: []anthropic.Message{{
+			Role: "assistant",
+			Content: []anthropic.ContentBlock{
+				{Type: "tool_use", ID: "call-stream", Name: "exec_command", Input: json.RawMessage(`{"cmd":"pwd"}`)},
+			},
+		}},
+	}
+
+	prependCachedThinking(req, sess)
+
+	if len(req.Messages[0].Content) < 2 {
+		t.Fatalf("assistant message should prepend cached thinking, got %+v", req.Messages[0].Content)
+	}
+	head := req.Messages[0].Content[0]
+	if head.Type != "thinking" || head.Thinking != "stream reasoning" || head.Signature != "sig-stream" {
+		t.Fatalf("prepended stream thinking block mismatch, got %+v", head)
+	}
+}
+
+func TestRememberStreamResponseContentCachesDeepSeekThinkingForLaterReplay(t *testing.T) {
+	registry := plugin.NewRegistry(nil)
+	dsPlugin := deepseekv4.NewPlugin(func(string) bool { return true })
+	registry.Register(dsPlugin)
+	if err := registry.InitAll(nil); err != nil {
+		t.Fatalf("InitAll() error = %v", err)
+	}
+
+	sess := session.New()
+	sess.InitExtensions(registry.NewSessionData())
+
+	streamResp := &openai.Response{
+		Output: []openai.OutputItem{
+			{
+				Type:   "reasoning",
+				Status: "completed",
+				Summary: []openai.ReasoningItemSummary{{
+					Type:      "text",
+					Text:      "trace stream reasoning",
+					Signature: "sig-trace-stream",
+				}},
+			},
+			{
+				Type:      "function_call",
+				CallID:    "call-stream-trace",
+				Name:      "exec_command",
+				Arguments: `{"cmd":"pwd"}`,
+				Status:    "completed",
+			},
+		},
+	}
+
+	if !rememberStreamResponseContent(registry, sess, "deepseek-v4-flash", streamResp) {
+		t.Fatal("rememberStreamResponseContent() = false, want true")
+	}
+
+	req := &anthropic.MessageRequest{
+		Messages: []anthropic.Message{{
+			Role: "assistant",
+			Content: []anthropic.ContentBlock{
+				{Type: "tool_use", ID: "call-stream-trace", Name: "exec_command", Input: json.RawMessage(`{"cmd":"pwd"}`)},
+			},
+		}},
+	}
+
+	prependCachedThinking(req, sess)
+
+	if len(req.Messages[0].Content) < 2 {
+		t.Fatalf("assistant message should prepend cached thinking, got %+v", req.Messages[0].Content)
+	}
+	head := req.Messages[0].Content[0]
+	if head.Type != "thinking" || head.Thinking != "trace stream reasoning" || head.Signature != "sig-trace-stream" {
+		t.Fatalf("prepended stream-response thinking block mismatch, got %+v", head)
 	}
 }


### PR DESCRIPTION
## 概述

将 `codex/bugfix` 分支中已验证的两个修复合并回 `main`。

## Commits

- [`2486243`](https://github.com/ZhiYi-R/moon-bridge/commit/2486243) fix(proxy): strip client auth headers before upstream forwarding
- [`b6c8e12`](https://github.com/ZhiYi-R/moon-bridge/commit/b6c8e12) feat(adapter): 统一非流式/流式响应的推理内容记忆，支持 OpenAI 原生流输出

## 涉及模块

- **Proxy**: 屏蔽客户端认证头向上游转发，避免认证信息泄漏
- **Adapter**: 统一流式/非流式响应的推理内容记忆逻辑，适配 OpenAI 原生流输出格式

## 变更统计

```
 4 files changed, 392 insertions(+), 30 deletions(-)

 internal/service/proxy/common.go                  |  14 +-
 internal/service/proxy/proxy_test.go              |  28 +++-
 internal/service/server/adapter_dispatch.go       | 184 +++++++++++++++++---
 internal/service/server/candidate_routing_test.go | 196 ++++++++++++++++++++++
```