### PR TITLE
fix(server): clamp CoreRequest.MaxTokens to per-route max_output_tokens

### DIFF
--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -170,6 +170,12 @@ func (s *Server) handleWithAdapters(
 	// the upstream provider receives the correct model identifier.
 	coreReq.Model = preferred.UpstreamModel
 
+	if maxOut := s.routeMaxOutputTokens(openAIReq.Model, preferred); maxOut > 0 {
+		if coreReq.MaxTokens <= 0 || coreReq.MaxTokens > maxOut {
+			coreReq.MaxTokens = maxOut
+		}
+	}
+
 	wsMode := resolvedWebSearchMode(pm, openAIReq.Model, preferred)
 
 	// Inject web search tools at Core level if mode is "injected".

--- a/internal/service/server/adapter_dispatch_test.go
+++ b/internal/service/server/adapter_dispatch_test.go
@@ -265,3 +265,75 @@ func TestInjectCoreWebSearchSkipsWhenCandidateHasNativeSearch(t *testing.T) {
 		t.Fatalf("len(coreReq.Tools) = %d, want 0", len(coreReq.Tools))
 	}
 }
+
+func TestRouteMaxOutputTokensPrefersRouteEntry(t *testing.T) {
+	rt := runtime.NewRuntime(config.Config{
+		Routes: map[string]config.RouteEntry{
+			"claude-haiku-4-5": {
+				Provider:        "newapi",
+				Model:           "claude-haiku-4-5",
+				MaxOutputTokens: 64000,
+			},
+		},
+		ProviderDefs: map[string]config.ProviderDef{
+			"newapi": {
+				Models: map[string]config.ModelMeta{
+					"claude-haiku-4-5": {MaxOutputTokens: 200000},
+				},
+			},
+		},
+	}, nil, nil)
+	srv := &Server{runtime: rt}
+
+	got := srv.routeMaxOutputTokens("claude-haiku-4-5", provider.ProviderCandidate{
+		ProviderKey:   "newapi",
+		UpstreamModel: "claude-haiku-4-5",
+	})
+	if got != 64000 {
+		t.Fatalf("routeMaxOutputTokens() = %d, want 64000", got)
+	}
+}
+
+func TestRouteMaxOutputTokensFallsBackToProviderModelMeta(t *testing.T) {
+	rt := runtime.NewRuntime(config.Config{
+		Routes: map[string]config.RouteEntry{
+			"qwen3.6-plus": {Provider: "newapi", Model: "qwen3.6-plus"},
+		},
+		ProviderDefs: map[string]config.ProviderDef{
+			"newapi": {
+				Models: map[string]config.ModelMeta{
+					"qwen3.6-plus": {MaxOutputTokens: 65536},
+				},
+			},
+		},
+	}, nil, nil)
+	srv := &Server{runtime: rt}
+
+	got := srv.routeMaxOutputTokens("qwen3.6-plus", provider.ProviderCandidate{
+		ProviderKey:   "newapi",
+		UpstreamModel: "qwen3.6-plus",
+	})
+	if got != 65536 {
+		t.Fatalf("routeMaxOutputTokens() = %d, want 65536", got)
+	}
+}
+
+func TestRouteMaxOutputTokensReturnsZeroWhenUnset(t *testing.T) {
+	rt := runtime.NewRuntime(config.Config{
+		Routes: map[string]config.RouteEntry{
+			"unbounded": {Provider: "newapi", Model: "unbounded"},
+		},
+		ProviderDefs: map[string]config.ProviderDef{
+			"newapi": {Models: map[string]config.ModelMeta{}},
+		},
+	}, nil, nil)
+	srv := &Server{runtime: rt}
+
+	got := srv.routeMaxOutputTokens("unbounded", provider.ProviderCandidate{
+		ProviderKey:   "newapi",
+		UpstreamModel: "unbounded",
+	})
+	if got != 0 {
+		t.Fatalf("routeMaxOutputTokens() = %d, want 0", got)
+	}
+}

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -96,6 +96,26 @@ func (s *Server) activeProviderDefs() map[string]config.ProviderDef {
 	return nil
 }
 
+// routeMaxOutputTokens resolves the effective per-route max_output_tokens cap
+// for the given inbound model alias, falling back to the upstream provider
+// catalog metadata when the route does not declare its own value.
+// Returns 0 when no cap is configured (caller should leave defaults alone).
+func (s *Server) routeMaxOutputTokens(modelAlias string, preferred provider.ProviderCandidate) int {
+	snap := s.runtimeSnapshot()
+	if snap == nil {
+		return 0
+	}
+	if entry, ok := snap.Config.Routes[modelAlias]; ok && entry.MaxOutputTokens > 0 {
+		return entry.MaxOutputTokens
+	}
+	if def, ok := snap.Config.ProviderDefs[preferred.ProviderKey]; ok {
+		if meta, ok := def.Models[preferred.UpstreamModel]; ok && meta.MaxOutputTokens > 0 {
+			return meta.MaxOutputTokens
+		}
+	}
+	return 0
+}
+
 func (s *Server) activeChatClient(providerKey string) any {
 	if snap := s.runtimeSnapshot(); snap != nil {
 		if def, ok := snap.Config.ProviderDefs[providerKey]; ok && def.Protocol == config.ProtocolOpenAIChat {


### PR DESCRIPTION
## Problem
When an inbound OpenAI Responses request omits `max_output_tokens` (or sets a value above the upstream model's actual ceiling), moonbridge falls back to `defaults.max_tokens` from the global config and forwards that value verbatim to the upstream protocol adapters. Each protocol adapter (anthropic, chat, openai, google) currently has its own `defaultMaxTokens` helper that only consults the inbound request and the global default — none of them clamp to the per-route `models.<slug>.max_output_tokens` declared in config.

In a deployment that routes Claude (max 64K out), Qwen DashScope (32K / 65K), Gemini (65K) and DeepSeek V4 Pro (320K) through a single moonbridge instance, the global default has to be sized for the largest cap (DeepSeek), which then makes every smaller-cap upstream return `400 Invalid request` / `400 Range of max_tokens should be [1, 65536]` whenever the client doesn't supply an explicit cap.

Real production trace excerpt (anonymised):
```
level=ERROR msg=提供商错误 model=claude-sonnet-4-6 status=400 ... req_max_tokens=320000
level=ERROR msg=提供商错误 model=qwen3.6-plus    status=400 ... req_max_tokens=320000
    error="<400> Range of max_tokens should be [1, 65536]"
```

## Fix
Single-point clamp in `internal/service/server/adapter_dispatch.go::handleWithAdapters`, applied right after `client.ToCoreRequest` and the upstream model alias resolution and before `providerAdapter.FromCoreRequest`. The clamp uses a new helper `(*Server).routeMaxOutputTokens(modelAlias, preferred)` that prefers `config.Routes[alias].MaxOutputTokens` and falls back to `config.ProviderDefs[providerKey].Models[upstreamModel].MaxOutputTokens`. Returns 0 (no clamp) when neither is set, preserving prior behavior for configs that don't declare per-model caps.

Because this lives at the protocol-agnostic `format.CoreRequest` boundary, all four protocol adapters (anthropic, chat, openai, google) inherit the clamp without changes.

## Tests
Adds three tests in `internal/service/server/adapter_dispatch_test.go`:
- `TestRouteMaxOutputTokensPrefersRouteEntry` — route-level cap wins over provider-meta.
- `TestRouteMaxOutputTokensFallsBackToProviderModelMeta` — provider catalog metadata is consulted when the route doesn't declare its own.
- `TestRouteMaxOutputTokensReturnsZeroWhenUnset` — both unset → 0 (no clamp).

Full `go test ./...` passes locally on `golang:1.26-bookworm`.

## Backwards compatibility
Pure additive behavior — installations that don't declare `max_output_tokens` per model see no change. Installations that do declare it now get an automatic clamp instead of relying on the upstream HTTP response.

## Operational note
This patch was deployed in production at the PKU CCLab moonbridge instance for ~10 minutes before this PR was opened, where it eliminated the 400 cycle and verified normal operation across Claude / Qwen / DeepSeek / Gemini routes.
