### PR TITLE
feat(visual): openai-chat 协议下视觉扩展无效——补齐 dispatch 接入

### DIFF
--- a/internal/e2e/visual_chat_e2e_test.go
+++ b/internal/e2e/visual_chat_e2e_test.go
@@ -1,0 +1,201 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	visualpkg "moonbridge/internal/extension/visual"
+	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/chat"
+)
+
+// TestVisualOnOpenAIChat_OrchestratesBriefAcrossTwoMocks proves the visual
+// orchestrator works end-to-end on the openai-chat protocol:
+//
+//  1. The upstream (text-only) model is asked to describe an image and chooses
+//     to call the visual_brief tool with image_refs ["Image #1"].
+//  2. The orchestrator strips the image from the request before forwarding it
+//     to the upstream and routes the actual image to the configured visual
+//     provider on the openai-chat protocol.
+//  3. The brief text returned by the visual provider is fed back to the
+//     upstream as a tool_result, the upstream emits a final answer, and the
+//     orchestrator returns it.
+//
+// Asserting the upstream never sees image_url content guards against the
+// previous bug where chat-protocol upstreams received the raw base64 payload
+// because the orchestrator was not wired in.
+func TestVisualOnOpenAIChat_OrchestratesBriefAcrossTwoMocks(t *testing.T) {
+	ctx := context.Background()
+
+	type observed struct {
+		mu      sync.Mutex
+		bodies  [][]byte
+		rounds  int
+	}
+	upstreamObs := &observed{}
+	visualObs := &observed{}
+
+	// --- Upstream (text-only "deepseek") mock: returns visual_brief tool_use
+	// on the first call, final text on the second.
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		upstreamObs.mu.Lock()
+		upstreamObs.rounds++
+		round := upstreamObs.rounds
+		upstreamObs.bodies = append(upstreamObs.bodies, body)
+		upstreamObs.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if round == 1 {
+			fmt.Fprint(w, `{
+				"id":"chatcmpl_upstream_1","object":"chat.completion","model":"deepseek-test",
+				"choices":[{"index":0,"finish_reason":"tool_calls","message":{
+					"role":"assistant","content":null,
+					"tool_calls":[{
+						"id":"call_visual_1","type":"function",
+						"function":{"name":"visual_brief","arguments":"{\"image_refs\":[\"Image #1\"],\"context\":\"describe\"}"}
+					}]
+				}}],
+				"usage":{"prompt_tokens":50,"completion_tokens":10,"total_tokens":60}
+			}`)
+			return
+		}
+		fmt.Fprint(w, `{
+			"id":"chatcmpl_upstream_2","object":"chat.completion","model":"deepseek-test",
+			"choices":[{"index":0,"finish_reason":"stop","message":{
+				"role":"assistant","content":"based on the brief: a chat screenshot"
+			}}],
+			"usage":{"prompt_tokens":80,"completion_tokens":12,"total_tokens":92}
+		}`)
+	}))
+	defer upstreamSrv.Close()
+
+	// --- Visual provider (vision-capable "qwen-vl") mock: returns a brief.
+	visualSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		visualObs.mu.Lock()
+		visualObs.rounds++
+		visualObs.bodies = append(visualObs.bodies, body)
+		visualObs.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{
+			"id":"chatcmpl_visual_1","object":"chat.completion","model":"qwen-vl-test",
+			"choices":[{"index":0,"finish_reason":"stop","message":{
+				"role":"assistant","content":"a chat screenshot with two people"
+			}}],
+			"usage":{"prompt_tokens":200,"completion_tokens":10,"total_tokens":210}
+		}`)
+	}))
+	defer visualSrv.Close()
+
+	upstreamChatClient := chat.NewClient(chat.ClientConfig{
+		BaseURL: upstreamSrv.URL, APIKey: "k", Client: upstreamSrv.Client(),
+	})
+	visualChatClient := chat.NewClient(chat.ClientConfig{
+		BaseURL: visualSrv.URL, APIKey: "k", Client: visualSrv.Client(),
+	})
+
+	hooks := format.CorePluginHooks{}.WithDefaults()
+	upstreamAdapter := chat.NewChatProviderAdapter(2048, nil, hooks)
+	visualAdapter := chat.NewChatProviderAdapter(2048, nil, hooks)
+
+	// Build a CoreProvider that drives the chat adapter end-to-end against a
+	// chat.Client — equivalent to the production adapterCoreProvider wired
+	// through chatProviderClient.
+	chatCoreProvider := func(adapter *chat.ChatProviderAdapter, client *chat.Client) visualpkg.CoreProvider {
+		return visualpkg.CoreProviderFunc(func(ctx context.Context, req *format.CoreRequest) (*format.CoreResponse, error) {
+			upstreamAny, err := adapter.FromCoreRequest(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			chatReq := upstreamAny.(*chat.ChatRequest)
+			chatResp, err := client.CreateChat(ctx, chatReq)
+			if err != nil {
+				return nil, err
+			}
+			return adapter.ToCoreResponse(ctx, chatResp)
+		})
+	}
+
+	bridge := visualpkg.NewCoreBridge(
+		chatCoreProvider(upstreamAdapter, upstreamChatClient),
+		chatCoreProvider(visualAdapter, visualChatClient),
+		"qwen-vl-test", 4, 2048,
+	)
+
+	coreReq := &format.CoreRequest{
+		Model: "deepseek-test",
+		Messages: []format.CoreMessage{{
+			Role: "user",
+			Content: []format.CoreContentBlock{
+				{Type: "text", Text: "describe the image"},
+				{Type: "image", ImageData: "ZHVtbXlpbWFnZQ==", MediaType: "image/png"},
+			},
+		}},
+		ToolChoice: &format.CoreToolChoice{Mode: "auto"},
+	}
+
+	resp, err := bridge.CreateCore(ctx, coreReq)
+	if err != nil {
+		t.Fatalf("CreateCore error: %v", err)
+	}
+
+	// --- Assertion 1: upstream was called twice (tool_use round + final answer).
+	if upstreamObs.rounds != 2 {
+		t.Fatalf("upstream rounds = %d, want 2 (visual_brief tool_use + final)", upstreamObs.rounds)
+	}
+	// --- Assertion 2: visual provider was called once (executing visual_brief).
+	if visualObs.rounds != 1 {
+		t.Fatalf("visual rounds = %d, want 1", visualObs.rounds)
+	}
+
+	// --- Assertion 3: the upstream NEVER receives image_url content. This is
+	// the core regression guard for the wiring bug — before the fix, the
+	// upstream would have received the full base64 image_url payload.
+	for i, body := range upstreamObs.bodies {
+		if strings.Contains(string(body), `"image_url"`) {
+			t.Fatalf("upstream round %d body contains image_url payload (orchestrator did not strip): %s", i+1, string(body))
+		}
+		if strings.Contains(string(body), `"ZHVtbXlpbWFnZQ=="`) {
+			t.Fatalf("upstream round %d body contains raw base64 image data: %s", i+1, string(body))
+		}
+	}
+
+	// --- Assertion 4: the visual provider DOES receive the image, with the
+	// reconstructed data: URL (the chat adapter must rebuild the data URL
+	// from raw base64 + media type).
+	if visualObs.rounds < 1 {
+		t.Fatal("visual provider was not called at all")
+	}
+	visualBody := visualObs.bodies[0]
+	if !strings.Contains(string(visualBody), `"image_url"`) {
+		t.Fatalf("visual body missing image_url part: %s", string(visualBody))
+	}
+	if !strings.Contains(string(visualBody), "data:image/png;base64,ZHVtbXlpbWFnZQ==") {
+		t.Fatalf("visual body missing reconstructed data URL: %s", string(visualBody))
+	}
+
+	// --- Assertion 5: the orchestrator returned the upstream's final answer.
+	if len(resp.Messages) == 0 || len(resp.Messages[0].Content) == 0 {
+		t.Fatal("orchestrator returned empty response")
+	}
+	finalText := ""
+	for _, block := range resp.Messages[0].Content {
+		if block.Type == "text" {
+			finalText = block.Text
+			break
+		}
+	}
+	if !strings.Contains(finalText, "chat screenshot") {
+		t.Fatalf("final response = %q, want it to incorporate the visual brief", finalText)
+	}
+}

--- a/internal/extension/visual/chat_strip.go
+++ b/internal/extension/visual/chat_strip.go
@@ -1,0 +1,46 @@
+package visual
+
+import (
+	"moonbridge/internal/protocol/chat"
+)
+
+// StripImagesFromChat strips image_url content parts from a chat.ChatRequest
+// and replaces them with text placeholders that reference the image by index.
+//
+// Returns the stripped request and whether any images were found. Use this on
+// the streaming chat path where the visual orchestrator does not run but the
+// model would otherwise receive raw base64 image data that it cannot consume
+// (text-only upstreams) and that wastes tokens.
+//
+// Mirrors StripImagesFromAnthropic for the openai-chat protocol.
+func StripImagesFromChat(req chat.ChatRequest) (chat.ChatRequest, bool) {
+	modified := false
+	imageIndex := 0
+
+	out := req
+	out.Messages = make([]chat.ChatMessage, len(req.Messages))
+	copy(out.Messages, req.Messages)
+
+	for mi := range out.Messages {
+		msg := &out.Messages[mi]
+		parts, ok := msg.Content.([]chat.ContentPart)
+		if !ok {
+			continue
+		}
+		newParts := make([]chat.ContentPart, 0, len(parts))
+		for _, part := range parts {
+			if part.Type == "image_url" {
+				imageIndex++
+				newParts = append(newParts, chat.ContentPart{
+					Type: "text",
+					Text: visualAttachmentText(imageIndex),
+				})
+				modified = true
+				continue
+			}
+			newParts = append(newParts, part)
+		}
+		msg.Content = newParts
+	}
+	return out, modified
+}

--- a/internal/extension/visual/chat_strip_test.go
+++ b/internal/extension/visual/chat_strip_test.go
@@ -1,0 +1,124 @@
+package visual
+
+import (
+	"strings"
+	"testing"
+
+	"moonbridge/internal/protocol/chat"
+)
+
+func TestStripImagesFromChat_StripsImageURL(t *testing.T) {
+	req := chat.ChatRequest{
+		Model: "qwen-vl-plus",
+		Messages: []chat.ChatMessage{{
+			Role: "user",
+			Content: []chat.ContentPart{
+				{Type: "text", Text: "描述图片"},
+				{Type: "image_url", ImageURL: &chat.ImageURL{URL: "data:image/png;base64,AAAA", Detail: "auto"}},
+			},
+		}},
+	}
+
+	stripped, modified := StripImagesFromChat(req)
+
+	if !modified {
+		t.Fatal("modified = false, want true")
+	}
+	parts, ok := stripped.Messages[0].Content.([]chat.ContentPart)
+	if !ok {
+		t.Fatalf("Content = %T, want []chat.ContentPart", stripped.Messages[0].Content)
+	}
+	for _, p := range parts {
+		if p.Type == "image_url" {
+			t.Fatal("image_url part still present after stripping")
+		}
+	}
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2 (original text + placeholder)", len(parts))
+	}
+	if parts[0].Text != "描述图片" {
+		t.Errorf("part[0].Text = %q, want original prompt preserved", parts[0].Text)
+	}
+	if !strings.Contains(parts[1].Text, "Image #1") {
+		t.Errorf("part[1].Text = %q, want placeholder referencing Image #1", parts[1].Text)
+	}
+}
+
+func TestStripImagesFromChat_TextOnlyUnchanged(t *testing.T) {
+	req := chat.ChatRequest{
+		Model: "deepseek",
+		Messages: []chat.ChatMessage{{
+			Role:    "user",
+			Content: "hello",
+		}},
+	}
+
+	stripped, modified := StripImagesFromChat(req)
+
+	if modified {
+		t.Fatal("modified = true, want false for text-only request")
+	}
+	if got := stripped.Messages[0].Content.(string); got != "hello" {
+		t.Errorf("content = %q, want %q (string content untouched)", got, "hello")
+	}
+}
+
+func TestStripImagesFromChat_MultipleImagesAcrossTurns(t *testing.T) {
+	req := chat.ChatRequest{
+		Model: "qwen-vl-plus",
+		Messages: []chat.ChatMessage{
+			{
+				Role: "user",
+				Content: []chat.ContentPart{
+					{Type: "text", Text: "first turn"},
+					{Type: "image_url", ImageURL: &chat.ImageURL{URL: "data:image/png;base64,AAA"}},
+				},
+			},
+			{
+				Role: "assistant",
+				Content: []chat.ContentPart{
+					{Type: "text", Text: "ack"},
+				},
+			},
+			{
+				Role: "user",
+				Content: []chat.ContentPart{
+					{Type: "image_url", ImageURL: &chat.ImageURL{URL: "data:image/png;base64,BBB"}},
+					{Type: "text", Text: "and this one?"},
+				},
+			},
+		},
+	}
+
+	stripped, _ := StripImagesFromChat(req)
+
+	// Indexes must continue across messages so the model can reference each
+	// stripped attachment uniquely (Image #1, Image #2, ...).
+	p0 := stripped.Messages[0].Content.([]chat.ContentPart)
+	p2 := stripped.Messages[2].Content.([]chat.ContentPart)
+	if !strings.Contains(p0[1].Text, "Image #1") {
+		t.Errorf("first stripped placeholder = %q, want Image #1", p0[1].Text)
+	}
+	if !strings.Contains(p2[0].Text, "Image #2") {
+		t.Errorf("second stripped placeholder = %q, want Image #2", p2[0].Text)
+	}
+}
+
+func TestStripImagesFromChat_DoesNotMutateInput(t *testing.T) {
+	original := chat.ChatRequest{
+		Model: "qwen-vl-plus",
+		Messages: []chat.ChatMessage{{
+			Role: "user",
+			Content: []chat.ContentPart{
+				{Type: "image_url", ImageURL: &chat.ImageURL{URL: "data:image/png;base64,AAA"}},
+			},
+		}},
+	}
+	originalParts := original.Messages[0].Content.([]chat.ContentPart)
+
+	_, _ = StripImagesFromChat(original)
+
+	if originalParts[0].Type != "image_url" {
+		t.Fatal("StripImagesFromChat mutated the caller's slice — must operate on a copy")
+	}
+}

--- a/internal/protocol/chat/adapter.go
+++ b/internal/protocol/chat/adapter.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	"moonbridge/internal/format"
@@ -654,9 +655,22 @@ func (a *ChatProviderAdapter) toChatContent(blocks []format.CoreContentBlock) an
 		case "text", "input_text", "output_text":
 			parts = append(parts, ContentPart{Type: "text", Text: b.Text})
 		case "image":
+			// CoreContentBlock.ImageData may be either a full URL/data URL or
+			// raw base64 (with MediaType set separately, e.g. after the visual
+			// extension's CoreSource splits an incoming data URL). Reconstruct
+			// a "data:<mime>;base64,<data>" URL when needed so chat upstreams
+			// receive a well-formed image_url reference.
+			imgURL := b.ImageData
+			if !strings.HasPrefix(imgURL, "http://") && !strings.HasPrefix(imgURL, "https://") && !strings.HasPrefix(imgURL, "data:") {
+				mediaType := b.MediaType
+				if mediaType == "" {
+					mediaType = "image/png"
+				}
+				imgURL = "data:" + mediaType + ";base64," + imgURL
+			}
 			parts = append(parts, ContentPart{
 				Type:     "image_url",
-				ImageURL: &ImageURL{URL: b.ImageData, Detail: "auto"},
+				ImageURL: &ImageURL{URL: imgURL, Detail: "auto"},
 			})
 		case "tool_result":
 			var resultText string

--- a/internal/protocol/chat/chat_test.go
+++ b/internal/protocol/chat/chat_test.go
@@ -995,6 +995,85 @@ func TestFromCoreRequest_MultiTurn(t *testing.T) {
 	}
 }
 
+// TestFromCoreRequest_ImageContent_DataURLReconstructed proves the chat
+// adapter rebuilds a "data:<mime>;base64,<data>" URL from a CoreContentBlock
+// whose ImageData is raw base64 with a separate MediaType field. Without the
+// reconstruction the chat upstream receives a bare base64 string in
+// image_url.url which DashScope (and other OpenAI-compatible providers)
+// reject as malformed.
+func TestFromCoreRequest_ImageContent_DataURLReconstructed(t *testing.T) {
+	adapter := newTestAdapter()
+	result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{
+		Model: "qwen-vl-plus",
+		Messages: []format.CoreMessage{{
+			Role: "user",
+			Content: []format.CoreContentBlock{
+				{Type: "text", Text: "describe"},
+				{Type: "image", ImageData: "abc123base64==", MediaType: "image/png"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chatReq := result.(*chat.ChatRequest)
+	parts, ok := chatReq.Messages[0].Content.([]chat.ContentPart)
+	if !ok {
+		t.Fatalf("Content = %T, want []ContentPart", chatReq.Messages[0].Content)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("parts = %d, want 2", len(parts))
+	}
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil {
+		t.Fatalf("part[1] = %+v, want image_url with ImageURL set", parts[1])
+	}
+	if got, want := parts[1].ImageURL.URL, "data:image/png;base64,abc123base64=="; got != want {
+		t.Errorf("ImageURL.URL = %q, want %q", got, want)
+	}
+}
+
+func TestFromCoreRequest_ImageContent_FullDataURLPreserved(t *testing.T) {
+	adapter := newTestAdapter()
+	original := "data:image/jpeg;base64,xyz"
+	result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{
+		Model: "qwen-vl-plus",
+		Messages: []format.CoreMessage{{
+			Role: "user",
+			Content: []format.CoreContentBlock{
+				{Type: "image", ImageData: original, MediaType: "image/png"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := result.(*chat.ChatRequest).Messages[0].Content.([]chat.ContentPart)
+	if got := parts[0].ImageURL.URL; got != original {
+		t.Errorf("ImageURL.URL = %q, want %q (existing data URL must pass through unchanged)", got, original)
+	}
+}
+
+func TestFromCoreRequest_ImageContent_HTTPURLPreserved(t *testing.T) {
+	adapter := newTestAdapter()
+	original := "https://example.com/cat.png"
+	result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{
+		Model: "qwen-vl-plus",
+		Messages: []format.CoreMessage{{
+			Role: "user",
+			Content: []format.CoreContentBlock{
+				{Type: "image", ImageData: original},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := result.(*chat.ChatRequest).Messages[0].Content.([]chat.ContentPart)
+	if got := parts[0].ImageURL.URL; got != original {
+		t.Errorf("ImageURL.URL = %q, want %q (http(s) URL must pass through unchanged)", got, original)
+	}
+}
+
 func TestFromCoreRequest_SystemInstruction(t *testing.T) {
 	adapter := newTestAdapter()
 	result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -370,6 +370,47 @@ func (s *Server) handleWithAdapters(
 		}
 
 		record.ChatRequest = chatReq
+
+		// finalizeChatUpstream applies per-round mutations (cached reasoning
+		// replay) on every orchestrator round. prependCachedReasoningForChat
+		// is idempotent so duplicate application against the initial chatReq
+		// above is safe.
+		finalizeChatUpstream := func(_ context.Context, upstream any) (any, error) {
+			req, ok := upstream.(*chat.ChatRequest)
+			if !ok {
+				return nil, fmt.Errorf("finalizeChatUpstream: expected *chat.ChatRequest, got %T", upstream)
+			}
+			if s.pluginRegistry != nil && sess != nil {
+				prependCachedReasoningForChat(req, sess)
+			}
+			return req, nil
+		}
+
+		// Wrap with visual orchestrator at Core level if enabled for this model.
+		// preferred.Client carries an anthropic-shaped adapter; substitute the
+		// real chat client so the orchestrator's per-round upstream calls hit
+		// the chat-protocol endpoint instead.
+		visualCandidate := preferred
+		visualCandidate.Client = &chatProviderClient{c: chatClient}
+		if visProv := s.wrapWithVisual(ctx, openAIReq.Model, visualCandidate, providerAdapter, finalizeChatUpstream); visProv != nil {
+			coreResp, err = visProv.CreateCore(ctx, coreReq)
+			if err != nil {
+				log.Error("adapter path: chat visual CreateCore failed", "error", err)
+				payload := openai.ErrorResponse{
+					Error: openai.ErrorObject{
+						Message: fmt.Sprintf("visual orchestration failed: %v", err),
+						Type:    "server_error",
+						Code:    "provider_error",
+					},
+				}
+				record.Error = traceError("chat_visual_core", err)
+				record.OpenAIResponse = payload
+				writeOpenAIError(w, http.StatusBadGateway, payload)
+				return
+			}
+			break
+		}
+
 		var chatResp *chat.ChatResponse
 		if wsInjected {
 			chatResp, err = s.executeChatSearchLoop(ctx, chatClient, chatReq, searchCfg.tavilyKey, searchCfg.firecrawlKey, searchCfg.maxRounds)
@@ -1028,6 +1069,20 @@ func (s *Server) handleAdapterStream(
 			streamRecord.OpenAIResponse = payload
 			writeOpenAIError(w, http.StatusInternalServerError, payload)
 			return
+		}
+
+		// Strip image blocks from chat request when the visual extension is
+		// enabled for this model. The visual orchestrator does not run on the
+		// streaming path; without stripping, raw base64 image data would be
+		// forwarded to a text-only upstream that cannot consume it and would
+		// burn input tokens. Mirrors the anthropic streaming behavior above.
+		if s.pluginRegistry != nil && s.runtime != nil && openAIReq.Model != "" {
+			cfgV := s.runtime.Current().Config
+			visCfg, visOk := visualpkg.ConfigForModelFromResolvedConfig(cfgV, openAIReq.Model)
+			if visOk && visCfg.Provider != "" && visCfg.Model != "" {
+				strippedReq, _ := visualpkg.StripImagesFromChat(*chatReq)
+				chatReq = &strippedReq
+			}
 		}
 
 		// Prepend cached reasoning for DeepSeek thinking chain replay.
@@ -2002,11 +2057,6 @@ func (s *Server) wrapWithVisual(
 	upstreamCP := newFinalizingAdapterCoreProvider(providerAdapter, effectiveClient, finalizeUpstream)
 
 	// Visual provider CoreProvider.
-	visClient, err := pm.ClientForKey(visCfg.Provider)
-	if err != nil || visClient == nil {
-		slog.Default().Warn("visual: provider not found", "visual_provider", visCfg.Provider, "model", modelAlias)
-		return nil
-	}
 	visProtocol := pm.ProtocolForKey(visCfg.Provider)
 	if visProtocol == "" {
 		slog.Default().Warn("visual: cannot resolve visual provider protocol")
@@ -2017,9 +2067,66 @@ func (s *Server) wrapWithVisual(
 		slog.Default().Warn("visual: no provider adapter for visual protocol", "protocol", visProtocol)
 		return nil
 	}
+	// Resolve a protocol-appropriate ProviderClient for the visual provider.
+	// pm.ClientForKey always returns an anthropic-shaped adapter; for
+	// chat-protocol visual providers, wrap the dedicated chat client so the
+	// visual call uses the chat protocol end-to-end.
+	var visClient provider.ProviderClient
+	switch visProtocol {
+	case config.ProtocolOpenAIChat:
+		chatClient, ok := s.chatClients[visCfg.Provider].(*chat.Client)
+		if !ok || chatClient == nil {
+			slog.Default().Warn("visual: no chat client for visual provider", "visual_provider", visCfg.Provider, "model", modelAlias)
+			return nil
+		}
+		visClient = &chatProviderClient{c: chatClient}
+	default:
+		c, err := pm.ClientForKey(visCfg.Provider)
+		if err != nil || c == nil {
+			slog.Default().Warn("visual: provider not found", "visual_provider", visCfg.Provider, "model", modelAlias)
+			return nil
+		}
+		visClient = c
+	}
 	visCP := newAdapterCoreProvider(visAdapter, visClient)
 
 	return visualpkg.NewCoreBridge(upstreamCP, visCP, visCfg.Model, visCfg.MaxRounds, visCfg.MaxTokens)
+}
+
+// chatProviderClient adapts *chat.Client to provider.ProviderClient so the
+// adapter-based CoreProvider machinery (used by the visual orchestrator) can
+// drive a chat-protocol upstream uniformly across protocols.
+//
+// pm.ClientForKey only constructs anthropic-shaped clients; chat-protocol
+// providers keep their dedicated *chat.Client in s.chatClients. This adapter
+// bridges the two when visual orchestration needs to call into a chat upstream.
+type chatProviderClient struct{ c *chat.Client }
+
+func (p *chatProviderClient) CreateMessage(ctx context.Context, req any) (any, error) {
+	chatReq, ok := req.(*chat.ChatRequest)
+	if !ok {
+		return nil, fmt.Errorf("chatProviderClient: expected *chat.ChatRequest, got %T", req)
+	}
+	return p.c.CreateChat(ctx, chatReq)
+}
+
+func (p *chatProviderClient) StreamMessage(ctx context.Context, req any) (<-chan any, error) {
+	chatReq, ok := req.(*chat.ChatRequest)
+	if !ok {
+		return nil, fmt.Errorf("chatProviderClient: expected *chat.ChatRequest, got %T", req)
+	}
+	stream, err := p.c.StreamChat(ctx, chatReq)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan any)
+	go func() {
+		defer close(out)
+		for chunk := range stream {
+			out <- chunk
+		}
+	}()
+	return out, nil
 }
 
 func normalizeAnthropicRequest(upstream any) (anthropic.MessageRequest, error) {
@@ -2035,6 +2142,7 @@ func normalizeAnthropicRequest(upstream any) (anthropic.MessageRequest, error) {
 		return anthropic.MessageRequest{}, fmt.Errorf("expected anthropic.MessageRequest, got %T", upstream)
 	}
 }
+
 
 // injectCoreWebSearch replaces web_search tools in coreReq.Tools with injected
 // tavily_search/firecrawl_fetch tools when the resolved web search mode is "injected".


### PR DESCRIPTION
Closes #41

issue #41 中 yogkin 在 codex 里粘贴图片询问，配置了视觉扩展走 bailian（百炼）的 kimi-k2.6 但"日志也没有提示转发到 kimi"。百炼跟 DashScope 一样是 OpenAI-Chat 兼容接口（`protocol: openai-chat`），正好踩在 moonbridge dispatch 层的同一个漏洞上——下面复现场景里把 provider 换成百炼、视觉模型换成 kimi-k2.6，症状一致。

### 复现场景

config.yml：
```yaml
mode: "Transform"

server:
  addr: "127.0.0.1:38440"

extensions:
  visual:
    config:
      provider: "aliyun"
      model: "qwen3.6-plus"
      max_rounds: 10
      max_tokens: 10000

models:
  deepseek-v4-pro:
    context_window: 1000000
    max_output_tokens: 384000
    extensions:
      visual:
        enabled: true
    default_reasoning_level: "high"
    supported_reasoning_levels:
      - effort: "high"
        description: "High reasoning effort"
      - effort: "max"
        description: "Extra high reasoning effort"
  qwen3.6-plus:
    context_window: 1000000
    max_output_tokens: 64000
    default_reasoning_level: "high"
    supported_reasoning_levels:
      - effort: "high"
        description: "High reasoning effort"

providers:
  aliyun:
    base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"
    api_key: "sk-***"
    protocol: openai-chat
    offers:
      - model: deepseek-v4-pro
      - model: qwen3.6-plus

routes:
  moonbridge:
    model: deepseek-v4-pro
    provider: aliyun

defaults:
  model: moonbridge
  max_tokens: 65536
```

请求：
```bash
IMG_B64=$(base64 -i /path/to/some-image.png | tr -d '\n')
curl http://127.0.0.1:38440/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-***" \
  -d "{
    \"model\": \"moonbridge\",
    \"input\": [{
      \"role\": \"user\",
      \"content\": [
        {\"type\": \"input_text\", \"text\": \"描述这张图\"},
        {\"type\": \"input_image\", \"image_url\": \"data:image/png;base64,${IMG_B64}\"}
      ]
    }]
  }"
```

**期望**：deepseek-v4-pro 调 `visual_brief` 工具，moonbridge 把图发给 qwen3.6-plus 拿到描述再喂回 deepseek。

**实际**：
- 上游 HTTP body 中图片 base64 原样塞在 `image_url` 里发给了 deepseek-v4-pro
- 在 DashScope 控制台能看到 deepseek-v4-pro 收到了图片但当作不存在
- 返回内容要么是"我看不到图片"，要么是模型瞎编（input_tokens 数值异常低，明显没经过视觉模型）
- 日志里没有任何转发到视觉模型（qwen3.6-plus / kimi）的痕迹——跟 issue #41 反馈的症状一致

Anthropic 协议（例如 Claude 上游）走的是同一份 visual 扩展配置，工作正常。

### 根因

`internal/service/server/adapter_dispatch.go` 里只有 Anthropic 分支调用了 `wrapWithVisual`：

```go
// 非流式 anthropic 分支（line ~286）
if visProv := s.wrapWithVisual(ctx, openAIReq.Model, preferred, providerAdapter, finalize); visProv != nil {
    // → 跑 CoreOrchestrator
}

// 非流式 openai-chat 分支（line ~341）
// ← 直接 chatClient.CreateChat(ctx, chatReq)，没经过视觉编排
```

流式 openai-chat 分支同样没有图片剥离逻辑，对照 Anthropic 流式分支里已有的 `StripImagesFromAnthropic` 调用。

### 改动

#### `fix(chat): 重建 image content block 的 base64 data URL`

`internal/protocol/chat/adapter.go`：视觉扩展的 `CoreSource` 在转换 incoming data URL 时拆成"裸 base64 + 独立 MediaType"两个字段。chat 适配器原先直接把裸 base64 当 `image_url.url`，DashScope 等 OpenAI 兼容后端报：

```
400 InternalError.Algo.InvalidParameter: The provided URL does not appear to be valid.
```

改成 `data:<mime>;base64,<data>` 形式再发出。

#### `feat(server): 在 openai-chat 协议路径上接通 visual orchestrator`

`internal/service/server/adapter_dispatch.go`：
- 新增 `chatProviderClient`，把 `*chat.Client` 适配成 `provider.ProviderClient`，让 CoreProvider 抽象能驱动 chat 协议。`pm.ClientForKey` 只构造 anthropic 形态客户端；chat 协议的 `*chat.Client` 单独保存在 `s.chatClients`，这个适配器把两者桥接起来。
- 非流式 openai-chat 分支：增加 `finalizeChatUpstream` 闭包负责每轮注入 cached reasoning，命中 `wrapWithVisual` 时走 CoreOrchestrator，否则继续原有直连路径。
- 流式 openai-chat 分支：参照 Anthropic 流式分支的做法，视觉扩展启用时通过 `StripImagesFromChat` 把图片块替换成占位文字。
- `wrapWithVisual` 内部 visual provider 客户端解析按协议分发：openai-chat 时从 `s.chatClients` 取并包 `chatProviderClient`，避免误用 anthropic 形态。

`internal/extension/visual/chat_strip.go`：新增 `StripImagesFromChat`，行为对齐 `StripImagesFromAnthropic`，把 `chat.ChatRequest` 中所有 `image_url` content part 替换成 `[Image #N is available ...]` 文字占位，跨多轮按全局索引连号。

### 验证

- `make test` 全绿
- 单测：
  - chat 适配器 image data URL 重建：3 个 case（裸 base64+mime / 完整 data URL / http(s) URL 透传）
  - `StripImagesFromChat`：4 个 case（剥离、纯文本不变、跨轮索引连号、不污染入参）
- E2E：`internal/e2e/visual_chat_e2e_test.go`（`//go:build e2e`）用两个 `httptest` mock 模拟 deepseek + qwen-vl 全链路，断言：
  - 视觉模型收到了 `image_url` 内容
  - 文本上游收到的请求里没有 `image_url` / 没有 base64
  - 最终回答整合了视觉 brief
- 真实 DashScope 后端：用上文 config + 一张微信聊天截图请求，修复前 deepseek 回 "我目前没有看到您上传的图片"，修复后返回准确描述（包含原图中实际的对话内容、双方头像描述等细节）
