### PR TITLE
feat: 增加 AnySearch 作为可插拔的 web search 后端

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type WebSearchConfig struct {
 	MaxUses         int
 	TavilyAPIKey    string
 	FirecrawlAPIKey string
+	AnySearchAPIKey string
 	SearchMaxRounds int
 }
 
@@ -63,6 +64,7 @@ type Config struct {
 	WebSearchMaxUses  int
 	TavilyAPIKey      string
 	FirecrawlAPIKey   string
+	AnySearchAPIKey   string
 	SearchMaxRounds   int
 	DefaultMaxTokens  int
 	MaxSessions int    `yaml:"max_sessions"`  // 0 = unlimited
@@ -134,6 +136,7 @@ type ProviderDef struct {
 	WebSearchMaxUses int
 	TavilyAPIKey     string
 	FirecrawlAPIKey  string
+	AnySearchAPIKey  string
 	SearchMaxRounds  int
 	Extensions       map[string]ExtensionSettings
 	// Models is the provider's model catalog: upstream model name -> metadata.
@@ -325,11 +328,11 @@ func (cfg Config) validateTransform() error {
 
 func (cfg Config) validateSearchConfig() error {
 	if cfg.WebSearchSupport == WebSearchSupportInjected {
-		if cfg.TavilyAPIKey == "" {
-			return errors.New("provider.tavily_api_key is required when web_search.support is 'injected'")
+		if cfg.TavilyAPIKey == "" && cfg.AnySearchAPIKey == "" {
+			return errors.New("web_search.tavily_api_key or anysearch_api_key is required when support is 'injected'")
 		}
 		if cfg.SearchMaxRounds <= 0 {
-			return errors.New("provider.search_max_rounds must be > 0 when web_search.support is 'injected'")
+			return errors.New("web_search.search_max_rounds must be > 0 when support is 'injected'")
 		}
 	}
 	for key, def := range cfg.ProviderDefs {
@@ -338,8 +341,8 @@ func (cfg Config) validateSearchConfig() error {
 			if tavilyKey == "" {
 				tavilyKey = cfg.TavilyAPIKey
 			}
-			if tavilyKey == "" {
-				return fmt.Errorf("providers.%s.web_search.tavily_api_key is required when web_search.support is 'injected'", key)
+			if tavilyKey == "" && def.AnySearchAPIKey == "" && cfg.AnySearchAPIKey == "" {
+				return fmt.Errorf("providers.%s: tavily_api_key or anysearch_api_key is required when web_search.support is 'injected'", key)
 			}
 			maxRounds := def.SearchMaxRounds
 			if maxRounds <= 0 {

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -193,6 +193,7 @@ type WebSearchFileConfig struct {
 	MaxUses         int    `yaml:"max_uses" json:"max_uses,omitempty"`
 	TavilyAPIKey    string `yaml:"tavily_api_key" json:"tavily_api_key,omitempty"`
 	FirecrawlAPIKey string `yaml:"firecrawl_api_key" json:"firecrawl_api_key,omitempty"`
+	AnySearchAPIKey string `yaml:"anysearch_api_key" json:"anysearch_api_key,omitempty"`
 	SearchMaxRounds int    `yaml:"search_max_rounds" json:"search_max_rounds,omitempty"`
 }
 
@@ -367,6 +368,7 @@ func FromFileConfigWithOptions(fileConfig FileConfig, opts LoadOptions) (Config,
 		WebSearchMaxUses: intOrDefault(fileConfig.WebSearch.MaxUses, 8),
 		TavilyAPIKey:     strings.TrimSpace(fileConfig.WebSearch.TavilyAPIKey),
 		FirecrawlAPIKey:  strings.TrimSpace(fileConfig.WebSearch.FirecrawlAPIKey),
+		AnySearchAPIKey:  strings.TrimSpace(fileConfig.WebSearch.AnySearchAPIKey),
 		SearchMaxRounds:  intOrDefault(fileConfig.WebSearch.SearchMaxRounds, 5),
 		DefaultMaxTokens: intOrDefault(defaults.MaxTokens, 1024),
 		Cache:            fromCacheFileConfig(fileConfig.Cache),
@@ -407,6 +409,7 @@ func fromModelDefFileConfig(fileConfig map[string]ModelDefFileConfig, specs exte
 				MaxUses:         m.WebSearch.MaxUses,
 				TavilyAPIKey:    strings.TrimSpace(m.WebSearch.TavilyAPIKey),
 				FirecrawlAPIKey: strings.TrimSpace(m.WebSearch.FirecrawlAPIKey),
+				AnySearchAPIKey: strings.TrimSpace(m.WebSearch.AnySearchAPIKey),
 				SearchMaxRounds: m.WebSearch.SearchMaxRounds,
 			}
 		}
@@ -536,6 +539,7 @@ func fromProviderDefFileConfig(fileConfig map[string]ProviderDefFileConfig, spec
 			WebSearchMaxUses: def.WebSearch.MaxUses,
 			TavilyAPIKey:     strings.TrimSpace(def.WebSearch.TavilyAPIKey),
 			FirecrawlAPIKey:  strings.TrimSpace(def.WebSearch.FirecrawlAPIKey),
+			AnySearchAPIKey:  strings.TrimSpace(def.WebSearch.AnySearchAPIKey),
 			SearchMaxRounds:  def.WebSearch.SearchMaxRounds,
 			Extensions:       providerExtensions,
 			Models:           providerModels,

--- a/internal/extension/websearch/anysearch.go
+++ b/internal/extension/websearch/anysearch.go
@@ -1,0 +1,167 @@
+package websearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const anysearchEndpoint = "https://api.anysearch.com/mcp"
+
+// AnySearchClient is an HTTP client for the AnySearch JSON-RPC API.
+type AnySearchClient struct {
+	httpClient *http.Client
+	apiKey     string
+}
+
+// NewAnySearchClient creates a new AnySearchClient.
+func NewAnySearchClient(apiKey string) *AnySearchClient {
+	return &AnySearchClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		apiKey:     apiKey,
+	}
+}
+
+// jsonrpcRequest is a JSON-RPC 2.0 request payload.
+type jsonrpcRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      int         `json:"id"`
+	Method  string      `json:"method"`
+	Params  rpcParams   `json:"params"`
+}
+
+type rpcParams struct {
+	Name      string         `json:"name"`
+	Arguments rpcArguments   `json:"arguments"`
+}
+
+type rpcArguments struct {
+	Query      string `json:"query"`
+	MaxResults int    `json:"max_results,omitempty"`
+	Zone       string `json:"zone,omitempty"`
+}
+
+// jsonrpcResponse is a JSON-RPC 2.0 response payload.
+type jsonrpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  *rpcResult      `json:"result,omitempty"`
+	Error   *jsonrpcError   `json:"error,omitempty"`
+}
+
+type rpcResult struct {
+	Content []rpcContent `json:"content"`
+}
+
+type rpcContent struct {
+	Type     string         `json:"type"`
+	Text     string         `json:"text,omitempty"`
+	Resource *rpcResource   `json:"resource,omitempty"`
+}
+
+type rpcResource struct {
+	Text string `json:"text"`
+}
+
+type jsonrpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Search executes a search query against the AnySearch API.
+func (c *AnySearchClient) Search(ctx context.Context, req SearchRequest) (*SearchResult, error) {
+	if req.MaxResults <= 0 {
+		req.MaxResults = 5
+	}
+
+	args := rpcArguments{
+		Query:      req.Query,
+		MaxResults: req.MaxResults,
+		Zone:       "web",
+	}
+
+	payload := jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params: rpcParams{
+			Name:      "search",
+			Arguments: args,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal anysearch request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, anysearchEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create anysearch request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("anysearch request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read anysearch response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &SearchError{
+			StatusCode: resp.StatusCode,
+			Message:    fmt.Sprintf("AnySearch API error %d: %s", resp.StatusCode, string(respBody)),
+		}
+	}
+
+	var rpcResp jsonrpcResponse
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		return nil, fmt.Errorf("unmarshal anysearch response: %w", err)
+	}
+
+	if rpcResp.Error != nil {
+		return nil, &SearchError{
+			StatusCode: 0,
+			Message:    fmt.Sprintf("AnySearch error: %s", rpcResp.Error.Message),
+		}
+	}
+
+	if rpcResp.Result == nil || len(rpcResp.Result.Content) == 0 {
+		return &SearchResult{
+			Query:   req.Query,
+			Results: []SearchItem{},
+		}, nil
+	}
+
+	result := &SearchResult{
+		Query:   req.Query,
+		Results: make([]SearchItem, 0),
+	}
+
+	for _, c := range rpcResp.Result.Content {
+		text := c.Text
+		if c.Resource != nil {
+			text = c.Resource.Text
+		}
+		if text != "" {
+			result.Results = append(result.Results, SearchItem{
+				Title:   "Search Result",
+				URL:     "",
+				Content: text,
+				Score:   1.0,
+			})
+		}
+	}
+
+	return result, nil
+}

--- a/internal/extension/websearch/orchestrator.go
+++ b/internal/extension/websearch/orchestrator.go
@@ -14,13 +14,18 @@ import (
 // ToolHandler executes a tool given its input and returns a formatted result string.
 type ToolHandler func(context.Context, json.RawMessage) (string, error)
 
+// Searcher is the interface for search backends (Tavily, AnySearch, etc.)
+type Searcher interface {
+	Search(ctx context.Context, req SearchRequest) (*SearchResult, error)
+}
+
 // Orchestrator wraps an Anthropic client and transparently executes
 // web_search / web_fetch (or tavily_search / firecrawl_fetch in injected mode)
-// tool calls server-side via Tavily / Firecrawl.
+// tool calls server-side via a search backend (Tavily / AnySearch).
 // It presents the same interface as anthropic.Client to callers.
 type Orchestrator struct {
 	anthropic    *anthropic.Client
-	tavily       *TavilyClient
+	searcher     Searcher
 	firecrawl    *FirecrawlClient
 	maxRounds    int
 	toolHandlers map[string]ToolHandler
@@ -30,6 +35,7 @@ type Orchestrator struct {
 type OrchestratorConfig struct {
 	Anthropic       *anthropic.Client
 	TavilyKey       string
+	AnySearchKey    string
 	FirecrawlKey    string
 	SearchMaxRounds int
 	ToolHandlers    map[string]ToolHandler
@@ -38,9 +44,15 @@ type OrchestratorConfig struct {
 // NewOrchestrator creates a new search orchestrator with default
 // handlers for web_search and web_fetch tool names.
 func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
+	var searcher Searcher
+	if cfg.AnySearchKey != "" {
+		searcher = NewAnySearchClient(cfg.AnySearchKey)
+	} else {
+		searcher = NewTavilyClient(cfg.TavilyKey)
+	}
 	o := &Orchestrator{
 		anthropic: cfg.Anthropic,
-		tavily:    NewTavilyClient(cfg.TavilyKey),
+		searcher:  searcher,
 		maxRounds: cfg.SearchMaxRounds,
 	}
 	if cfg.FirecrawlKey != "" {
@@ -68,9 +80,15 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 // where tavily_search and firecrawl_fetch are injected as function tools
 // to the provider.
 func NewInjectedOrchestrator(cfg OrchestratorConfig) *Orchestrator {
+	var searcher Searcher
+	if cfg.AnySearchKey != "" {
+		searcher = NewAnySearchClient(cfg.AnySearchKey)
+	} else {
+		searcher = NewTavilyClient(cfg.TavilyKey)
+	}
 	o := &Orchestrator{
 		anthropic: cfg.Anthropic,
-		tavily:    NewTavilyClient(cfg.TavilyKey),
+		searcher:  searcher,
 		maxRounds: cfg.SearchMaxRounds,
 	}
 	if cfg.FirecrawlKey != "" {
@@ -275,7 +293,7 @@ func (o *Orchestrator) executeTavilySearch(ctx context.Context, raw json.RawMess
 		return "", fmt.Errorf("search: query is required")
 	}
 
-	result, err := o.tavily.Search(ctx, SearchRequest{
+	result, err := o.searcher.Search(ctx, SearchRequest{
 		Query:          params.Query,
 		SearchDepth:    params.SearchDepth,
 		Topic:          params.Topic,

--- a/internal/extension/websearchinjected/websearchinjected.go
+++ b/internal/extension/websearchinjected/websearchinjected.go
@@ -45,10 +45,11 @@ func CoreTools(firecrawlKey string) []format.CoreTool {
 // WrapProvider wraps an Anthropic client with the injected search orchestrator.
 // The returned *websearch.Orchestrator implements the same CreateMessage /
 // StreamMessage interface as *anthropic.Client.
-func WrapProvider(client *anthropic.Client, tavilyKey, firecrawlKey string, maxRounds int) *websearch.Orchestrator {
+func WrapProvider(client *anthropic.Client, tavilyKey, anysearchKey, firecrawlKey string, maxRounds int) *websearch.Orchestrator {
 	return websearch.NewInjectedOrchestrator(websearch.OrchestratorConfig{
 		Anthropic:       client,
 		TavilyKey:       tavilyKey,
+		AnySearchKey:    anysearchKey,
 		FirecrawlKey:    firecrawlKey,
 		SearchMaxRounds: maxRounds,
 	})

--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -120,6 +120,9 @@ func (a *AnthropicProviderAdapter) anthropicToCoreRequest(req *MessageRequest) *
 	if len(req.Tools) > 0 {
 		coreReq.Tools = make([]format.CoreTool, 0, len(req.Tools))
 		for _, t := range req.Tools {
+			if t.Name == "" {
+				continue
+			}
 			coreReq.Tools = append(coreReq.Tools, format.CoreTool{
 				Name:        t.Name,
 				Description: t.Description,
@@ -310,6 +313,9 @@ func (a *AnthropicProviderAdapter) FromCoreRequest(ctx context.Context, req *for
 	if len(req.Tools) > 0 {
 		anthropicReq.Tools = make([]Tool, 0, len(req.Tools))
 		for _, t := range req.Tools {
+			if t.Name == "" {
+				continue
+			}
 			schema := cleanSchema(t.InputSchema)
 			if schema == nil {
 				schema = map[string]any{"type": "object"}

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -263,10 +263,10 @@ func (s *Server) handleWithAdapters(
 		// Wrap provider with search orchestrator if web search is "injected".
 		if wsInjected {
 			if acc, ok := effectiveProvider.(provider.AnthropicClientAccessor); ok {
-				wrapped := websearchinjected.WrapProvider(
-					acc.AnthropicClient(),
-					searchCfg.tavilyKey, searchCfg.firecrawlKey, searchCfg.maxRounds,
-				)
+			wrapped := websearchinjected.WrapProvider(
+				acc.AnthropicClient(),
+				searchCfg.tavilyKey, searchCfg.anysearchKey, searchCfg.firecrawlKey, searchCfg.maxRounds,
+			)
 				effectiveProvider = &searchProviderAdapter{wrapped: wrapped}
 			}
 		}
@@ -2250,6 +2250,7 @@ func (a *searchProviderAdapter) AnthropicClient() *anthropic.Client { return nil
 
 type searchConfig struct {
 	tavilyKey    string
+	anysearchKey string
 	firecrawlKey string
 	maxRounds    int
 }
@@ -2258,6 +2259,7 @@ func (s *Server) resolvedSearchConfig(providerKey, modelAlias string) searchConf
 	// Keep a conservative fallback to existing global/runtime behavior.
 	cfg := searchConfig{
 		tavilyKey:    "",
+		anysearchKey: "",
 		firecrawlKey: "",
 		maxRounds:    s.maxSearchRounds(),
 	}
@@ -2266,6 +2268,7 @@ func (s *Server) resolvedSearchConfig(providerKey, modelAlias string) searchConf
 	}
 	fullCfg := s.runtime.Current().Config
 	cfg.tavilyKey = fullCfg.TavilyAPIKey
+	cfg.anysearchKey = fullCfg.AnySearchAPIKey
 	cfg.firecrawlKey = fullCfg.FirecrawlAPIKey
 
 	// Prefer model-level resolved config; then provider-level fallback.


### PR DESCRIPTION
## 改动说明

在现有的 Tavily 搜索后端之外，增加 AnySearch 作为可选的注入式 web search 后端。

### 核心改动

**AnySearch 客户端** (`internal/extension/websearch/anysearch.go`)
新的 HTTP 客户端，实现 `Searcher` 接口，调用 AnySearch JSON-RPC API (`https://api.anysearch.com/mcp`)。

**Searcher 接口抽象**
将 `Orchestrator.tavily *TavilyClient` 重构为 `Orchestrator.searcher Searcher`，使搜索后端可插拔。`TavilyClient` 和 `AnySearchClient` 都实现了 `Searcher` 接口。

**配置集成**
- `WebSearchFileConfig`、`WebSearchConfig`、`Config`、`ProviderDef` 四级增加 `anysearch_api_key` 字段
- YAML 解析和配置校验支持 `anysearch_api_key` 作为 `tavily_api_key` 的替代

### 使用方法

```yaml
web_search:
  support: injected
  anysearch_api_key: "as_sk_your_key_here"
```

关闭 #66
