### PR TITLE
fix: sanitize flash chat tool payloads

### DIFF
--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1568,6 +1568,8 @@ func convertToolWithNamespace(tool Tool, namespace string) []format.CoreTool {
 			Description: "Use a computer to perform actions.",
 			Extensions:  ext,
 		}}
+	case "image_generation":
+		return nil
 
 	case "namespace":
 		ns := namespacedToolName(namespace, tool.Name)

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -89,6 +89,37 @@ func TestToCoreRequest_AppendsInjectedTools(t *testing.T) {
 	}
 }
 
+func TestToCoreRequest_SkipsImageGenerationTool(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+
+	req := &openai.ResponsesRequest{
+		Model: "deepseek-v4-flash",
+		Input: json.RawMessage(`"draw something"`),
+		Tools: []openai.Tool{
+			{Type: "function", Name: "exec_command", Description: "Run a command"},
+			{Type: "image_generation"},
+			{Type: "web_search"},
+		},
+	}
+
+	result, err := adapter.ToCoreRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Tools) != 2 {
+		t.Fatalf("got %d tools, want 2: %+v", len(result.Tools), result.Tools)
+	}
+	for _, tool := range result.Tools {
+		if tool.Name == "" {
+			t.Fatalf("unexpected empty tool name in %+v", result.Tools)
+		}
+	}
+	if result.Tools[0].Name != "exec_command" || result.Tools[1].Name != "web_search" {
+		t.Fatalf("tools = %+v, want exec_command and web_search", result.Tools)
+	}
+}
+
 func TestToCoreRequest_FunctionCallOutputImage(t *testing.T) {
 	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
 
@@ -294,8 +325,8 @@ func TestToCoreRequest_BatchesCustomToolCallsAndOutputsIntoSingleRound(t *testin
 	for i, want := range []struct {
 		assistantTextIdx int
 		msgIdx           int
-		callID  string
-		outcome string
+		callID           string
+		outcome          string
 	}{
 		{0, 1, "call_a", "ok a"},
 		{3, 4, "call_b", "ok b"},

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -337,6 +337,7 @@ func (s *Server) handleWithAdapters(
 			record.OpenAIRequest = nil
 			return
 		}
+		record.Sanitization = sanitizeChatRequestBeforeSend(chatReq)
 
 		chatClientRaw := s.activeChatClient(preferred.ProviderKey)
 		if chatClientRaw == nil {
@@ -1034,6 +1035,7 @@ func (s *Server) handleAdapterStream(
 		if s.pluginRegistry != nil && sess != nil {
 			prependCachedReasoningForChat(chatReq, sess)
 		}
+		streamRecord.Sanitization = sanitizeChatRequestBeforeSend(chatReq)
 
 		chatClientRaw := s.activeChatClient(candidate.ProviderKey)
 		if chatClientRaw == nil {
@@ -1551,6 +1553,73 @@ func (s *Server) adapterRegistryProvider(protocol string) format.ProviderAdapter
 	}
 	adapter, _ := s.adapterRegistry.GetProvider(protocol)
 	return adapter
+}
+
+type chatRequestSanitization struct {
+	RemovedTools        []removedChatTool `json:"removed_tools,omitempty"`
+	OriginalToolChoice  any               `json:"original_tool_choice,omitempty"`
+	SanitizedToolChoice string            `json:"sanitized_tool_choice,omitempty"`
+}
+
+type removedChatTool struct {
+	Index  int    `json:"index"`
+	Reason string `json:"reason"`
+	Name   string `json:"name,omitempty"`
+}
+
+func sanitizeChatRequestBeforeSend(req *chat.ChatRequest) any {
+	if req == nil {
+		return nil
+	}
+
+	removed := make([]removedChatTool, 0)
+	validNames := make(map[string]bool, len(req.Tools))
+	filteredTools := make([]chat.ChatTool, 0, len(req.Tools))
+	for i, tool := range req.Tools {
+		if tool.Type == "function" && tool.Function.Name == "" {
+			removed = append(removed, removedChatTool{
+				Index:  i,
+				Reason: "empty_function_name",
+			})
+			continue
+		}
+		if tool.Function.Name != "" {
+			validNames[tool.Function.Name] = true
+		}
+		filteredTools = append(filteredTools, tool)
+	}
+	req.Tools = filteredTools
+
+	report := chatRequestSanitization{RemovedTools: removed}
+	name, ok := chatToolChoiceFunctionName(req.ToolChoice)
+	if ok && !validNames[name] {
+		report.OriginalToolChoice = json.RawMessage(append([]byte(nil), req.ToolChoice...))
+		report.SanitizedToolChoice = "auto"
+		req.ToolChoice = json.RawMessage(`"auto"`)
+	}
+	if len(report.RemovedTools) == 0 && report.SanitizedToolChoice == "" {
+		return nil
+	}
+	return report
+}
+
+func chatToolChoiceFunctionName(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var obj struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return "", false
+	}
+	if obj.Type != "function" {
+		return "", false
+	}
+	return obj.Function.Name, true
 }
 
 func (s *Server) writeCoreResponseAsOpenAIStream(

--- a/internal/service/server/adapter_dispatch_test.go
+++ b/internal/service/server/adapter_dispatch_test.go
@@ -7,6 +7,7 @@ import (
 
 	"moonbridge/internal/config"
 	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/chat"
 	"moonbridge/internal/protocol/openai"
 	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/runtime"
@@ -83,6 +84,82 @@ func TestCoreResponseToCoreStreamEmitsUsageOnCompleted(t *testing.T) {
 	}
 	if !sawToolArgsDone {
 		t.Fatal("missing tool args done event")
+	}
+}
+
+func TestSanitizeChatRequestBeforeSendRemovesEmptyFunctionTools(t *testing.T) {
+	req := &chat.ChatRequest{
+		Model: "deepseek-v4-flash",
+		Tools: []chat.ChatTool{
+			{Type: "function", Function: chat.FunctionDef{Name: "exec_command"}},
+			{Type: "function", Function: chat.FunctionDef{Name: ""}},
+			{Type: "function", Function: chat.FunctionDef{Name: "web_search"}},
+		},
+		ToolChoice: json.RawMessage(`{"type":"function","function":{"name":""}}`),
+	}
+
+	report, ok := sanitizeChatRequestBeforeSend(req).(chatRequestSanitization)
+	if !ok {
+		t.Fatalf("sanitization report type = %T, want chatRequestSanitization", report)
+	}
+	if len(req.Tools) != 2 {
+		t.Fatalf("tools: got %d, want 2: %+v", len(req.Tools), req.Tools)
+	}
+	if req.Tools[0].Function.Name != "exec_command" || req.Tools[1].Function.Name != "web_search" {
+		t.Fatalf("tools = %+v, want exec_command and web_search", req.Tools)
+	}
+	if len(report.RemovedTools) != 1 || report.RemovedTools[0].Index != 1 || report.RemovedTools[0].Reason != "empty_function_name" {
+		t.Fatalf("removed tools = %+v", report.RemovedTools)
+	}
+	if string(req.ToolChoice) != `"auto"` {
+		t.Fatalf("tool_choice = %s, want auto", string(req.ToolChoice))
+	}
+	if report.SanitizedToolChoice != "auto" || report.OriginalToolChoice == nil {
+		t.Fatalf("report = %+v", report)
+	}
+}
+
+func TestSanitizeChatRequestBeforeSendLeavesValidRequestUnchanged(t *testing.T) {
+	req := &chat.ChatRequest{
+		Model: "deepseek-v4-flash",
+		Tools: []chat.ChatTool{
+			{Type: "function", Function: chat.FunctionDef{Name: "exec_command"}},
+		},
+		ToolChoice: json.RawMessage(`{"type":"function","function":{"name":"exec_command"}}`),
+	}
+
+	if report := sanitizeChatRequestBeforeSend(req); report != nil {
+		t.Fatalf("report = %+v, want nil", report)
+	}
+	if len(req.Tools) != 1 || req.Tools[0].Function.Name != "exec_command" {
+		t.Fatalf("tools = %+v", req.Tools)
+	}
+	if string(req.ToolChoice) != `{"type":"function","function":{"name":"exec_command"}}` {
+		t.Fatalf("tool_choice changed to %s", string(req.ToolChoice))
+	}
+}
+
+func TestSanitizeChatRequestBeforeSendSanitizesMissingToolChoice(t *testing.T) {
+	req := &chat.ChatRequest{
+		Model: "deepseek-v4-flash",
+		Tools: []chat.ChatTool{
+			{Type: "function", Function: chat.FunctionDef{Name: "exec_command"}},
+		},
+		ToolChoice: json.RawMessage(`{"type":"function","function":{"name":"missing_tool"}}`),
+	}
+
+	report, ok := sanitizeChatRequestBeforeSend(req).(chatRequestSanitization)
+	if !ok {
+		t.Fatalf("sanitization report type = %T, want chatRequestSanitization", report)
+	}
+	if len(report.RemovedTools) != 0 {
+		t.Fatalf("removed tools = %+v, want none", report.RemovedTools)
+	}
+	if string(req.ToolChoice) != `"auto"` {
+		t.Fatalf("tool_choice = %s, want auto", string(req.ToolChoice))
+	}
+	if report.SanitizedToolChoice != "auto" || report.OriginalToolChoice == nil {
+		t.Fatalf("report = %+v", report)
 	}
 }
 

--- a/internal/service/server/dispatch.go
+++ b/internal/service/server/dispatch.go
@@ -201,6 +201,7 @@ func (server *Server) writeTrace(record mbtrace.Record) {
 			ChatRequest:      record.ChatRequest,
 			ChatResponse:     record.ChatResponse,
 			ChatStreamEvents: record.ChatStreamEvents,
+			Sanitization:     record.Sanitization,
 			Error:            record.Error,
 		})
 	}

--- a/internal/service/server/trace/writer.go
+++ b/internal/service/server/trace/writer.go
@@ -24,8 +24,8 @@ type Writer interface {
 
 // FileWriter implements Writer by delegating to a *mbtrace.Tracer.
 type FileWriter struct {
-	tracer      *mbtrace.Tracer
-	errors      io.Writer
+	tracer *mbtrace.Tracer
+	errors io.Writer
 }
 
 // NewFileWriter creates a new FileWriter.
@@ -47,6 +47,7 @@ func (w *FileWriter) WriteTrace(record mbtrace.Record) {
 			ChatRequest:      record.ChatRequest,
 			ChatResponse:     record.ChatResponse,
 			ChatStreamEvents: record.ChatStreamEvents,
+			Sanitization:     record.Sanitization,
 			Error:            record.Error,
 		})
 	}

--- a/internal/service/trace/tracer.go
+++ b/internal/service/trace/tracer.go
@@ -50,6 +50,7 @@ type Record struct {
 	AnthropicStreamEvents any         `json:"anthropic_stream_events,omitempty"`
 	OpenAIResponse        any         `json:"openai_response,omitempty"`
 	OpenAIStreamEvents    any         `json:"openai_stream_events,omitempty"`
+	Sanitization          any         `json:"sanitization,omitempty"`
 	Error                 any         `json:"error,omitempty"`
 }
 


### PR DESCRIPTION
修复 deepseek-v4-flash 请求中空 function.name 的工具格式问题，并在 openai-chat 发送前兜底清理非法工具格式、记录 trace。

Sanitize invalid chat tool payloads before upstream OpenAI Chat calls and record sanitization details in trace output.