### PR TITLE
feat: codex_tool_proxy extension — configurable apply_patch proxy expansion

### DIFF
--- a/internal/extension/codex_tool_proxy/plugin.go
+++ b/internal/extension/codex_tool_proxy/plugin.go
@@ -1,0 +1,65 @@
+// Package codextoolproxy provides the codex_tool_proxy extension, which
+// controls whether apply_patch custom tools are expanded into structured
+// proxy tools for upstream models.
+//
+// When disabled, apply_patch is sent to upstream as a raw custom tool (ToolRaw),
+// and the response-side reconstruction passes it through as-is.
+package codextoolproxy
+
+import (
+	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
+)
+
+const PluginName = "codex_tool_proxy"
+
+// ProxyPlugin implements the plugin.Plugin interface plus PatchProxyDecider.
+type ProxyPlugin struct {
+	plugin.BasePlugin
+	appCfg config.Config
+}
+
+// NewPlugin creates a new codex_tool_proxy plugin.
+func NewPlugin() *ProxyPlugin {
+	return &ProxyPlugin{}
+}
+
+func (p *ProxyPlugin) Name() string { return PluginName }
+
+func (p *ProxyPlugin) ConfigSpecs() []config.ExtensionConfigSpec {
+	return ConfigSpecs()
+}
+
+func (p *ProxyPlugin) EnabledForModel(model string) bool {
+	return p.appCfg.ExtensionEnabled(PluginName, model)
+}
+
+func (p *ProxyPlugin) Init(ctx plugin.PluginContext) error {
+	p.appCfg = ctx.AppConfig
+	return nil
+}
+
+// DisablePatchProxy implements plugin.PatchProxyDecider.
+func (p *ProxyPlugin) DisablePatchProxy(model string) bool {
+	return DisablePatchProxyForModel(p.appCfg, model)
+}
+
+// DisablePatchProxyForModel returns true when patch proxy expansion should be
+// skipped for a model alias, based on the extension's enabled state.
+func DisablePatchProxyForModel(cfg config.Config, model string) bool {
+	return !cfg.ExtensionEnabled(PluginName, model)
+}
+
+// ConfigSpecs returns the extension config specs for codex_tool_proxy.
+func ConfigSpecs() []config.ExtensionConfigSpec {
+	return []config.ExtensionConfigSpec{{
+		Name:           PluginName,
+		DefaultEnabled: true,
+		Scopes: []config.ExtensionScope{
+			config.ExtensionScopeGlobal,
+			config.ExtensionScopeProvider,
+			config.ExtensionScopeModel,
+			config.ExtensionScopeRoute,
+		},
+	}}
+}

--- a/internal/extension/codex_tool_proxy/plugin_test.go
+++ b/internal/extension/codex_tool_proxy/plugin_test.go
@@ -1,0 +1,69 @@
+package codextoolproxy
+
+import (
+	"testing"
+
+	"moonbridge/internal/config"
+)
+
+func TestDisablePatchProxyForModelDefaultEnabled(t *testing.T) {
+	cfg, err := config.LoadFromYAMLWithOptions([]byte(_testYAML), config.LoadOptions{ExtensionSpecs: ConfigSpecs()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if DisablePatchProxyForModel(cfg, "test-model") {
+		t.Fatal("expected proxy enabled by default")
+	}
+}
+
+func TestDisablePatchProxyForModelWhenExtensionDisabled(t *testing.T) {
+	cfg, err := config.LoadFromYAMLWithOptions([]byte(_testYAML+_extDisabled), config.LoadOptions{ExtensionSpecs: ConfigSpecs()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !DisablePatchProxyForModel(cfg, "test-model") {
+		t.Fatal("expected proxy disabled when extension is disabled")
+	}
+}
+
+func TestDisablePatchProxyForModelRouteOverride(t *testing.T) {
+	cfg, err := config.LoadFromYAMLWithOptions([]byte(_testYAML+_routeYAML), config.LoadOptions{ExtensionSpecs: ConfigSpecs()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !DisablePatchProxyForModel(cfg, "specific") {
+		t.Fatal("expected proxy disabled via specific route override")
+	}
+	if DisablePatchProxyForModel(cfg, "unmatched-model") {
+		t.Fatal("expected proxy enabled for unmatched model")
+	}
+}
+
+const _testYAML = `
+mode: Transform
+models:
+  test-model:
+    context_window: 200000
+providers:
+  main:
+    base_url: https://example.test
+    api_key: test
+    offers:
+      - model: test-model
+`
+
+const _extDisabled = `
+extensions:
+  codex_tool_proxy:
+    enabled: false
+`
+
+const _routeYAML = `
+routes:
+  specific:
+    model: test-model
+    provider: main
+    extensions:
+      codex_tool_proxy:
+        enabled: false
+`

--- a/internal/extension/plugin/capabilities.go
+++ b/internal/extension/plugin/capabilities.go
@@ -212,3 +212,11 @@ type CoreContentFilter interface {
 type CoreContentRememberer interface {
 	RememberCoreContent(ctx context.Context, content []format.CoreContentBlock)
 }
+
+
+// PatchProxyDecider is implemented by plugins that control whether apply_patch
+// custom tools are expanded into structured proxy tools for upstream models.
+type PatchProxyDecider interface {
+	DisablePatchProxy(model string) bool
+}
+

--- a/internal/extension/plugin/registry.go
+++ b/internal/extension/plugin/registry.go
@@ -525,5 +525,11 @@ func (r *Registry) CorePluginHooks() format.CorePluginHooks {
 			}
 		}
 	}
+
+	// Wire codex_tool_proxy PatchProxyDecider into DisablePatchProxy hook.
+	if ppd, ok := r.Plugin("codex_tool_proxy").(PatchProxyDecider); ok {
+		hooks.DisablePatchProxy = ppd.DisablePatchProxy
+	}
+
 	return hooks
 }

--- a/internal/format/adapter.go
+++ b/internal/format/adapter.go
@@ -138,6 +138,13 @@ type CorePluginHooks struct {
 	// PrependThinkingToAssistant injects thinking content before assistant messages.
 	// deepseek_v4 uses this for reasoning replay.
 	PrependThinkingToAssistant func(ctx context.Context, req *CoreRequest)
+
+	// DisablePatchProxy reports whether apply_patch proxy expansion should be
+	// skipped for the given model alias. When true, apply_patch custom tools
+	// are passed through as ToolRaw instead of being expanded into five
+	// structured proxy tools (add_file, delete_file, update_file, replace_file, batch).
+	// Populated by the codex_tool_proxy extension via the plugin registry.
+	DisablePatchProxy func(model string) bool
 }
 
 // WithDefaults returns a copy of hooks with all nil function fields
@@ -180,6 +187,9 @@ func (hooks CorePluginHooks) WithDefaults() CorePluginHooks {
 	}
 	if hooks.PrependThinkingToAssistant == nil {
 		hooks.PrependThinkingToAssistant = func(_ context.Context, _ *CoreRequest) {}
+	}
+	if hooks.DisablePatchProxy == nil {
+		hooks.DisablePatchProxy = func(_ string) bool { return false }
 	}
 	return hooks
 }

--- a/internal/service/app/extensions.go
+++ b/internal/service/app/extensions.go
@@ -9,6 +9,7 @@ import (
 	deepseekv4 "moonbridge/internal/extension/deepseek_v4"
 	kimiworkaround "moonbridge/internal/extension/kimi_workaround"
 	mbtrics "moonbridge/internal/extension/metrics"
+	codextoolproxy "moonbridge/internal/extension/codex_tool_proxy"
 	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/extension/visual"
 	"moonbridge/internal/config"
@@ -36,6 +37,7 @@ func (cat BuiltinExtensionCatalog) ConfigSpecs() []config.ExtensionConfigSpec {
 	specs = append(specs, dbsqlite.ConfigSpecs()...)
 	specs = append(specs, dbd1.ConfigSpecs()...)
 	specs = append(specs, mbtrics.ConfigSpecs()...)
+	specs = append(specs, codextoolproxy.ConfigSpecs()...)
 	return specs
 }
 
@@ -58,5 +60,6 @@ func (cat BuiltinExtensionCatalog) NewRegistry(logger *slog.Logger, cfg config.C
 	registry.Register(d1)
 
 	registry.Register(mbtrics.NewPlugin())
+	registry.Register(codextoolproxy.NewPlugin())
 	return registry
 }


### PR DESCRIPTION
Move apply_patch proxy expansion control into the extension system via codex_tool_proxy plugin.

Infrastructure:
- New extension codex_tool_proxy with PatchProxyDecider capability
- CorePluginHooks gains DisablePatchProxy callback
- Registry wires codex_tool_proxy into CorePluginHooks
- PatchProxyDecider interface in plugin capabilities

Default enabled (no behaviour change). Disable per-route or globally:

```yaml
extensions:
  codex_tool_proxy:
    enabled: false
```

Rebased onto latest dev (replaces #45).