### PR TITLE
fix(adapter): stabilize DeepSeek Responses SSE conversion for Codex

### DIFF
--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -565,6 +565,18 @@ func (s *streamConverterState) convertEvent(events chan<- format.CoreStreamEvent
 				},
 			})
 
+		case "reasoning_content":
+			// DeepSeek anthropic-compatible API uses "reasoning_content" as the
+			// content-block type for reasoning, with the text in the .Text field.
+			s.emit(events, format.CoreStreamEvent{
+				Type:  format.CoreContentBlockStarted,
+				Index: index,
+				ContentBlock: &format.CoreContentBlock{
+					Type:          "reasoning",
+					ReasoningText: ev.ContentBlock.Text,
+				},
+			})
+
 		case "server_tool_use":
 			// Anthropic server-side tool usage marker. Do NOT forward — the tool_use
 			// would become an orphan in subsequent requests (no matching tool_result),
@@ -613,6 +625,18 @@ func (s *streamConverterState) convertEvent(events chan<- format.CoreStreamEvent
 				},
 			})
 
+		case ev.Delta.Type == "reasoning_content_delta" || blockType == "reasoning_content":
+			// DeepSeek streams reasoning content via delta.reasoning_content_delta
+			// (instead of delta.thinking_delta). The text is in ev.Delta.Text.
+			s.emit(events, format.CoreStreamEvent{
+				Type:  format.CoreTextDelta,
+				Index: index,
+				Delta: ev.Delta.Text,
+				ContentBlock: &format.CoreContentBlock{
+					Type: "reasoning",
+				},
+			})
+
 		case ev.Delta.Type == "signature_delta":
 			if sig := ev.Delta.Signature; sig != "" {
 				s.blockSignatures[index] = sig
@@ -629,7 +653,7 @@ func (s *streamConverterState) convertEvent(events chan<- format.CoreStreamEvent
 			break
 		}
 
-		if blockType == "thinking" {
+		if blockType == "thinking" || blockType == "reasoning_content" {
 			s.emit(events, format.CoreStreamEvent{
 				Type:  format.CoreContentBlockDone,
 				Index: index,
@@ -920,6 +944,14 @@ func (a *AnthropicProviderAdapter) fromContentBlock(b ContentBlock) format.CoreC
 			Type:               "reasoning",
 			ReasoningText:      b.Thinking,
 			ReasoningSignature: b.Signature,
+		}
+
+	case "reasoning_content":
+		// DeepSeek non-streaming responses may use "reasoning_content" as the
+		// content-block type with the text in the .Text field instead of .Thinking.
+		return format.CoreContentBlock{
+			Type:          "reasoning",
+			ReasoningText: b.Text,
 		}
 
 	default:

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/uuid"
+
 	"moonbridge/internal/extension/codextool"
 	"moonbridge/internal/format"
 )
@@ -34,14 +36,14 @@ type OpenAIAdapter struct {
 	hooks format.CorePluginHooks
 
 	disablePatchProxy func(string) bool
-	streamMu     sync.Mutex
-	streamEvents []StreamEvent
+	streamMu          sync.Mutex
+	streamEvents      []StreamEvent
 }
 
 // NewOpenAIAdapter creates a new OpenAIAdapter with the given config and hooks.
 func NewOpenAIAdapter(hooks format.CorePluginHooks) *OpenAIAdapter {
 	return &OpenAIAdapter{
-		hooks: hooks.WithDefaults(),
+		hooks:             hooks.WithDefaults(),
 		disablePatchProxy: hooks.DisablePatchProxy,
 	}
 }
@@ -192,11 +194,12 @@ func (a *OpenAIAdapter) FromCoreResponse(ctx context.Context, resp *format.CoreR
 	a.hooks.PostProcessCoreResponse(ctx, resp)
 
 	response := &Response{
-		ID:     resp.ID,
+		ID:     responseIDOrSynthetic(resp.ID),
 		Object: "response",
 		Status: resp.Status,
 		Model:  resp.Model,
 	}
+	itemIDs := newResponseItemIDFactory(response.ID)
 
 	// Convert Messages → Output items.
 	var output []OutputItem
@@ -214,6 +217,7 @@ func (a *OpenAIAdapter) FromCoreResponse(ctx context.Context, resp *format.CoreR
 			case "reasoning":
 				output = append(output, OutputItem{
 					Type:   "reasoning",
+					ID:     itemIDs.next("rs"),
 					Status: "completed",
 					Summary: []ReasoningItemSummary{
 						{Type: "text", Text: block.ReasoningText, Signature: block.ReasoningSignature},
@@ -225,13 +229,18 @@ func (a *OpenAIAdapter) FromCoreResponse(ctx context.Context, resp *format.CoreR
 				if len(textParts) > 0 {
 					output = append(output, OutputItem{
 						Type:    "message",
+						ID:      itemIDs.next("msg"),
 						Status:  "completed",
 						Role:    "assistant",
 						Content: copyContentParts(textParts),
 					})
 					textParts = textParts[:0]
 				}
-				output = append(output, buildToolOutputItem(block, resp.Extensions))
+				callID := block.ToolUseID
+				if callID == "" {
+					callID = itemIDs.next("call")
+				}
+				output = append(output, buildToolOutputItem(block, resp.Extensions, itemIDs.next("fc"), callID))
 
 			case "tool_result":
 				// Tool results don't translate to output items in the response.
@@ -245,6 +254,7 @@ func (a *OpenAIAdapter) FromCoreResponse(ctx context.Context, resp *format.CoreR
 		if len(textParts) > 0 {
 			output = append(output, OutputItem{
 				Type:    "message",
+				ID:      itemIDs.next("msg"),
 				Status:  "completed",
 				Role:    "assistant",
 				Content: copyContentParts(textParts),
@@ -362,9 +372,11 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 
 	// State tracked during streaming.
 	var response = &Response{
+		ID:     responseIDOrSynthetic(""),
 		Object: "response",
 		Status: "in_progress",
 	}
+	itemIDFactory := newResponseItemIDFactory(response.ID)
 	contentText := make(map[int]string)
 	toolCallArgs := make(map[int]string)
 	toolBlockNames := make(map[int]string)
@@ -372,6 +384,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 	itemIDs := make(map[int]string)
 	reasonIndexes := make(map[int]bool)
 	toolCallFinalized := make(map[int]bool)
+	inProgressSent := false
 
 	for event := range events {
 		// Let hooks skip events.
@@ -387,6 +400,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 			// Use ItemID as the response ID if set; otherwise keep the current one.
 			if event.ItemID != "" {
 				response.ID = event.ItemID
+				itemIDFactory = newResponseItemIDFactory(response.ID)
 			}
 			response.Status = "in_progress"
 
@@ -398,12 +412,26 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 					Response:       cloneResponse(response),
 				},
 			})
+			if !inProgressSent {
+				send(StreamEvent{
+					Event: "response.in_progress",
+					Data: ResponseLifecycleEvent{
+						Type:           "response.in_progress",
+						SequenceNumber: next(),
+						Response:       cloneResponse(response),
+					},
+				})
+				inProgressSent = true
+			}
 
 		// ==================================================================
 		// Lifecycle: in_progress
 		// ==================================================================
 		case format.CoreEventInProgress:
 			response.Status = "in_progress"
+			if inProgressSent {
+				break
+			}
 			send(StreamEvent{
 				Event: "response.in_progress",
 				Data: ResponseLifecycleEvent{
@@ -412,6 +440,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 					Response:       cloneResponse(response),
 				},
 			})
+			inProgressSent = true
 
 		// ==================================================================
 		// Content block started
@@ -424,12 +453,12 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 
 			switch event.ContentBlock.Type {
 			case "text":
-				id := fmt.Sprintf("msg_item_%d", index)
+				id := itemIDFactory.next("msg")
 				itemIDs[index] = id
 				contentText[index] = ""
 
 			case "reasoning":
-				id := fmt.Sprintf("rs_item_%d", index)
+				id := itemIDFactory.next("rs")
 				itemIDs[index] = id
 				contentText[index] = ""
 				reasonIndexes[index] = true
@@ -458,17 +487,18 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 						ItemID:         id,
 						OutputIndex:    io,
 						SummaryIndex:   0,
+						Part:           ReasoningItemSummary{Type: "summary_text"},
 					},
 				})
 				contentText[index] = ""
 			case "tool_use":
 				toolUseID := event.ContentBlock.ToolUseID
 				if toolUseID == "" {
-					toolUseID = fmt.Sprintf("call_%d", index)
+					toolUseID = itemIDFactory.next("call")
 				}
-				itemIDs[index] = fmt.Sprintf("fc_item_%d", index)
+				itemIDs[index] = itemIDFactory.next("fc")
 				toolBlockNames[index] = event.ContentBlock.ToolName
-				item := buildToolOutputItemStreaming(event.ContentBlock, coreReq.Extensions, toolUseID)
+				item := buildToolOutputItemStreaming(event.ContentBlock, coreReq.Extensions, itemIDs[index], toolUseID)
 				outputIndexes[index] = len(response.Output)
 				response.Output = append(response.Output, item)
 				send(StreamEvent{
@@ -509,7 +539,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 			if _, exists := outputIndexes[index]; !exists {
 				id, ok := itemIDs[index]
 				if !ok {
-					id = fmt.Sprintf("msg_item_%d", index)
+					id = itemIDFactory.next("msg")
 					itemIDs[index] = id
 				}
 				item := OutputItem{
@@ -567,7 +597,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 			if _, hasOutput := outputIndexes[index]; !hasOutput {
 				id := itemIDs[index]
 				if id == "" {
-					id = fmt.Sprintf("msg_item_%d", index)
+					id = itemIDFactory.next("msg")
 					itemIDs[index] = id
 				}
 				outputIndexes[index] = len(response.Output)
@@ -613,19 +643,34 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 				},
 			})
 
-		// ==================================================================
-		// Tool call arguments delta
-		// ==================================================================
+			// ==================================================================
+			// Tool call arguments delta
+			// ==================================================================
 		case format.CoreToolCallArgsDelta:
 			index := event.Index
 			toolCallArgs[index] += event.Delta
+			outputIndex := outputIndexes[index]
+			if outputIndex < len(response.Output) && response.Output[outputIndex].Type == "custom_tool_call" {
+				send(StreamEvent{
+					Event: "response.custom_tool_call_input.delta",
+					Data: CustomToolCallInputDeltaEvent{
+						Type:           "response.custom_tool_call_input.delta",
+						SequenceNumber: next(),
+						ItemID:         itemIDs[index],
+						CallID:         response.Output[outputIndex].CallID,
+						OutputIndex:    outputIndex,
+						Delta:          event.Delta,
+					},
+				})
+				break
+			}
 			send(StreamEvent{
 				Event: "response.function_call_arguments.delta",
 				Data: FunctionCallArgumentsDeltaEvent{
 					Type:           "response.function_call_arguments.delta",
 					SequenceNumber: next(),
 					ItemID:         itemIDs[index],
-					OutputIndex:    outputIndexes[index],
+					OutputIndex:    outputIndex,
 					Delta:          event.Delta,
 				},
 			})
@@ -652,23 +697,38 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 				}
 			}
 			toolCallFinalized[index] = true
-			send(StreamEvent{
-				Event: "response.function_call_arguments.done",
-				Data: FunctionCallArgumentsDoneEvent{
-					Type:           "response.function_call_arguments.done",
-					SequenceNumber: next(),
-					ItemID:         itemIDs[index],
-					OutputIndex:    outputIndexes[index],
-					Arguments:      finalArgs,
-				},
-			})
+			outputIndex := outputIndexes[index]
+			if outputIndex < len(response.Output) && response.Output[outputIndex].Type == "custom_tool_call" {
+				send(StreamEvent{
+					Event: "response.custom_tool_call_input.done",
+					Data: CustomToolCallInputDoneEvent{
+						Type:           "response.custom_tool_call_input.done",
+						SequenceNumber: next(),
+						ItemID:         itemIDs[index],
+						CallID:         response.Output[outputIndex].CallID,
+						OutputIndex:    outputIndex,
+						Input:          response.Output[outputIndex].Input,
+					},
+				})
+			} else {
+				send(StreamEvent{
+					Event: "response.function_call_arguments.done",
+					Data: FunctionCallArgumentsDoneEvent{
+						Type:           "response.function_call_arguments.done",
+						SequenceNumber: next(),
+						ItemID:         itemIDs[index],
+						OutputIndex:    outputIndex,
+						Arguments:      finalArgs,
+					},
+				})
+			}
 			send(StreamEvent{
 				Event: "response.output_item.done",
 				Data: OutputItemEvent{
 					Type:           "response.output_item.done",
 					SequenceNumber: next(),
-					OutputIndex:    outputIndexes[index],
-					Item:           response.Output[outputIndexes[index]],
+					OutputIndex:    outputIndex,
+					Item:           response.Output[outputIndex],
 				},
 			})
 
@@ -743,36 +803,59 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 				},
 			})
 
-		// ==================================================================
-		// Content block done
-		// ==================================================================
+			// ==================================================================
+			// Content block done
+			// ==================================================================
 		case format.CoreContentBlockDone:
 			index := event.Index
 
-			// Reasoning block done — emit reasoning summary part done.
+			// Reasoning block done — close the summary text, summary part, and item.
 			if reasonIndexes[index] {
+				outputIndex := outputIndexes[index]
+				summary := ReasoningItemSummary{
+					Type: "summary_text",
+					Text: contentText[index],
+				}
 				if idx, ok := outputIndexes[index]; ok && idx < len(response.Output) {
 					response.Output[idx].Status = "completed"
-					sig := ""
 					if event.ContentBlock != nil {
-						sig = event.ContentBlock.ReasoningSignature
+						summary.Signature = event.ContentBlock.ReasoningSignature
 					}
-					response.Output[idx].Summary = []ReasoningItemSummary{{
-						Type:      "text",
-						Text:      contentText[index],
-						Signature: sig,
-					}}
+					response.Output[idx].Summary = []ReasoningItemSummary{summary}
 				}
+				send(StreamEvent{
+					Event: "response.reasoning_summary_text.done",
+					Data: ReasoningSummaryTextDoneEvent{
+						Type:           "response.reasoning_summary_text.done",
+						SequenceNumber: next(),
+						ItemID:         itemIDs[index],
+						OutputIndex:    outputIndex,
+						SummaryIndex:   0,
+						Text:           contentText[index],
+					},
+				})
 				send(StreamEvent{
 					Event: "response.reasoning_summary_part.done",
 					Data: ReasoningSummaryPartDoneEvent{
 						Type:           "response.reasoning_summary_part.done",
 						SequenceNumber: next(),
 						ItemID:         itemIDs[index],
-						OutputIndex:    outputIndexes[index],
+						OutputIndex:    outputIndex,
 						SummaryIndex:   0,
+						Part:           summary,
 					},
 				})
+				if outputIndex < len(response.Output) {
+					send(StreamEvent{
+						Event: "response.output_item.done",
+						Data: OutputItemEvent{
+							Type:           "response.output_item.done",
+							SequenceNumber: next(),
+							OutputIndex:    outputIndex,
+							Item:           response.Output[outputIndex],
+						},
+					})
+				}
 				delete(contentText, index)
 				delete(itemIDs, index)
 				delete(outputIndexes, index)
@@ -785,7 +868,7 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 				// Ensure output item exists (may not be created if no deltas arrived).
 				if _, hasOutput := outputIndexes[index]; !hasOutput {
 					if itemID == "" {
-						itemID = fmt.Sprintf("msg_item_%d", index)
+						itemID = itemIDFactory.next("msg")
 						itemIDs[index] = itemID
 					}
 					outputIndexes[index] = len(response.Output)
@@ -872,17 +955,31 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 					}
 				}
 
-				// function_call_arguments.done
-				send(StreamEvent{
-					Event: "response.function_call_arguments.done",
-					Data: FunctionCallArgumentsDoneEvent{
-						Type:           "response.function_call_arguments.done",
-						SequenceNumber: next(),
-						ItemID:         itemID,
-						OutputIndex:    outputIndex,
-						Arguments:      finalArgs,
-					},
-				})
+				if outputIndex < len(response.Output) && response.Output[outputIndex].Type == "custom_tool_call" {
+					send(StreamEvent{
+						Event: "response.custom_tool_call_input.done",
+						Data: CustomToolCallInputDoneEvent{
+							Type:           "response.custom_tool_call_input.done",
+							SequenceNumber: next(),
+							ItemID:         itemID,
+							CallID:         response.Output[outputIndex].CallID,
+							OutputIndex:    outputIndex,
+							Input:          response.Output[outputIndex].Input,
+						},
+					})
+				} else {
+					// function_call_arguments.done
+					send(StreamEvent{
+						Event: "response.function_call_arguments.done",
+						Data: FunctionCallArgumentsDoneEvent{
+							Type:           "response.function_call_arguments.done",
+							SequenceNumber: next(),
+							ItemID:         itemID,
+							OutputIndex:    outputIndex,
+							Arguments:      finalArgs,
+						},
+					})
+				}
 
 				// output_item.done
 				send(StreamEvent{
@@ -1415,6 +1512,42 @@ func isReasoningModel(model string) bool {
 		strings.Contains(m, "reasoning")
 }
 
+type responseItemIDFactory struct {
+	suffix   string
+	counters map[string]int
+}
+
+func responseIDOrSynthetic(id string) string {
+	if id != "" {
+		return id
+	}
+	return "resp_" + compactUUID()
+}
+
+func newResponseItemIDFactory(responseID string) *responseItemIDFactory {
+	suffix := strings.TrimPrefix(responseID, "resp_")
+	if suffix == "" {
+		suffix = compactUUID()
+	}
+	return &responseItemIDFactory{
+		suffix:   suffix,
+		counters: make(map[string]int),
+	}
+}
+
+func (f *responseItemIDFactory) next(prefix string) string {
+	if f == nil {
+		return prefix + "_" + compactUUID()
+	}
+	n := f.counters[prefix]
+	f.counters[prefix] = n + 1
+	return fmt.Sprintf("%s_%s_%d", prefix, f.suffix, n)
+}
+
+func compactUUID() string {
+	return strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
 // toolInputString converts a json.RawMessage tool input to a string,
 // defaulting to "{}" when the input is nil or null.
 func toolInputString(input json.RawMessage) string {
@@ -1465,22 +1598,22 @@ func localShellActionFromRaw(raw json.RawMessage) *ToolAction {
 
 // buildToolOutputItem constructs an OutputItem using the codex_tool_map
 // to determine the correct output item type (function_call, custom_tool_call, local_shell_call).
-func buildToolOutputItem(block format.CoreContentBlock, extensions map[string]any) OutputItem {
+func buildToolOutputItem(block format.CoreContentBlock, extensions map[string]any, itemID, callID string) OutputItem {
 	toolMap := codextool.DecodeToolMapFromExtensions(extensions)
 	itemT, itemN, itemNS, itemInput, isLS, actionJSON := codextool.OutputItemFromBlock(block.ToolName, block.ToolInput, toolMap)
 	if isLS {
 		return OutputItem{
 			Type:   "local_shell_call",
-			ID:     block.ToolUseID,
-			CallID: block.ToolUseID,
+			ID:     itemID,
+			CallID: callID,
 			Status: "completed",
 			Action: localShellActionFromRaw(actionJSON),
 		}
 	}
 	return OutputItem{
 		Type:      itemT,
-		ID:        block.ToolUseID,
-		CallID:    block.ToolUseID,
+		ID:        itemID,
+		CallID:    callID,
 		Name:      itemN,
 		Namespace: itemNS,
 		Arguments: toolInputString(block.ToolInput),
@@ -1491,23 +1624,23 @@ func buildToolOutputItem(block format.CoreContentBlock, extensions map[string]an
 
 // buildToolOutputItemStreaming constructs a streaming OutputItem for a tool_use content block start.
 // The item is created with "in_progress" status.
-func buildToolOutputItemStreaming(block *format.CoreContentBlock, extensions map[string]any, toolUseID string) OutputItem {
+func buildToolOutputItemStreaming(block *format.CoreContentBlock, extensions map[string]any, itemID, callID string) OutputItem {
 	toolMap := codextool.DecodeToolMapFromExtensions(extensions)
 	itemT, itemN, itemNS, itemInput, isLS, actionJSON := codextool.OutputItemFromBlock(block.ToolName, block.ToolInput, toolMap)
 	_ = itemInput
 	if isLS {
 		return OutputItem{
 			Type:   "local_shell_call",
-			ID:     toolUseID,
-			CallID: toolUseID,
+			ID:     itemID,
+			CallID: callID,
 			Status: "in_progress",
 			Action: localShellActionFromRaw(actionJSON),
 		}
 	}
 	return OutputItem{
 		Type:      itemT,
-		ID:        toolUseID,
-		CallID:    toolUseID,
+		ID:        itemID,
+		CallID:    callID,
 		Name:      itemN,
 		Namespace: itemNS,
 		Arguments: toolInputString(block.ToolInput),

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1084,38 +1084,28 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 
 	messages := make([]format.CoreMessage, 0, len(items))
 	system := make([]format.CoreContentBlock, 0)
-	var pendingReasoning []format.CoreContentBlock
-	var pendingFCBlocks []format.CoreContentBlock // batch consecutive function_calls
+	var pendingAssistant []format.CoreContentBlock
+
+	flushPendingAssistant := func() {
+		if len(pendingAssistant) == 0 {
+			return
+		}
+		flushed := make([]format.CoreContentBlock, len(pendingAssistant))
+		copy(flushed, pendingAssistant)
+		messages = append(messages, format.CoreMessage{
+			Role:    "assistant",
+			Content: flushed,
+		})
+		pendingAssistant = pendingAssistant[:0]
+	}
 
 	for _, item := range items {
 		if isToolCallOutputType(item.Type) {
-			// Keep any pending reasoning within the same assistant tool-call turn.
-			// Emitting a standalone assistant reasoning message here would break
-			// the required adjacency of assistant tool_use -> immediate tool_result.
-			if len(pendingFCBlocks) > 0 && len(pendingReasoning) > 0 {
-				pendingFCBlocks = mergeReasoningBeforeToolUse(pendingFCBlocks, pendingReasoning)
-				pendingReasoning = pendingReasoning[:0]
-			}
-			// Flush pending function_calls before tool results.
-			if len(pendingFCBlocks) > 0 {
-				flushed := make([]format.CoreContentBlock, len(pendingFCBlocks))
-				copy(flushed, pendingFCBlocks)
-				messages = append(messages, format.CoreMessage{
-					Role:    "assistant",
-					Content: flushed,
-				})
-				pendingFCBlocks = pendingFCBlocks[:0]
-			}
-			// Flush pending reasoning before tool results.
-			if len(pendingReasoning) > 0 {
-				flushedReasoning := make([]format.CoreContentBlock, len(pendingReasoning))
-				copy(flushedReasoning, pendingReasoning)
-				messages = append(messages, format.CoreMessage{
-					Role:    "assistant",
-					Content: flushedReasoning,
-				})
-				pendingReasoning = pendingReasoning[:0]
-			}
+			// Tool results must immediately follow the assistant turn containing
+			// the matching tool_use block. Keep any text/reasoning that preceded
+			// the tool call in the same assistant message instead of replaying it
+			// as a standalone assistant turn in later tool loops.
+			flushPendingAssistant()
 			// Each tool result → separate tool-role Core message.
 			messages = append(messages, format.CoreMessage{
 				Role: "tool",
@@ -1127,18 +1117,6 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 			})
 			continue
 		}
-		// Flush pending function_calls before non-function-call items.
-		// Don't flush between consecutive function_call items — they should
-		// be batched into a single assistant message.
-		if !isToolCallInputType(item.Type) && item.Type != "reasoning" && len(pendingFCBlocks) > 0 {
-			flushed := make([]format.CoreContentBlock, len(pendingFCBlocks))
-			copy(flushed, pendingFCBlocks)
-			messages = append(messages, format.CoreMessage{
-				Role:    "assistant",
-				Content: flushed,
-			})
-			pendingFCBlocks = pendingFCBlocks[:0]
-		}
 
 		role := item.Role
 		if role == "" {
@@ -1148,11 +1126,11 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 		// Handle reasoning input items — convert to thinking blocks for the next assistant message.
 		if item.Type == "reasoning" {
 			blocks := reasoningBlocksFromSummary(item.Summary)
-			if len(pendingFCBlocks) > 0 {
-				pendingFCBlocks = mergeReasoningBeforeToolUse(pendingFCBlocks, blocks)
+			if containsToolUse(pendingAssistant) {
+				pendingAssistant = mergeReasoningBeforeToolUse(pendingAssistant, blocks)
 				continue
 			}
-			pendingReasoning = append(pendingReasoning, blocks...)
+			pendingAssistant = append(pendingAssistant, blocks...)
 			continue
 		}
 
@@ -1165,8 +1143,8 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 			// dummy reasoning block is injected if pendingReasoning is empty.
 			// A future fix should add a dummy reasoning block here when:
 			// (a) the model is a reasoning model, and (b) pendingReasoning is empty.
-			if len(pendingReasoning) == 0 && isReasoningModel(model) {
-				pendingReasoning = append(pendingReasoning, format.CoreContentBlock{
+			if !containsReasoning(pendingAssistant) && isReasoningModel(model) {
+				pendingAssistant = append(pendingAssistant, format.CoreContentBlock{
 					Type:          "reasoning",
 					ReasoningText: "",
 				})
@@ -1174,15 +1152,11 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 
 			// function_call in input → tool_use assistant block.
 			// Collect into pendingFCBlocks to batch consecutive calls into a single assistant message.
-			if len(pendingReasoning) > 0 {
-				pendingFCBlocks = append(pendingFCBlocks, pendingReasoning...)
-				pendingReasoning = pendingReasoning[:0]
-			}
 			toolInput := json.RawMessage(item.Arguments)
 			if !json.Valid([]byte(item.Arguments)) {
 				toolInput = json.RawMessage(`{}`)
 			}
-			pendingFCBlocks = append(pendingFCBlocks, format.CoreContentBlock{
+			pendingAssistant = append(pendingAssistant, format.CoreContentBlock{
 				Type:      "tool_use",
 				ToolUseID: firstNonEmpty(item.CallID, item.ID),
 				ToolName:  item.Name,
@@ -1190,10 +1164,6 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 			})
 
 		case item.Type == "custom_tool_call" || item.Type == "local_shell_call":
-			if len(pendingReasoning) > 0 {
-				pendingFCBlocks = append(pendingFCBlocks, pendingReasoning...)
-				pendingReasoning = pendingReasoning[:0]
-			}
 			toolInput := json.RawMessage(item.Arguments)
 			if !json.Valid([]byte(item.Arguments)) {
 				if item.Input != "" {
@@ -1206,7 +1176,7 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 				data, _ := json.Marshal(item.Action)
 				toolInput = data
 			}
-			pendingFCBlocks = append(pendingFCBlocks, format.CoreContentBlock{
+			pendingAssistant = append(pendingAssistant, format.CoreContentBlock{
 				Type:      "tool_use",
 				ToolUseID: firstNonEmpty(item.CallID, item.ID),
 				ToolName:  item.Name,
@@ -1214,6 +1184,7 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 			})
 
 		case role == "system" || role == "developer":
+			flushPendingAssistant()
 			blocks := contentBlocksFromRaw(item.Content)
 			if len(blocks) > 0 {
 				system = append(system, blocks...)
@@ -1221,20 +1192,12 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 
 		case role == "assistant":
 			blocks := contentBlocksFromRaw(item.Content)
-			// Prepend any pending reasoning blocks (from previous reasoning input items)
-			// before the assistant message content.
-			if len(pendingReasoning) > 0 {
-				blocks = append(pendingReasoning, blocks...)
-				pendingReasoning = pendingReasoning[:0]
-			}
 			if len(blocks) > 0 {
-				messages = append(messages, format.CoreMessage{
-					Role:    "assistant",
-					Content: blocks,
-				})
+				pendingAssistant = append(pendingAssistant, blocks...)
 			}
 
 		default:
+			flushPendingAssistant()
 			blocks := contentBlocksFromRaw(item.Content)
 			if len(blocks) > 0 {
 				messages = append(messages, format.CoreMessage{
@@ -1245,23 +1208,7 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 		}
 	}
 
-	// Flush remaining reasoning blocks (no following assistant message).
-	if len(pendingReasoning) > 0 {
-		messages = append(messages, format.CoreMessage{
-			Role:    "assistant",
-			Content: pendingReasoning,
-		})
-	}
-
-	// Flush any remaining batched function_calls.
-	if len(pendingFCBlocks) > 0 {
-		flushed := make([]format.CoreContentBlock, len(pendingFCBlocks))
-		copy(flushed, pendingFCBlocks)
-		messages = append(messages, format.CoreMessage{
-			Role:    "assistant",
-			Content: flushed,
-		})
-	}
+	flushPendingAssistant()
 
 	return messages, system, nil
 }
@@ -1473,6 +1420,24 @@ func mergeReasoningBeforeToolUse(blocks []format.CoreContentBlock, reasoning []f
 	merged = append(merged, reasoning...)
 	merged = append(merged, blocks[insertAt:]...)
 	return merged
+}
+
+func containsReasoning(blocks []format.CoreContentBlock) bool {
+	for _, block := range blocks {
+		if block.Type == "reasoning" {
+			return true
+		}
+	}
+	return false
+}
+
+func containsToolUse(blocks []format.CoreContentBlock) bool {
+	for _, block := range blocks {
+		if block.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
 }
 
 func isToolCallInputType(itemType string) bool {

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -3,9 +3,11 @@ package openai_test
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
+	"moonbridge/internal/extension/codextool"
 	"moonbridge/internal/format"
 	"moonbridge/internal/protocol/openai"
 )
@@ -151,6 +153,59 @@ func TestFromCoreResponse_Basic(t *testing.T) {
 	if resp.Status != "completed" {
 		t.Errorf("Status = %q", resp.Status)
 	}
+	if len(resp.Output) != 1 {
+		t.Fatalf("Output len=%d, want 1", len(resp.Output))
+	}
+	if !strings.HasPrefix(resp.Output[0].ID, "msg_123_") {
+		t.Fatalf("message output id = %q, want msg_123_*", resp.Output[0].ID)
+	}
+}
+
+func TestFromCoreResponse_SynthesizesStableResponseStyleIDs(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+
+	coreResp := &format.CoreResponse{
+		Status: "completed",
+		Model:  "deepseek-v4-pro",
+		Messages: []format.CoreMessage{
+			{Role: "assistant", Content: []format.CoreContentBlock{
+				{Type: "reasoning", ReasoningText: "think"},
+				{Type: "text", Text: "before"},
+				{Type: "tool_use", ToolUseID: "call_1", ToolName: "exec_command", ToolInput: json.RawMessage(`{"cmd":"pwd"}`)},
+				{Type: "text", Text: "after"},
+			}},
+		},
+	}
+
+	result, err := adapter.FromCoreResponse(context.Background(), coreResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := result.(*openai.Response)
+
+	if !strings.HasPrefix(resp.ID, "resp_") {
+		t.Fatalf("response id = %q, want resp_*", resp.ID)
+	}
+	if len(resp.Output) != 4 {
+		t.Fatalf("Output len=%d, want 4: %+v", len(resp.Output), resp.Output)
+	}
+	wantPrefixes := []string{"rs_", "msg_", "fc_", "msg_"}
+	seen := make(map[string]bool)
+	for i, item := range resp.Output {
+		if !strings.HasPrefix(item.ID, wantPrefixes[i]) {
+			t.Fatalf("output[%d].ID = %q, want prefix %q", i, item.ID, wantPrefixes[i])
+		}
+		if seen[item.ID] {
+			t.Fatalf("duplicate output id %q in %+v", item.ID, resp.Output)
+		}
+		seen[item.ID] = true
+	}
+	if resp.Output[2].CallID != "call_1" {
+		t.Fatalf("tool call_id = %q, want call_1", resp.Output[2].CallID)
+	}
+	if resp.Output[2].ID == resp.Output[2].CallID {
+		t.Fatalf("tool item id should differ from call_id: %+v", resp.Output[2])
+	}
 }
 
 func TestFromCoreResponse_Error(t *testing.T) {
@@ -294,8 +349,8 @@ func TestToCoreRequest_BatchesCustomToolCallsAndOutputsIntoSingleRound(t *testin
 	for i, want := range []struct {
 		assistantTextIdx int
 		msgIdx           int
-		callID  string
-		outcome string
+		callID           string
+		outcome          string
 	}{
 		{0, 1, "call_a", "ok a"},
 		{3, 4, "call_b", "ok b"},
@@ -348,7 +403,34 @@ func TestFromCoreStream_NoDuplicateDoneForToolUse(t *testing.T) {
 	stream := streamAny.(<-chan openai.StreamEvent)
 	var argsDone int
 	var itemDone int
+	var toolItemID string
 	for ev := range stream {
+		switch ev.Event {
+		case "response.output_item.added":
+			data := ev.Data.(openai.OutputItemEvent)
+			if data.Item.Type == "function_call" {
+				toolItemID = data.Item.ID
+				if !strings.HasPrefix(toolItemID, "fc_") {
+					t.Fatalf("tool item id = %q, want fc_*", toolItemID)
+				}
+				if data.Item.CallID != "call_1" {
+					t.Fatalf("tool call_id = %q, want call_1", data.Item.CallID)
+				}
+				if data.Item.ID == data.Item.CallID {
+					t.Fatalf("tool item id should differ from call_id: %+v", data.Item)
+				}
+			}
+		case "response.function_call_arguments.delta":
+			data := ev.Data.(openai.FunctionCallArgumentsDeltaEvent)
+			if data.ItemID != toolItemID {
+				t.Fatalf("args delta item_id = %q, want %q", data.ItemID, toolItemID)
+			}
+		case "response.function_call_arguments.done":
+			data := ev.Data.(openai.FunctionCallArgumentsDoneEvent)
+			if data.ItemID != toolItemID {
+				t.Fatalf("args done item_id = %q, want %q", data.ItemID, toolItemID)
+			}
+		}
 		if ev.Event == "response.function_call_arguments.done" {
 			argsDone++
 		}
@@ -363,5 +445,350 @@ func TestFromCoreStream_NoDuplicateDoneForToolUse(t *testing.T) {
 	}
 	if itemDone != 1 {
 		t.Fatalf("output_item.done (tool) count=%d, want 1", itemDone)
+	}
+}
+
+func TestFromCoreStream_ReasoningSummaryLifecycle(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	coreReq := &format.CoreRequest{Model: "deepseek-v4"}
+	evCh := make(chan format.CoreStreamEvent, 8)
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockStarted,
+		Index: 1,
+		ContentBlock: &format.CoreContentBlock{
+			Type: "reasoning",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreTextDelta, Index: 1, Delta: "thinking"}
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockDone,
+		Index: 1,
+		ContentBlock: &format.CoreContentBlock{
+			Type:               "reasoning",
+			ReasoningSignature: "sig-1",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreEventCompleted, Status: "completed"}
+	close(evCh)
+
+	streamAny, err := adapter.FromCoreStream(context.Background(), coreReq, evCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var events []string
+	var addedPart openai.ReasoningSummaryPartAddedEvent
+	var textDone openai.ReasoningSummaryTextDoneEvent
+	var partDone openai.ReasoningSummaryPartDoneEvent
+	var itemDone openai.OutputItemEvent
+	for ev := range streamAny.(<-chan openai.StreamEvent) {
+		events = append(events, ev.Event)
+		switch ev.Event {
+		case "response.reasoning_summary_part.added":
+			addedPart = ev.Data.(openai.ReasoningSummaryPartAddedEvent)
+		case "response.reasoning_summary_text.done":
+			textDone = ev.Data.(openai.ReasoningSummaryTextDoneEvent)
+		case "response.reasoning_summary_part.done":
+			partDone = ev.Data.(openai.ReasoningSummaryPartDoneEvent)
+		case "response.output_item.done":
+			if data := ev.Data.(openai.OutputItemEvent); data.Item.Type == "reasoning" {
+				itemDone = data
+			}
+		}
+	}
+
+	want := []string{
+		"response.output_item.added",
+		"response.reasoning_summary_part.added",
+		"response.reasoning_summary_text.delta",
+		"response.reasoning_summary_text.done",
+		"response.reasoning_summary_part.done",
+		"response.output_item.done",
+		"response.completed",
+	}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %#v, want %#v", events, want)
+	}
+	if addedPart.Part.Type != "summary_text" {
+		t.Fatalf("added part = %+v, want summary_text", addedPart.Part)
+	}
+	if textDone.Text != "thinking" {
+		t.Fatalf("text done = %q, want thinking", textDone.Text)
+	}
+	if partDone.Part.Type != "summary_text" || partDone.Part.Text != "thinking" || partDone.Part.Signature != "sig-1" {
+		t.Fatalf("part done = %+v, want completed reasoning part", partDone.Part)
+	}
+	if itemDone.Item.Status != "completed" || len(itemDone.Item.Summary) != 1 || itemDone.Item.Summary[0].Text != "thinking" {
+		t.Fatalf("item done = %+v, want completed reasoning item", itemDone.Item)
+	}
+}
+
+func TestFromCoreStream_CustomToolUsesCustomInputEvents(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	coreReq := &format.CoreRequest{
+		Model: "deepseek-v4",
+		Extensions: map[string]any{
+			"codex_tool_map": codextool.ToolMap{
+				"apply_patch": {
+					Kind:       codextool.ToolRaw,
+					OpenAIName: "apply_patch",
+				},
+			}.Encode(),
+		},
+	}
+	evCh := make(chan format.CoreStreamEvent, 8)
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockStarted,
+		Index: 2,
+		ContentBlock: &format.CoreContentBlock{
+			Type:      "tool_use",
+			ToolUseID: "call_patch",
+			ToolName:  "apply_patch",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreToolCallArgsDelta, Index: 2, Delta: `{"input":"*** Begin Patch\n*** End Patch"}`}
+	evCh <- format.CoreStreamEvent{Type: format.CoreContentBlockDone, Index: 2}
+	evCh <- format.CoreStreamEvent{Type: format.CoreEventCompleted, Status: "completed"}
+	close(evCh)
+
+	streamAny, err := adapter.FromCoreStream(context.Background(), coreReq, evCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var customDelta int
+	var customDone int
+	var functionArgsDone int
+	for ev := range streamAny.(<-chan openai.StreamEvent) {
+		switch ev.Event {
+		case "response.custom_tool_call_input.delta":
+			customDelta++
+			data := ev.Data.(openai.CustomToolCallInputDeltaEvent)
+			if data.CallID != "call_patch" || data.Delta == "" {
+				t.Fatalf("custom delta = %+v", data)
+			}
+		case "response.custom_tool_call_input.done":
+			customDone++
+			data := ev.Data.(openai.CustomToolCallInputDoneEvent)
+			if data.CallID != "call_patch" || data.Input != "*** Begin Patch\n*** End Patch" {
+				t.Fatalf("custom done = %+v", data)
+			}
+		case "response.function_call_arguments.done":
+			functionArgsDone++
+		}
+	}
+	if customDelta != 1 {
+		t.Fatalf("custom_tool_call_input.delta count=%d, want 1", customDelta)
+	}
+	if customDone != 1 {
+		t.Fatalf("custom_tool_call_input.done count=%d, want 1", customDone)
+	}
+	if functionArgsDone != 0 {
+		t.Fatalf("function_call_arguments.done count=%d, want 0", functionArgsDone)
+	}
+}
+
+func TestFromCoreStream_InterleavedTextAndToolsLifecycle(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	coreReq := &format.CoreRequest{
+		Model: "deepseek-v4-pro",
+		Extensions: map[string]any{
+			"codex_tool_map": codextool.ToolMap{
+				"apply_patch": {
+					Kind:       codextool.ToolRaw,
+					OpenAIName: "apply_patch",
+				},
+			}.Encode(),
+		},
+	}
+
+	// Simulate DeepSeek stream: thinking → text → tool_use → text
+	evCh := make(chan format.CoreStreamEvent, 20)
+	evCh <- format.CoreStreamEvent{Type: format.CoreEventCreated, Status: "in_progress", Model: "deepseek-v4-pro"}
+
+	// 1. thinking / reasoning_content block
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockStarted,
+		Index: 0,
+		ContentBlock: &format.CoreContentBlock{
+			Type:          "reasoning",
+			ReasoningText: "I need to check the code first.",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreTextDelta, Index: 0, Delta: "I need to check the code first."}
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockDone,
+		Index: 0,
+		ContentBlock: &format.CoreContentBlock{
+			Type:               "reasoning",
+			ReasoningSignature: "deepseek-sig-abc",
+		},
+	}
+
+	// 2. first text block
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockStarted,
+		Index: 1,
+		ContentBlock: &format.CoreContentBlock{
+			Type: "text",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreTextDelta, Index: 1, Delta: "Let me read the file."}
+	evCh <- format.CoreStreamEvent{Type: format.CoreContentBlockDone, Index: 1}
+
+	// 3. tool_use block
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockStarted,
+		Index: 2,
+		ContentBlock: &format.CoreContentBlock{
+			Type:      "tool_use",
+			ToolUseID: "call_patch",
+			ToolName:  "apply_patch",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreToolCallArgsDelta, Index: 2, Delta: `{"input":"*** Begin Patch\n*** End Patch"}`}
+	evCh <- format.CoreStreamEvent{Type: format.CoreContentBlockDone, Index: 2}
+
+	// 4. second text block
+	evCh <- format.CoreStreamEvent{
+		Type:  format.CoreContentBlockStarted,
+		Index: 3,
+		ContentBlock: &format.CoreContentBlock{
+			Type: "text",
+		},
+	}
+	evCh <- format.CoreStreamEvent{Type: format.CoreTextDelta, Index: 3, Delta: "The change looks correct."}
+	evCh <- format.CoreStreamEvent{Type: format.CoreContentBlockDone, Index: 3}
+
+	evCh <- format.CoreStreamEvent{Type: format.CoreEventCompleted, Status: "completed"}
+	close(evCh)
+
+	streamAny, err := adapter.FromCoreStream(context.Background(), coreReq, evCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var events []string
+	var completed *openai.ResponseLifecycleEvent
+	var responseCreated *openai.ResponseLifecycleEvent
+	var responseInProgress *openai.ResponseLifecycleEvent
+	var customToolID string
+	for ev := range streamAny.(<-chan openai.StreamEvent) {
+		events = append(events, ev.Event)
+		switch ev.Event {
+		case "response.created":
+			data := ev.Data.(openai.ResponseLifecycleEvent)
+			responseCreated = &data
+		case "response.in_progress":
+			data := ev.Data.(openai.ResponseLifecycleEvent)
+			responseInProgress = &data
+		case "response.custom_tool_call_input.delta":
+			data := ev.Data.(openai.CustomToolCallInputDeltaEvent)
+			if data.CallID != "call_patch" {
+				t.Fatalf("custom delta call_id = %q, want call_patch", data.CallID)
+			}
+			if !strings.HasPrefix(data.ItemID, "fc_") {
+				t.Fatalf("custom delta item_id = %q, want fc_*", data.ItemID)
+			}
+			customToolID = data.ItemID
+		case "response.custom_tool_call_input.done":
+			data := ev.Data.(openai.CustomToolCallInputDoneEvent)
+			if data.CallID != "call_patch" {
+				t.Fatalf("custom done call_id = %q, want call_patch", data.CallID)
+			}
+			if data.ItemID != customToolID {
+				t.Fatalf("custom done item_id = %q, want %q", data.ItemID, customToolID)
+			}
+		case "response.completed":
+			data := ev.Data.(openai.ResponseLifecycleEvent)
+			completed = &data
+		}
+	}
+
+	// Verify event order follows the expected interleaved lifecycle.
+	wantOrder := []string{
+		"response.created",
+		"response.in_progress",
+		"response.output_item.added", // reasoning
+		"response.reasoning_summary_part.added",
+		"response.reasoning_summary_text.delta",
+		"response.reasoning_summary_text.done",
+		"response.reasoning_summary_part.done",
+		"response.output_item.done",  // reasoning completed
+		"response.output_item.added", // text 1
+		"response.content_part.added",
+		"response.output_text.delta",
+		"response.output_text.done",
+		"response.content_part.done",
+		"response.output_item.done",  // text 1 completed
+		"response.output_item.added", // custom tool
+		"response.custom_tool_call_input.delta",
+		"response.custom_tool_call_input.done",
+		"response.output_item.done",  // custom tool completed
+		"response.output_item.added", // text 2
+		"response.content_part.added",
+		"response.output_text.delta",
+		"response.output_text.done",
+		"response.content_part.done",
+		"response.output_item.done", // text 2 completed
+		"response.completed",
+	}
+	if !reflect.DeepEqual(events, wantOrder) {
+		t.Fatalf("events = %#v\nwant %#v", events, wantOrder)
+	}
+	if responseCreated == nil || !strings.HasPrefix(responseCreated.Response.ID, "resp_") {
+		t.Fatalf("response.created = %+v, want resp_* id", responseCreated)
+	}
+	if responseInProgress == nil || responseInProgress.Response.ID != responseCreated.Response.ID {
+		t.Fatalf("response.in_progress = %+v, want same response id as created %+v", responseInProgress, responseCreated)
+	}
+
+	// Verify response.Output in completed event has all four items in correct order.
+	if completed == nil {
+		t.Fatal("missing response.completed")
+	}
+	resp := completed.Response
+	if len(resp.Output) != 4 {
+		t.Fatalf("Output len=%d, want 4: %+v", len(resp.Output), resp.Output)
+	}
+	if resp.ID != responseCreated.Response.ID {
+		t.Fatalf("completed response id = %q, want %q", resp.ID, responseCreated.Response.ID)
+	}
+	if want := []string{"reasoning", "message", "custom_tool_call", "message"}; !reflect.DeepEqual(
+		[]string{resp.Output[0].Type, resp.Output[1].Type, resp.Output[2].Type, resp.Output[3].Type},
+		want,
+	) {
+		t.Fatalf("Output types = %v, want %v",
+			[]string{resp.Output[0].Type, resp.Output[1].Type, resp.Output[2].Type, resp.Output[3].Type}, want)
+	}
+	if resp.Output[0].Status != "completed" || resp.Output[1].Status != "completed" ||
+		resp.Output[2].Status != "completed" || resp.Output[3].Status != "completed" {
+		t.Fatalf("all Output items should be completed: %+v", resp.Output)
+	}
+	wantPrefixes := []string{"rs_", "msg_", "fc_", "msg_"}
+	seen := make(map[string]bool)
+	for i, item := range resp.Output {
+		if !strings.HasPrefix(item.ID, wantPrefixes[i]) {
+			t.Fatalf("output[%d].ID = %q, want prefix %q", i, item.ID, wantPrefixes[i])
+		}
+		if seen[item.ID] {
+			t.Fatalf("duplicate output item id %q in %+v", item.ID, resp.Output)
+		}
+		seen[item.ID] = true
+	}
+	if resp.Output[2].ID != customToolID {
+		t.Fatalf("custom tool item id = %q, want event item_id %q", resp.Output[2].ID, customToolID)
+	}
+	if resp.Output[2].CallID != "call_patch" {
+		t.Fatalf("custom tool call_id = %q, want call_patch", resp.Output[2].CallID)
+	}
+	if resp.Output[2].ID == resp.Output[2].CallID {
+		t.Fatalf("custom tool item id should differ from call_id: %+v", resp.Output[2])
+	}
+	if resp.Output[1].Content == nil || len(resp.Output[1].Content) == 0 || resp.Output[1].Content[0].Text != "Let me read the file." {
+		t.Fatalf("text 1 content = %+v", resp.Output[1].Content)
+	}
+	if resp.Output[3].Content == nil || len(resp.Output[3].Content) == 0 || resp.Output[3].Content[0].Text != "The change looks correct." {
+		t.Fatalf("text 2 content = %+v", resp.Output[3].Content)
 	}
 }

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -273,6 +273,46 @@ func TestToCoreRequest_ReasoningModelInjectsEmptyReasoningBeforeFunctionCall(t *
 	}
 }
 
+func TestToCoreRequest_KeepsAssistantTextWithFollowingToolUse(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	req := &openai.ResponsesRequest{
+		Model: "deepseek-v4-pro",
+		Input: json.RawMessage(`[
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"I will inspect the file."}]},
+			{"type":"function_call","id":"fc_1","call_id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}
+		]`),
+	}
+
+	result, err := adapter.ToCoreRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Messages) != 3 {
+		t.Fatalf("messages len=%d, want 3; got %+v", len(result.Messages), result.Messages)
+	}
+	assistant := result.Messages[0]
+	if assistant.Role != "assistant" {
+		t.Fatalf("messages[0].Role=%q, want assistant", assistant.Role)
+	}
+	if len(assistant.Content) != 2 {
+		t.Fatalf("assistant content len=%d, want text + tool_use; got %+v", len(assistant.Content), assistant.Content)
+	}
+	if assistant.Content[0].Type != "text" || assistant.Content[0].Text != "I will inspect the file." {
+		t.Fatalf("assistant.Content[0]=%+v, want preserved text", assistant.Content[0])
+	}
+	if assistant.Content[1].Type != "tool_use" || assistant.Content[1].ToolUseID != "call_1" {
+		t.Fatalf("assistant.Content[1]=%+v, want tool_use call_1", assistant.Content[1])
+	}
+	if result.Messages[1].Role != "tool" || result.Messages[1].Content[0].ToolUseID != "call_1" {
+		t.Fatalf("messages[1]=%+v, want tool result call_1", result.Messages[1])
+	}
+	if result.Messages[2].Role != "user" || result.Messages[2].Content[0].Text != "continue" {
+		t.Fatalf("messages[2]=%+v, want user continue", result.Messages[2])
+	}
+}
+
 func TestToCoreRequest_KeepsToolUseAdjacentToToolResultWhenReasoningPrecedesOutput(t *testing.T) {
 	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
 	req := &openai.ResponsesRequest{
@@ -338,30 +378,29 @@ func TestToCoreRequest_BatchesCustomToolCallsAndOutputsIntoSingleRound(t *testin
 		t.Fatal(err)
 	}
 
-	if len(result.Messages) != 10 {
-		t.Fatalf("messages len=%d, want 10; got %+v", len(result.Messages), result.Messages)
-	}
-
-	if result.Messages[0].Role != "assistant" || len(result.Messages[0].Content) != 1 || result.Messages[0].Content[0].Text != "before tools" {
-		t.Fatalf("messages[0]=%+v, want pre-tool assistant text", result.Messages[0])
+	if len(result.Messages) != 7 {
+		t.Fatalf("messages len=%d, want 7; got %+v", len(result.Messages), result.Messages)
 	}
 
 	for i, want := range []struct {
-		assistantTextIdx int
-		msgIdx           int
-		callID           string
-		outcome          string
+		msgIdx  int
+		text    string
+		callID  string
+		outcome string
 	}{
-		{0, 1, "call_a", "ok a"},
-		{3, 4, "call_b", "ok b"},
-		{6, 7, "call_c", "ok c"},
+		{0, "before tools", "call_a", "ok a"},
+		{2, "between tools", "call_b", "ok b"},
+		{4, "between tools 2", "call_c", "ok c"},
 	} {
-		if result.Messages[want.assistantTextIdx].Role != "assistant" {
-			t.Fatalf("assistant commentary turn %d = %+v", i, result.Messages[want.assistantTextIdx])
-		}
 		assistant := result.Messages[want.msgIdx]
-		if assistant.Role != "assistant" || len(assistant.Content) != 1 || assistant.Content[0].Type != "tool_use" || assistant.Content[0].ToolUseID != want.callID {
+		if assistant.Role != "assistant" || len(assistant.Content) != 2 {
 			t.Fatalf("assistant tool turn %d = %+v", i, assistant)
+		}
+		if assistant.Content[0].Type != "text" || assistant.Content[0].Text != want.text {
+			t.Fatalf("assistant text turn %d = %+v, want %q", i, assistant.Content[0], want.text)
+		}
+		if assistant.Content[1].Type != "tool_use" || assistant.Content[1].ToolUseID != want.callID {
+			t.Fatalf("assistant tool turn %d content[1] = %+v, want tool_use %s", i, assistant.Content[1], want.callID)
 		}
 		toolResult := result.Messages[want.msgIdx+1]
 		if toolResult.Role != "tool" || len(toolResult.Content) != 1 || toolResult.Content[0].Type != "tool_result" || toolResult.Content[0].ToolUseID != want.callID {
@@ -372,8 +411,8 @@ func TestToCoreRequest_BatchesCustomToolCallsAndOutputsIntoSingleRound(t *testin
 		}
 	}
 
-	if result.Messages[9].Role != "assistant" || len(result.Messages[9].Content) != 1 || result.Messages[9].Content[0].Text != "after tools" {
-		t.Fatalf("messages[9]=%+v, want trailing assistant text", result.Messages[9])
+	if result.Messages[6].Role != "assistant" || len(result.Messages[6].Content) != 1 || result.Messages[6].Content[0].Text != "after tools" {
+		t.Fatalf("messages[6]=%+v, want trailing assistant text", result.Messages[6])
 	}
 }
 

--- a/internal/protocol/openai/types.go
+++ b/internal/protocol/openai/types.go
@@ -116,10 +116,10 @@ type ContentPart struct {
 
 // Usage represents token usage statistics.
 type Usage struct {
-	InputTokens        int                `json:"input_tokens,omitempty"`
-	OutputTokens       int                `json:"output_tokens,omitempty"`
-	TotalTokens        int                `json:"total_tokens"`
-	InputTokensDetails InputTokensDetails `json:"input_tokens_details,omitempty"`
+	InputTokens         int                 `json:"input_tokens,omitempty"`
+	OutputTokens        int                 `json:"output_tokens,omitempty"`
+	TotalTokens         int                 `json:"total_tokens"`
+	InputTokensDetails  InputTokensDetails  `json:"input_tokens_details,omitempty"`
 	OutputTokensDetails OutputTokensDetails `json:"output_tokens_details,omitempty"`
 }
 
@@ -240,6 +240,16 @@ type CustomToolCallInputDeltaEvent struct {
 	Delta          string `json:"delta"`
 }
 
+// CustomToolCallInputDoneEvent is emitted when custom tool call input is complete.
+type CustomToolCallInputDoneEvent struct {
+	Type           string `json:"type"`
+	SequenceNumber int64  `json:"sequence_number"`
+	ItemID         string `json:"item_id,omitempty"`
+	CallID         string `json:"call_id,omitempty"`
+	OutputIndex    int    `json:"output_index"`
+	Input          string `json:"input"`
+}
+
 // ReasoningItemSummary provides a summary of reasoning content.
 type ReasoningItemSummary struct {
 	// Signature is the provider-specific reasoning signature (e.g. DeepSeek thinking signature)
@@ -255,11 +265,12 @@ type ReasoningItemSummary struct {
 
 // ReasoningSummaryPartAddedEvent is emitted when a reasoning summary part is added.
 type ReasoningSummaryPartAddedEvent struct {
-	Type           string `json:"type"`
-	SequenceNumber int64  `json:"sequence_number"`
-	ItemID         string `json:"item_id"`
-	OutputIndex    int    `json:"output_index"`
-	SummaryIndex   int    `json:"summary_index"`
+	Type           string               `json:"type"`
+	SequenceNumber int64                `json:"sequence_number"`
+	ItemID         string               `json:"item_id"`
+	OutputIndex    int                  `json:"output_index"`
+	SummaryIndex   int                  `json:"summary_index"`
+	Part           ReasoningItemSummary `json:"part"`
 }
 
 // ReasoningSummaryTextDeltaEvent is emitted for reasoning text deltas.
@@ -272,11 +283,22 @@ type ReasoningSummaryTextDeltaEvent struct {
 	Delta          string `json:"delta"`
 }
 
-// ReasoningSummaryPartDoneEvent is emitted when a reasoning summary part is complete.
-type ReasoningSummaryPartDoneEvent struct {
+// ReasoningSummaryTextDoneEvent is emitted when reasoning summary text is complete.
+type ReasoningSummaryTextDoneEvent struct {
 	Type           string `json:"type"`
 	SequenceNumber int64  `json:"sequence_number"`
 	ItemID         string `json:"item_id"`
 	OutputIndex    int    `json:"output_index"`
 	SummaryIndex   int    `json:"summary_index"`
+	Text           string `json:"text"`
+}
+
+// ReasoningSummaryPartDoneEvent is emitted when a reasoning summary part is complete.
+type ReasoningSummaryPartDoneEvent struct {
+	Type           string               `json:"type"`
+	SequenceNumber int64                `json:"sequence_number"`
+	ItemID         string               `json:"item_id"`
+	OutputIndex    int                  `json:"output_index"`
+	SummaryIndex   int                  `json:"summary_index"`
+	Part           ReasoningItemSummary `json:"part"`
 }


### PR DESCRIPTION
## Problem

When DeepSeek V4 is served through the Anthropic-compatible path and converted back to OpenAI Responses SSE for Codex, tool-heavy turns can render incorrectly: earlier assistant text may be overwritten, tool calls can appear reordered at the end, and the last assistant text may repeat between consecutive tool calls.

The issue comes from adapter-produced Responses data that does not look stable enough for Codex transcript reconstruction:

- response ids could be empty,
- reasoning/message/tool item ids could be reused across requests,
- tool item ids were inconsistent between output items and argument/input events,
- assistant text and immediately following tool calls could be split into separate history messages when converting Responses input back to Core/Anthropic.

## Fix

This PR makes the Anthropic/Core/OpenAI adapter path preserve stable Responses semantics:

- maps DeepSeek `reasoning_content` / `reasoning_content_delta` into Core reasoning blocks,
- emits the missing Responses reasoning lifecycle events,
- generates non-empty `resp_*`, `rs_*`, `msg_*`, and `fc_*` ids when upstream ids are unavailable,
- keeps provider tool ids in `call_id` while using the same `fc_*` item id for tool output items and argument/input delta/done events,
- emits `response.in_progress` immediately after `response.created`,
- uses `custom_tool_call_input.delta/done` for custom tools,
- keeps assistant text/reasoning together with immediately following tool calls during Responses input conversion, so historical assistant text is not replayed as a standalone message in consecutive tool loops.
