### PR TITLE
fix: 过滤空函数名的工具定义（Anthropic 协议适配器）

### DIFF
--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -120,6 +120,9 @@ func (a *AnthropicProviderAdapter) anthropicToCoreRequest(req *MessageRequest) *
 	if len(req.Tools) > 0 {
 		coreReq.Tools = make([]format.CoreTool, 0, len(req.Tools))
 		for _, t := range req.Tools {
+			if t.Name == "" {
+				continue
+			}
 			coreReq.Tools = append(coreReq.Tools, format.CoreTool{
 				Name:        t.Name,
 				Description: t.Description,
@@ -310,6 +313,9 @@ func (a *AnthropicProviderAdapter) FromCoreRequest(ctx context.Context, req *for
 	if len(req.Tools) > 0 {
 		anthropicReq.Tools = make([]Tool, 0, len(req.Tools))
 		for _, t := range req.Tools {
+			if t.Name == "" {
+				continue
+			}
 			schema := cleanSchema(t.InputSchema)
 			if schema == nil {
 				schema = map[string]any{"type": "object"}


### PR DESCRIPTION
## 改动

在转发到上游 Anthropic API 之前，过滤掉 `Name` 为空字符串的工具定义。防止上游因空函数名而返回 400 错误。

## 修改文件

- `internal/protocol/anthropic/adapter.go`：在非流式 and 流式两处工具遍历循环中各加一行 `if t.Name == "" { continue }`

修复 #65
