### PR TITLE
Drop empty-name tools before forwarding to upstream

### DIFF
--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -1639,6 +1640,17 @@ func flattenToolsWithNamespace(openaiTools []Tool, namespace string, disablePatc
 	seen := make(map[string]bool, len(result))
 	deduped := make([]format.CoreTool, 0, len(result))
 	for _, t := range result {
+		if strings.TrimSpace(t.Name) == "" {
+			// Codex sends OpenAI-only typed tools (e.g. image_generation, web_search)
+			// that arrive without a function.name; upstream Anthropic-compatible
+			// endpoints reject these. Drop them silently rather than failing the call.
+			extBytes, _ := json.Marshal(t.Extensions)
+			slog.Default().Debug("dropping empty-name tool",
+				"namespace", namespace,
+				"extensions", string(extBytes),
+			)
+			continue
+		}
 		if seen[t.Name] {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Codex's Responses API includes OpenAI-only typed tools (e.g. `image_generation`, `web_search`, `file_search`, `computer_use`) that have no `function.name` field — they are identified by `type` instead.
- Moon Bridge's converter has no special-case for these typed tools, so they flow into `flattenToolsWithNamespace` with `Name == ""` and Extensions like `{"source_type":"image_generation"}`.
- Upstream Anthropic-compatible endpoints (verified against DeepSeek `/anthropic`) then reject the request with `Invalid 'tools[N].function.name': empty string`, returning a 400 that Moon Bridge surfaces as 502 to Codex.
- This makes Codex unusable against DeepSeek (and likely other strict upstreams) whenever the user has Codex's built-in image generation enabled.

## Fix
Skip empty-name tools in `flattenToolsWithNamespace` (alongside the existing dedup pass). These hosted tool types cannot run on non-OpenAI upstreams anyway, so dropping them is the correct semantic — not a hack.

## Test plan
- [x] Reproduce 502 with Codex + DeepSeek via Moon Bridge
- [x] Confirm tool at index 389 in failing request has `Name=""`, `Extensions={"source_type":"image_generation"}`
- [x] Apply patch, rebuild, restart; confirm Codex turn completes successfully
- [x] Verify normal function tools still pass through (tool count drops by 1, the rest unchanged)