### PR TITLE
feat(chat): openai-chat 协议出口补齐 reasoning.effort 透传——修复客户端推理强度被静默丢弃的问题

### DIFF
--- a/internal/protocol/chat/adapter.go
+++ b/internal/protocol/chat/adapter.go
@@ -138,7 +138,28 @@ func (a *ChatProviderAdapter) FromCoreRequest(ctx context.Context, req *format.C
 		}
 	}
 
+	// reasoning_effort: surfaced from the OpenAI Responses input via
+	// Extensions["openai"]["reasoning"]["effort"] (see openai.OpenAIAdapter).
+	if effort := extractReasoningEffort(req.Extensions); effort != "" {
+		chatReq.ReasoningEffort = effort
+	}
+
 	return chatReq, nil
+}
+
+// extractReasoningEffort pulls the reasoning effort string out of the OpenAI
+// extension bag attached to a CoreRequest. Returns "" when not present.
+func extractReasoningEffort(ext map[string]any) string {
+	openai, ok := ext["openai"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	reasoning, ok := openai["reasoning"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	effort, _ := reasoning["effort"].(string)
+	return effort
 }
 
 // =========================================================================

--- a/internal/protocol/chat/chat_test.go
+++ b/internal/protocol/chat/chat_test.go
@@ -351,6 +351,62 @@ func TestTypes_StreamOptions_JSON(t *testing.T) {
 	}
 }
 
+// TestAdapter_ReasoningEffort_FromOpenAIExtensions verifies that
+// req.Extensions["openai"]["reasoning"]["effort"] (set by the OpenAI Responses
+// adapter when the client sends {"reasoning":{"effort":"high"}}) is propagated
+// to the outbound Chat Completions body as the standard reasoning_effort field.
+func TestAdapter_ReasoningEffort_FromOpenAIExtensions(t *testing.T) {
+	adapter := newTestAdapter()
+	core := &format.CoreRequest{
+		Model:    "deepseek-v4-pro",
+		Messages: []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
+		Extensions: map[string]any{
+			"openai": map[string]any{
+				"reasoning": map[string]any{"effort": "high"},
+			},
+		},
+	}
+	upstream, err := adapter.FromCoreRequest(context.Background(), core)
+	if err != nil {
+		t.Fatalf("FromCoreRequest: %v", err)
+	}
+	chatReq, ok := upstream.(*chat.ChatRequest)
+	if !ok {
+		t.Fatalf("upstream type = %T, want *chat.ChatRequest", upstream)
+	}
+	if chatReq.ReasoningEffort != "high" {
+		t.Errorf("ReasoningEffort = %q, want %q", chatReq.ReasoningEffort, "high")
+	}
+	// Confirm the field serializes to the OpenAI-standard JSON key.
+	data, err := json.Marshal(chatReq)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"reasoning_effort":"high"`) {
+		t.Errorf("outbound body missing reasoning_effort: %s", data)
+	}
+}
+
+func TestAdapter_ReasoningEffort_Absent_OmitsField(t *testing.T) {
+	adapter := newTestAdapter()
+	core := &format.CoreRequest{
+		Model:    "deepseek-v4-pro",
+		Messages: []format.CoreMessage{{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "hi"}}}},
+	}
+	upstream, err := adapter.FromCoreRequest(context.Background(), core)
+	if err != nil {
+		t.Fatalf("FromCoreRequest: %v", err)
+	}
+	chatReq := upstream.(*chat.ChatRequest)
+	if chatReq.ReasoningEffort != "" {
+		t.Errorf("ReasoningEffort = %q, want empty when client did not request it", chatReq.ReasoningEffort)
+	}
+	data, _ := json.Marshal(chatReq)
+	if strings.Contains(string(data), "reasoning_effort") {
+		t.Errorf("body should not include reasoning_effort when unset: %s", data)
+	}
+}
+
 func TestTypes_FunctionDef_Strict(t *testing.T) {
 	strict := true
 	in := chat.FunctionDef{

--- a/internal/protocol/chat/types.go
+++ b/internal/protocol/chat/types.go
@@ -23,6 +23,10 @@ type ChatRequest struct {
 	StreamOptions     *StreamOptions  `json:"stream_options,omitempty"`
 	Metadata          map[string]any  `json:"metadata,omitempty"`
 	User              string          `json:"user,omitempty"`
+	// ReasoningEffort is the OpenAI Chat Completions reasoning_effort field
+	// ("low" | "medium" | "high" | "minimal"). Populated from the inbound
+	// OpenAI Responses request's reasoning.effort.
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 }
 
 // ChatMessage represents a single message in the conversation.


### PR DESCRIPTION
## 问题

当 MoonBridge 把请求路由到使用 `openai-chat` 协议的上游时，客户端通过 OpenAI Responses 入口传入的 `reasoning.effort` 字段会被静默丢弃。上游模型最终按自身默认的推理强度执行，而不是客户端请求的强度。这意味着任何依赖通过 OpenAI 标准字段 `reasoning.effort` 来控制思考强度的客户端，在路由到 `openai-chat` 协议上游时，控制信号都失效。

### 复现场景

我使用的配置：

```yaml
mode: "Transform"

server:
  addr: "127.0.0.1:38440"

models:
  deepseek-v4-pro:
    context_window: 1000000
    max_output_tokens: 384000
    default_reasoning_level: "high"
    supported_reasoning_levels:
      - effort: "high"
        description: "High reasoning effort"
      - effort: "max"
        description: "Extra high reasoning effort"
  qwen3.6-plus:
    context_window: 1000000
    max_output_tokens: 64000
    default_reasoning_level: "high"
    supported_reasoning_levels:
      - effort: "high"
        description: "High reasoning effort"

providers:
  aliyun:
    base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"
    api_key: "sk-***"
    protocol: openai-chat
    offers:
      - model: deepseek-v4-pro
      - model: qwen3.6-plus

routes:
  moonbridge:
    model: deepseek-v4-pro
    provider: aliyun

defaults:
  model: moonbridge
  max_tokens: 65536
```

客户端向 `/v1/responses` 发送的请求体里包含 `{"reasoning\":{"effort":"high"}}`，期望 MoonBridge 把这个信号原样翻译给 DashScope，使 deepseek-v4-pro 按高强度推理执行。

实际抓包看转发给 DashScope 的请求体，里面完全没有 `reasoning_effort` 字段，模型按其默认强度执行。客户端层面表现就是设置 `reasoning.effort` 没有任何效果。

## 根本原因

出口侧把 CoreRequest 转换成 Chat Completions 请求时，chat 适配器从来没读过这个 Extensions 字段：

- [`internal/protocol/chat/types.go`](internal/protocol/chat/types.go) 中的 `ChatRequest` 结构体里没有任何对应的字段
- [`internal/protocol/chat/adapter.go`](internal/protocol/chat/adapter.go) 的 `FromCoreRequest` 方法只翻译 messages、tools、采样参数等，完全没处理 reasoning 信号

因此信号在协议转换的最后一步被丢弃。

## 修复方案

在 chat 适配器里读取 `CoreRequest.Extensions["openai"]["reasoning"]["effort"]`，把值写入新增的 `ChatRequest.ReasoningEffort` 字段。该字段序列化为 OpenAI Chat Completions 标准的 `reasoning_effort` JSON 键，并通过 `omitempty` 保证客户端没传时不会出现在出口请求体里——既不影响不支持该字段的上游，也不在客户端没有显式请求时引入新行为。

修复后，同样的客户端请求转发给 DashScope 时，请求体里会出现：

```json
{
  "model": "deepseek-v4-pro",
  "messages": [...],
  "reasoning_effort": "high"
}
```

deepseek-v4-pro 这边就能按高强度推理执行了。

## 测试覆盖

新增两条测试：

- `TestAdapter_ReasoningEffort_FromOpenAIExtensions`：验证客户端传 `{"reasoning":{"effort":"high"}}` 时，出口请求体中出现 `"reasoning_effort":"high"`
- `TestAdapter_ReasoningEffort_Absent_OmitsField`：验证客户端不传该字段时，出口请求体完全没有 `reasoning_effort` 键

`go test ./internal/protocol/chat/...` 全部通过。