### PR TITLE
feat: web_fetch, circuit_breaker, response_store extensions + tool-call dedup

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,59 @@
+# Moon Bridge Codex Enhancement PRD
+
+> 目标：在 moon-bridge 上补齐 codex-deepseek-v4-proxy 的差异化功能，纯 DeepSeek 场景。
+
+## 变更清单
+
+### P0 — web_fetch 代理工具
+
+**问题**：Codex 沙箱拦截 shell HTTP 请求，模型无法直接读取网页 URL。
+
+**方案**：新增 `web_fetch` 扩展，通过 `ToolInjector` 注入工具。当 Codex 调用 `web_fetch(url)` 时，moon-bridge 代理侧用 Jina Reader（或直接 HTTP）抓取内容，返回 markdown。
+
+**实现**：
+- 新文件：`internal/extension/web_fetch/plugin.go`
+- 接口：`plugin.ToolInjector` + `plugin.Plugin`
+- 工具定义：`web_fetch(url, method, headers, body)` → `{status, body}`
+- HTTP 抓取：Jina Reader（`r.jina.ai`）或直接 HTTP GET
+- 配置：`extensions.web_fetch.enabled: true`
+
+### P1 — 工具调用断路器
+
+**问题**：模型偶尔陷入工具调用死循环（相同工具反复调）。
+
+**方案**：新增 `circuit_breaker` 扩展，通过 `StreamInterceptor` 监控连续 `tool_use` 事件。超过阈值（默认 20 次）注入 reflection prompt，连续 30 次强制终止。
+
+**实现**：
+- 新文件：`internal/extension/circuit_breaker/plugin.go`
+- 接口：`plugin.StreamInterceptor` + `plugin.Plugin`
+- 配置：`extensions.circuit_breaker.max_consecutive_tools: 20`
+
+### P2 — previous_response_id 桥接
+
+**问题**：Codex 有时引用之前的 response_id，moon-bridge 无状态无法处理。
+
+**方案**：在 `ResponsePostProcessor` 中存储每次响应的 ID → output 映射。请求时若带 `previous_response_id`，注入历史上下文。
+
+**实现**：
+- 新文件：`internal/extension/response_store/plugin.go`
+- 接口：`plugin.ResponsePostProcessor` + `plugin.RequestMutator`
+- 存储：内存 LRU（无持久化需求）
+- TTL：1 小时，最多 500 条
+
+## 影响范围
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `internal/extension/web_fetch/plugin.go` | 新增 | web_fetch 工具 |
+| `internal/extension/circuit_breaker/plugin.go` | 新增 | 断路器 |
+| `internal/extension/response_store/plugin.go` | 新增 | 响应桥接 |
+| `internal/service/app/extensions.go` | 修改 | 注册 3 个新扩展 |
+| `config.yml` | 修改 | 默认启用 |
+
+## 测试验证
+
+```bash
+# 1. web_fetch：Codex 中用 web_fetch 读一个网页
+# 2. circuit_breaker：连续调 20+ 次 read_file → 被拦截
+# 3. response_store：带 previous_response_id 的请求正常桥接
+```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,40 @@ go run ./cmd/moonbridge -config config.yml
 - **Web Search 注入**：自动/注入模式，支持 Tavily、Firecrawl
 - **Prompt 缓存**：explicit / automatic / hybrid 三种模式
 
+## 内置扩展
+
+所有扩展通过 `config.yml` 的 `extensions` 字段启用，支持 Global / Provider / Model / Route 四级作用域。
+
+| 扩展 | 类型 | 功能 |
+|------|------|------|
+| `codex_tool_proxy` | ToolInjector | 为 Codex 注入 `apply_patch` 等工具代理 |
+| `deepseek_v4` | ReasoningExtractor | DeepSeek V4/V3 thinking/reasoning 提取与转换 |
+| `web_fetch` | ToolInjector + MessageRewriter | 注入 `web_fetch(url)` 工具，代理侧通过 Jina Reader 抓取网页 Markdown，绕过 Codex 沙箱的 HTTP 限制 |
+| `circuit_breaker` | RequestMutator | 按会话统计连续 tool_use 调用次数，超过阈值注入警告或强制终止，防止模型陷入死循环 |
+| `response_store` | ResponsePostProcessor | 缓存上游响应，当请求携带 `previous_response_id` 时自动桥接上次 assistant 输出到新请求 Input |
+| `kimi_workaround` | InputPreprocessor | Kimi 模型兼容处理 |
+| `visual` | ContentFilter | 视觉/图片内容过滤 |
+| `db_sqlite` / `db_d1` | Provider | SQLite / Cloudflare D1 持久化存储 |
+| `metrics` | RequestCompletionHook | Token 用量与费用统计 |
+
+### 配置示例
+
+```yaml
+extensions:
+  web_fetch:
+    enabled: true
+  circuit_breaker:
+    enabled: true
+    config:
+      max_consecutive_tools: 20
+      hard_limit: 30
+  response_store:
+    enabled: true
+    config:
+      ttl_seconds: 3600
+      max_entries: 500
+```
+
 ## 三种工作模式
 
 | 模式 | 行为 |

--- a/internal/extension/circuit_breaker/plugin.go
+++ b/internal/extension/circuit_breaker/plugin.go
@@ -142,6 +142,124 @@ func (p *Plugin) MutateRequest(ctx *plugin.RequestContext, req *format.CoreReque
 	}
 }
 
+// RewriteMessages implements plugin.MessageRewriter.
+// Detects and collapses consecutive identical tool_call blocks to prevent
+// DeepSeek/Claude from looping on repeated function calls.
+func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.CoreMessage) []format.CoreMessage {
+	// Dedup: collapse consecutive identical tool_use+tool_result pairs
+	return deduplicateToolCalls(messages)
+}
+
+// deduplicateToolCalls collapses consecutive identical tool call + result
+// blocks. DeepSeek and Claude sometimes repeat the same function call
+// (same name + args, different call_id) across multiple turns. Removing
+// the redundant history prevents the model from seeing its own repetition
+// and reinforcing the loop.
+func deduplicateToolCalls(messages []format.CoreMessage) []format.CoreMessage {
+	if len(messages) == 0 {
+		return messages
+	}
+
+	type toolCallSig struct {
+		name string
+		args string
+	}
+
+	result := make([]format.CoreMessage, 0, len(messages))
+	i := 0
+
+	for i < len(messages) {
+		msg := messages[i]
+
+		// Check if this is an assistant message with tool_calls
+		if msg.Role != "assistant" || !hasToolUses(msg) {
+			result = append(result, msg)
+			i++
+			continue
+		}
+
+		// Collect this assistant's tool calls
+		currentSigs := extractToolCallSigs(msg)
+
+		// Find end of tool results following this assistant
+		j := i + 1
+		for j < len(messages) && messages[j].Role == "tool" {
+			j++
+		}
+
+		// Keep this assistant + its tool results
+		for k := i; k < j; k++ {
+			result = append(result, messages[k])
+		}
+
+		// Look ahead for consecutive identical tool call blocks
+		next := j
+		skipped := false
+		for next < len(messages) {
+			if messages[next].Role != "assistant" || !hasToolUses(messages[next]) {
+				break
+			}
+			nextSigs := extractToolCallSigs(messages[next])
+			if !toolCallSigsEqual(currentSigs, nextSigs) {
+				break
+			}
+			// Found duplicate block — skip this assistant + its tool results
+			skipped = true
+			next++
+			for next < len(messages) && messages[next].Role == "tool" {
+				next++
+			}
+		}
+
+		i = next
+		_ = skipped
+	}
+	return result
+}
+
+func hasToolUses(msg format.CoreMessage) bool {
+	for _, block := range msg.Content {
+		if block.Type == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
+func extractToolCallSigs(msg format.CoreMessage) []struct {
+	name string
+	args string
+} {
+	var sigs []struct {
+		name string
+		args string
+	}
+	for _, block := range msg.Content {
+		if block.Type == "tool_use" {
+			sigs = append(sigs, struct {
+				name string
+				args string
+			}{block.ToolName, string(block.ToolInput)})
+		}
+	}
+	return sigs
+}
+
+func toolCallSigsEqual(a, b []struct {
+	name string
+	args string
+}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].name != b[i].name || a[i].args != b[i].args {
+			return false
+		}
+	}
+	return true
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"
@@ -165,6 +283,7 @@ func itoa(n int) string {
 }
 
 var (
-	_ plugin.Plugin         = (*Plugin)(nil)
-	_ plugin.RequestMutator = (*Plugin)(nil)
+	_ plugin.Plugin          = (*Plugin)(nil)
+	_ plugin.RequestMutator  = (*Plugin)(nil)
+	_ plugin.MessageRewriter = (*Plugin)(nil)
 )

--- a/internal/extension/circuit_breaker/plugin.go
+++ b/internal/extension/circuit_breaker/plugin.go
@@ -4,14 +4,15 @@
 package circuitbreaker
 
 import (
-	"sync"
-
 	"moonbridge/internal/config"
 	"moonbridge/internal/extension/plugin"
 	"moonbridge/internal/format"
 )
 
 const PluginName = "circuit_breaker"
+
+// sessionStateKey is used to store per-session state in RequestContext.SessionData.
+const sessionStateKey = "circuit_breaker_state"
 
 type Config struct {
 	MaxConsecutiveTools int `json:"max_consecutive_tools,omitempty" yaml:"max_consecutive_tools"`
@@ -28,12 +29,10 @@ type Plugin struct {
 	cfg           *Config
 	appCfg        config.Config
 	currentConfig func() config.Config
-	mu            sync.Mutex
-	sessions      map[string]*sessionState
 }
 
 func NewPlugin() *Plugin {
-	return &Plugin{sessions: make(map[string]*sessionState)}
+	return &Plugin{}
 }
 
 func (p *Plugin) Name() string { return PluginName }
@@ -78,6 +77,28 @@ func (p *Plugin) EnabledForModel(model string) bool {
 	return p.appCfg.ExtensionEnabled(PluginName, model)
 }
 
+// getState returns the per-session state for this request.
+// Uses RequestContext.SessionData so concurrent users don't mix.
+func (p *Plugin) getState(ctx *plugin.RequestContext) *sessionState {
+	if ctx.SessionData == nil {
+		ctx.SessionData = make(map[string]any)
+	}
+	raw, ok := ctx.SessionData[sessionStateKey]
+	if !ok {
+		state := &sessionState{}
+		ctx.SessionData[sessionStateKey] = state
+		return state
+	}
+	// The raw value is from session initialization which stores *sync.Mutex
+	// guarded maps. Here we use a pointer directly stored in SessionData.
+	state, ok := raw.(*sessionState)
+	if !ok {
+		state = &sessionState{}
+		ctx.SessionData[sessionStateKey] = state
+	}
+	return state
+}
+
 // MutateRequest implements plugin.RequestMutator.
 // Tracks tool calls and injects warnings when limits are exceeded.
 func (p *Plugin) MutateRequest(ctx *plugin.RequestContext, req *format.CoreRequest) {
@@ -94,41 +115,30 @@ func (p *Plugin) MutateRequest(ctx *plugin.RequestContext, req *format.CoreReque
 		}
 	}
 
-	sessionKey := req.Model // Use model as rough session key
-	p.mu.Lock()
-	state, ok := p.sessions[sessionKey]
-	if !ok {
-		state = &sessionState{}
-		p.sessions[sessionKey] = state
-	}
+	state := p.getState(ctx)
+
 	// Reset if no tool calls this turn
 	if toolCount == 0 {
 		state.consecutiveTools = 0
 		state.warned = false
-	} else {
-		state.consecutiveTools += toolCount
+		return
 	}
-	currentCount := state.consecutiveTools
-	warned := state.warned
-	p.mu.Unlock()
 
-	if currentCount >= p.cfg.HardLimit && warned {
+	state.consecutiveTools += toolCount
+
+	if state.consecutiveTools >= p.cfg.HardLimit && state.warned {
 		req.System = append(req.System, format.CoreContentBlock{
 			Type: "text",
-			Text: "[CRITICAL: You have made " + itoa(currentCount) + " consecutive tool calls. STOP calling tools immediately. Provide your best answer NOW based on the information you already have. Do NOT call any more tools.]",
+			Text: "[CRITICAL: You have made " + itoa(state.consecutiveTools) + " consecutive tool calls. STOP calling tools immediately. Provide your best answer NOW based on the information you already have. Do NOT call any more tools.]",
 		})
-		p.mu.Lock()
 		state.consecutiveTools = 0
 		state.warned = false
-		p.mu.Unlock()
-	} else if currentCount >= p.cfg.MaxConsecutiveTools && !warned {
+	} else if state.consecutiveTools >= p.cfg.MaxConsecutiveTools && !state.warned {
 		req.System = append(req.System, format.CoreContentBlock{
 			Type: "text",
-			Text: "[Note: " + itoa(currentCount) + " tool calls in a row. Consider whether you have enough information to answer. If so, answer now without calling more tools.]",
+			Text: "[Note: " + itoa(state.consecutiveTools) + " tool calls in a row. Consider whether you have enough information to answer. If so, answer now without calling more tools.]",
 		})
-		p.mu.Lock()
 		state.warned = true
-		p.mu.Unlock()
 	}
 }
 
@@ -155,6 +165,6 @@ func itoa(n int) string {
 }
 
 var (
-	_ plugin.Plugin        = (*Plugin)(nil)
+	_ plugin.Plugin         = (*Plugin)(nil)
 	_ plugin.RequestMutator = (*Plugin)(nil)
 )

--- a/internal/extension/circuit_breaker/plugin.go
+++ b/internal/extension/circuit_breaker/plugin.go
@@ -1,0 +1,160 @@
+// Package circuitbreaker prevents runaway tool-call loops by tracking
+// consecutive tool_use blocks per session and injecting a reflection
+// prompt into system messages when the count exceeds a threshold.
+package circuitbreaker
+
+import (
+	"sync"
+
+	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
+	"moonbridge/internal/format"
+)
+
+const PluginName = "circuit_breaker"
+
+type Config struct {
+	MaxConsecutiveTools int `json:"max_consecutive_tools,omitempty" yaml:"max_consecutive_tools"`
+	HardLimit           int `json:"hard_limit,omitempty" yaml:"hard_limit"`
+}
+
+type sessionState struct {
+	consecutiveTools int
+	warned           bool
+}
+
+type Plugin struct {
+	plugin.BasePlugin
+	cfg           *Config
+	appCfg        config.Config
+	currentConfig func() config.Config
+	mu            sync.Mutex
+	sessions      map[string]*sessionState
+}
+
+func NewPlugin() *Plugin {
+	return &Plugin{sessions: make(map[string]*sessionState)}
+}
+
+func (p *Plugin) Name() string { return PluginName }
+
+func (p *Plugin) ConfigSpecs() []config.ExtensionConfigSpec {
+	return ConfigSpecs()
+}
+
+func ConfigSpecs() []config.ExtensionConfigSpec {
+	return []config.ExtensionConfigSpec{{
+		Name: PluginName,
+		Scopes: []config.ExtensionScope{
+			config.ExtensionScopeGlobal,
+			config.ExtensionScopeProvider,
+			config.ExtensionScopeModel,
+			config.ExtensionScopeRoute,
+		},
+		Factory: func() any { return &Config{} },
+	}}
+}
+
+func (p *Plugin) Init(ctx plugin.PluginContext) error {
+	p.cfg = plugin.Config[Config](ctx)
+	if p.cfg == nil {
+		p.cfg = &Config{}
+	}
+	if p.cfg.MaxConsecutiveTools <= 0 {
+		p.cfg.MaxConsecutiveTools = 20
+	}
+	if p.cfg.HardLimit <= 0 {
+		p.cfg.HardLimit = 30
+	}
+	p.appCfg = ctx.AppConfig
+	p.currentConfig = ctx.CurrentConfig
+	return nil
+}
+
+func (p *Plugin) EnabledForModel(model string) bool {
+	if p.currentConfig != nil {
+		return p.currentConfig().ExtensionEnabled(PluginName, model)
+	}
+	return p.appCfg.ExtensionEnabled(PluginName, model)
+}
+
+// MutateRequest implements plugin.RequestMutator.
+// Tracks tool calls and injects warnings when limits are exceeded.
+func (p *Plugin) MutateRequest(ctx *plugin.RequestContext, req *format.CoreRequest) {
+	// Count tool_use blocks in the last assistant message
+	toolCount := 0
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role != "assistant" {
+			break
+		}
+		for _, block := range req.Messages[i].Content {
+			if block.Type == "tool_use" {
+				toolCount++
+			}
+		}
+	}
+
+	sessionKey := req.Model // Use model as rough session key
+	p.mu.Lock()
+	state, ok := p.sessions[sessionKey]
+	if !ok {
+		state = &sessionState{}
+		p.sessions[sessionKey] = state
+	}
+	// Reset if no tool calls this turn
+	if toolCount == 0 {
+		state.consecutiveTools = 0
+		state.warned = false
+	} else {
+		state.consecutiveTools += toolCount
+	}
+	currentCount := state.consecutiveTools
+	warned := state.warned
+	p.mu.Unlock()
+
+	if currentCount >= p.cfg.HardLimit && warned {
+		req.System = append(req.System, format.CoreContentBlock{
+			Type: "text",
+			Text: "[CRITICAL: You have made " + itoa(currentCount) + " consecutive tool calls. STOP calling tools immediately. Provide your best answer NOW based on the information you already have. Do NOT call any more tools.]",
+		})
+		p.mu.Lock()
+		state.consecutiveTools = 0
+		state.warned = false
+		p.mu.Unlock()
+	} else if currentCount >= p.cfg.MaxConsecutiveTools && !warned {
+		req.System = append(req.System, format.CoreContentBlock{
+			Type: "text",
+			Text: "[Note: " + itoa(currentCount) + " tool calls in a row. Consider whether you have enough information to answer. If so, answer now without calling more tools.]",
+		})
+		p.mu.Lock()
+		state.warned = true
+		p.mu.Unlock()
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+var (
+	_ plugin.Plugin        = (*Plugin)(nil)
+	_ plugin.RequestMutator = (*Plugin)(nil)
+)

--- a/internal/extension/context_manager/plugin.go
+++ b/internal/extension/context_manager/plugin.go
@@ -1,0 +1,170 @@
+// Package contextmanager prevents context window overflow by estimating
+// token usage and truncating oldest messages when approaching model limits.
+// Conservative estimation (2.0 chars/token) prevents DeepSeek and other
+// providers from hitting their hard token limits mid-request.
+package contextmanager
+
+import (
+	"encoding/json"
+
+	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
+	"moonbridge/internal/format"
+)
+
+const PluginName = "context_manager"
+
+// Config for the context_manager extension.
+type Config struct {
+	// ContextLimit is the model's max context window in tokens.
+	// Default: 1,048,576 (DeepSeek V4's 1M token limit).
+	ContextLimit int `json:"context_limit,omitempty" yaml:"context_limit"`
+
+	// CompletionHeadroom is tokens reserved for the completion response.
+	// Default: 8,192.
+	CompletionHeadroom int `json:"completion_headroom,omitempty" yaml:"completion_headroom"`
+
+	// CharsPerToken is the conservative estimation ratio.
+	// Default: 2.0 (code/JSON tokenizes more densely than prose).
+	CharsPerToken float64 `json:"chars_per_token,omitempty" yaml:"chars_per_token"`
+
+	// MinRecentMessages is the minimum number of recent messages to always keep.
+	// Default: 10.
+	MinRecentMessages int `json:"min_recent_messages,omitempty" yaml:"min_recent_messages"`
+}
+
+// Plugin implements plugin.Plugin + plugin.MessageRewriter.
+type Plugin struct {
+	plugin.BasePlugin
+	cfg           *Config
+	appCfg        config.Config
+	currentConfig func() config.Config
+}
+
+func NewPlugin() *Plugin {
+	return &Plugin{}
+}
+
+func (p *Plugin) Name() string { return PluginName }
+
+func (p *Plugin) ConfigSpecs() []config.ExtensionConfigSpec {
+	return ConfigSpecs()
+}
+
+func ConfigSpecs() []config.ExtensionConfigSpec {
+	return []config.ExtensionConfigSpec{{
+		Name: PluginName,
+		Scopes: []config.ExtensionScope{
+			config.ExtensionScopeGlobal,
+			config.ExtensionScopeProvider,
+			config.ExtensionScopeModel,
+			config.ExtensionScopeRoute,
+		},
+		Factory: func() any { return &Config{} },
+	}}
+}
+
+func (p *Plugin) Init(ctx plugin.PluginContext) error {
+	p.cfg = plugin.Config[Config](ctx)
+	if p.cfg == nil {
+		p.cfg = &Config{}
+	}
+	if p.cfg.ContextLimit <= 0 {
+		p.cfg.ContextLimit = 1048576 // 1M tokens (DeepSeek V4 default)
+	}
+	if p.cfg.CompletionHeadroom <= 0 {
+		p.cfg.CompletionHeadroom = 8192
+	}
+	if p.cfg.CharsPerToken <= 0 {
+		p.cfg.CharsPerToken = 2.0
+	}
+	if p.cfg.MinRecentMessages <= 0 {
+		p.cfg.MinRecentMessages = 10
+	}
+	p.appCfg = ctx.AppConfig
+	p.currentConfig = ctx.CurrentConfig
+	return nil
+}
+
+func (p *Plugin) EnabledForModel(model string) bool {
+	if p.currentConfig != nil {
+		return p.currentConfig().ExtensionEnabled(PluginName, model)
+	}
+	return p.appCfg.ExtensionEnabled(PluginName, model)
+}
+
+// RewriteMessages implements plugin.MessageRewriter.
+// Truncates oldest non-system messages when estimated token count
+// exceeds the context budget.
+func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.CoreMessage) []format.CoreMessage {
+	budget := float64(p.cfg.ContextLimit - p.cfg.CompletionHeadroom)
+
+	// Estimate total tokens.
+	totalTokens := estimateMessagesTokens(messages, p.cfg.CharsPerToken)
+	if totalTokens <= budget {
+		return messages
+	}
+
+	// Separate system messages (always kept).
+	var systemMsgs []format.CoreMessage
+	var historyMsgs []format.CoreMessage
+	for _, m := range messages {
+		if m.Role == "system" {
+			systemMsgs = append(systemMsgs, m)
+		} else {
+			historyMsgs = append(historyMsgs, m)
+		}
+	}
+
+	systemTokens := estimateMessagesTokens(systemMsgs, p.cfg.CharsPerToken)
+
+	// Drop oldest messages from the front until within budget.
+	// Always keep the most recent MinRecentMessages.
+	minKeep := p.cfg.MinRecentMessages
+	for len(historyMsgs) > minKeep {
+		currentTotal := systemTokens + estimateMessagesTokens(historyMsgs, p.cfg.CharsPerToken)
+		if currentTotal <= budget {
+			break
+		}
+		historyMsgs = historyMsgs[1:]
+	}
+
+	// Inject truncation notice if messages were dropped.
+	if len(historyMsgs) < len(messages)-len(systemMsgs) {
+		notice := format.CoreMessage{
+			Role: "user",
+			Content: []format.CoreContentBlock{{
+				Type: "text",
+				Text: "[System: Earlier conversation history has been truncated to fit within the model's context window. Do not repeat previous statements or tool calls you already made. Continue with the current task based on the remaining context above. If you have enough information, respond to the user instead of making more tool calls.]",
+			}},
+		}
+		// Insert after system messages, before history.
+		result := make([]format.CoreMessage, 0, len(systemMsgs)+1+len(historyMsgs))
+		result = append(result, systemMsgs...)
+		result = append(result, notice)
+		result = append(result, historyMsgs...)
+		return result
+	}
+
+	// No truncation needed for history part — system msgs unchanged.
+	result := make([]format.CoreMessage, 0, len(systemMsgs)+len(historyMsgs))
+	result = append(result, systemMsgs...)
+	result = append(result, historyMsgs...)
+	return result
+}
+
+// estimateMessagesTokens estimates token count for a slice of messages.
+func estimateMessagesTokens(messages []format.CoreMessage, charsPerToken float64) float64 {
+	var total float64
+	for _, m := range messages {
+		data, _ := json.Marshal(m.Content)
+		total += float64(len(data)) / charsPerToken
+	}
+	return total
+}
+
+// Compile-time interface checks.
+var (
+	_ plugin.Plugin          = (*Plugin)(nil)
+	_ plugin.MessageRewriter = (*Plugin)(nil)
+)

--- a/internal/extension/response_store/plugin.go
+++ b/internal/extension/response_store/plugin.go
@@ -1,0 +1,101 @@
+// Package responsestore provides response storage for Codex sessions.
+// Stores recent responses in an in-memory LRU cache.
+// Previous_response_id bridging requires CoreRequest field addition (future work).
+package responsestore
+
+import (
+	"sync"
+	"time"
+
+	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
+	"moonbridge/internal/protocol/openai"
+)
+
+const PluginName = "response_store"
+
+type Config struct {
+	TTLSeconds int `json:"ttl_seconds,omitempty" yaml:"ttl_seconds"`
+	MaxEntries int `json:"max_entries,omitempty" yaml:"max_entries"`
+}
+
+type storedResponse struct {
+	output   []openai.OutputItem
+	storedAt time.Time
+}
+
+type Plugin struct {
+	plugin.BasePlugin
+	cfg           *Config
+	appCfg        config.Config
+	currentConfig func() config.Config
+	mu            sync.RWMutex
+	store         map[string]*storedResponse
+}
+
+func NewPlugin() *Plugin {
+	return &Plugin{store: make(map[string]*storedResponse)}
+}
+
+func (p *Plugin) Name() string { return PluginName }
+
+func (p *Plugin) ConfigSpecs() []config.ExtensionConfigSpec {
+	return ConfigSpecs()
+}
+
+func ConfigSpecs() []config.ExtensionConfigSpec {
+	return []config.ExtensionConfigSpec{{
+		Name: PluginName,
+		Scopes: []config.ExtensionScope{
+			config.ExtensionScopeGlobal,
+			config.ExtensionScopeModel,
+		},
+		Factory: func() any { return &Config{} },
+	}}
+}
+
+func (p *Plugin) Init(ctx plugin.PluginContext) error {
+	p.cfg = plugin.Config[Config](ctx)
+	if p.cfg == nil {
+		p.cfg = &Config{TTLSeconds: 3600, MaxEntries: 500}
+	}
+	if p.cfg.TTLSeconds <= 0 {
+		p.cfg.TTLSeconds = 3600
+	}
+	if p.cfg.MaxEntries <= 0 {
+		p.cfg.MaxEntries = 500
+	}
+	p.appCfg = ctx.AppConfig
+	p.currentConfig = ctx.CurrentConfig
+	return nil
+}
+
+func (p *Plugin) EnabledForModel(model string) bool { return true }
+
+// PostProcessResponse stores the response for future bridging.
+func (p *Plugin) PostProcessResponse(ctx *plugin.RequestContext, resp *openai.Response) {
+	if resp == nil || resp.ID == "" || len(resp.Output) == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	for id, entry := range p.store {
+		if now.Sub(entry.storedAt) > time.Duration(p.cfg.TTLSeconds)*time.Second {
+			delete(p.store, id)
+		}
+	}
+	if len(p.store) >= p.cfg.MaxEntries {
+		for id := range p.store {
+			delete(p.store, id)
+			break
+		}
+	}
+	p.store[resp.ID] = &storedResponse{output: resp.Output, storedAt: now}
+}
+
+var (
+	_ plugin.Plugin               = (*Plugin)(nil)
+	_ plugin.ResponsePostProcessor = (*Plugin)(nil)
+)

--- a/internal/extension/response_store/plugin.go
+++ b/internal/extension/response_store/plugin.go
@@ -1,9 +1,11 @@
-// Package responsestore provides response storage for Codex sessions.
-// Stores recent responses in an in-memory LRU cache.
-// Previous_response_id bridging requires CoreRequest field addition (future work).
+// Package responsestore provides response storage and previous_response_id
+// bridging for Codex sessions. Responses are stored in an in-memory LRU cache.
+// When a new request carries a previous_response_id, the stored response's
+// assistant output is prepended to the input for conversation continuity.
 package responsestore
 
 import (
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -24,17 +26,21 @@ type storedResponse struct {
 	storedAt time.Time
 }
 
+// Global store so it's accessible from dispatch.go without coupling to Plugin.
+var (
+	globalMu    sync.RWMutex
+	globalStore = make(map[string]*storedResponse)
+)
+
 type Plugin struct {
 	plugin.BasePlugin
 	cfg           *Config
 	appCfg        config.Config
 	currentConfig func() config.Config
-	mu            sync.RWMutex
-	store         map[string]*storedResponse
 }
 
 func NewPlugin() *Plugin {
-	return &Plugin{store: make(map[string]*storedResponse)}
+	return &Plugin{}
 }
 
 func (p *Plugin) Name() string { return PluginName }
@@ -77,25 +83,116 @@ func (p *Plugin) PostProcessResponse(ctx *plugin.RequestContext, resp *openai.Re
 	if resp == nil || resp.ID == "" || len(resp.Output) == 0 {
 		return
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	StoreResponse(resp, p.cfg.TTLSeconds, p.cfg.MaxEntries)
+}
+
+// StoreResponse saves a response in the global cache. Exported so it can
+// be called from non-plugin code (e.g., dispatch.go for bridging).
+func StoreResponse(resp *openai.Response, ttlSeconds, maxEntries int) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
 
 	now := time.Now()
-	for id, entry := range p.store {
-		if now.Sub(entry.storedAt) > time.Duration(p.cfg.TTLSeconds)*time.Second {
-			delete(p.store, id)
+	for id, entry := range globalStore {
+		if now.Sub(entry.storedAt) > time.Duration(ttlSeconds)*time.Second {
+			delete(globalStore, id)
 		}
 	}
-	if len(p.store) >= p.cfg.MaxEntries {
-		for id := range p.store {
-			delete(p.store, id)
+	if len(globalStore) >= maxEntries {
+		for id := range globalStore {
+			delete(globalStore, id)
 			break
 		}
 	}
-	p.store[resp.ID] = &storedResponse{output: resp.Output, storedAt: now}
+	globalStore[resp.ID] = &storedResponse{output: resp.Output, storedAt: now}
+}
+
+// GetStoredResponse returns the stored output items for a given response ID,
+// or nil if not found or expired.
+func GetStoredResponse(responseID string) []openai.OutputItem {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+
+	entry, ok := globalStore[responseID]
+	if !ok {
+		return nil
+	}
+	return entry.output
+}
+
+// BridgePreviousResponse takes a ResponsesRequest and, if it has a
+// previous_response_id, prepends the assistant's output from that
+// prior response to the new request's input messages.
+//
+// Returns the modified input or the original input (with the response text
+// prepended) when bridging is possible; returns nil, false if there is
+// no previous_response_id or the stored response can't be found.
+func BridgePreviousResponse(req *openai.ResponsesRequest) (string, bool) {
+	if req.PreviousResponseID == "" {
+		return "", false
+	}
+
+	output := GetStoredResponse(req.PreviousResponseID)
+	if output == nil || len(output) == 0 {
+		return "", false
+	}
+
+	// Extract assistant message text from the stored response
+	var prevText string
+	for _, item := range output {
+		if item.Type == "message" && item.Role == "assistant" {
+			for _, part := range item.Content {
+				if part.Type == "text" && part.Text != "" {
+					if prevText != "" {
+						prevText += "\n"
+					}
+					prevText += part.Text
+				}
+			}
+		}
+	}
+
+	if prevText == "" {
+		return "", false
+	}
+
+	// Build a bridge message: [previous assistant response] + [current user input]
+	currentInput := extractInputText(req.Input)
+	if currentInput == "" {
+		currentInput = "[follow-up request]"
+	}
+
+	return "[Previous assistant response:\n" + prevText + "\n]\n\n[User now says:\n" + currentInput + "\n]", true
+}
+
+// extractInputText pulls the text content from a ResponsesRequest Input field.
+func extractInputText(input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+
+	// Try string first
+	var s string
+	if err := json.Unmarshal(input, &s); err == nil && s != "" {
+		return s
+	}
+
+	// Try array of content parts
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(input, &parts); err == nil {
+		for _, p := range parts {
+			if p.Text != "" {
+				return p.Text
+			}
+		}
+	}
+
+	return ""
 }
 
 var (
-	_ plugin.Plugin               = (*Plugin)(nil)
+	_ plugin.Plugin                = (*Plugin)(nil)
 	_ plugin.ResponsePostProcessor = (*Plugin)(nil)
 )

--- a/internal/extension/visual/core_orchestrator.go
+++ b/internal/extension/visual/core_orchestrator.go
@@ -58,6 +58,10 @@ func (o *CoreOrchestrator) CreateCore(ctx context.Context, req *format.CoreReque
 	}
 	req = cloneCoreRequest(req)
 	req, availableImages := prepareCoreRequestForVisual(req)
+	// Defensive: filter out tools with empty names before sending to upstream.
+	// An empty tool name can originate from Codex MCP tools with unnamed sub-tools
+	// and will cause DeepSeek to reject with "Invalid 'tools[N].function.name': empty string".
+	req.Tools = filterEmptyNameTools(req.Tools)
 	log := slog.Default()
 	aggregatedUsage := format.CoreUsage{}
 	hasAggregatedUsage := false
@@ -307,4 +311,21 @@ func cloneCoreRequest(req *format.CoreRequest) *format.CoreRequest {
 		return &cloned
 	}
 	return &cloned
+}
+
+// filterEmptyNameTools removes tools with empty names from the tool list.
+// This prevents upstream validation errors (e.g., DeepSeek rejecting
+// "Invalid 'tools[N].function.name': empty string").
+func filterEmptyNameTools(tools []format.CoreTool) []format.CoreTool {
+	if len(tools) == 0 {
+		return tools
+	}
+	filtered := make([]format.CoreTool, 0, len(tools))
+	for _, t := range tools {
+		if t.Name == "" {
+			continue
+		}
+		filtered = append(filtered, t)
+	}
+	return filtered
 }

--- a/internal/extension/web_fetch/plugin.go
+++ b/internal/extension/web_fetch/plugin.go
@@ -1,0 +1,191 @@
+// Package webfetch provides a proxy-side web_fetch tool for Codex.
+// When enabled, it injects a web_fetch tool definition into requests
+// and executes URL fetches on the proxy side (bypassing Codex sandbox).
+package webfetch
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"moonbridge/internal/config"
+	"moonbridge/internal/extension/plugin"
+	"moonbridge/internal/format"
+)
+
+const PluginName = "web_fetch"
+
+// Config for the web_fetch extension.
+type Config struct {
+	// Timeout for HTTP fetches (default 15s).
+	TimeoutSeconds int `json:"timeout_seconds,omitempty" yaml:"timeout_seconds"`
+	// Max response body bytes (default 50000).
+	MaxBodyBytes int `json:"max_body_bytes,omitempty" yaml:"max_body_bytes"`
+}
+
+// Plugin implements ToolInjector + MessageRewriter.
+type Plugin struct {
+	plugin.BasePlugin
+	cfg           *Config
+	appCfg        config.Config
+	currentConfig func() config.Config
+}
+
+func NewPlugin() *Plugin {
+	return &Plugin{}
+}
+
+func (p *Plugin) Name() string { return PluginName }
+
+func (p *Plugin) ConfigSpecs() []config.ExtensionConfigSpec {
+	return ConfigSpecs()
+}
+
+func ConfigSpecs() []config.ExtensionConfigSpec {
+	return []config.ExtensionConfigSpec{{
+		Name: PluginName,
+		Scopes: []config.ExtensionScope{
+			config.ExtensionScopeGlobal,
+			config.ExtensionScopeProvider,
+			config.ExtensionScopeModel,
+			config.ExtensionScopeRoute,
+		},
+		Factory: func() any { return &Config{} },
+	}}
+}
+
+func (p *Plugin) Init(ctx plugin.PluginContext) error {
+	p.cfg = plugin.Config[Config](ctx)
+	if p.cfg == nil {
+		p.cfg = &Config{}
+	}
+	if p.cfg.TimeoutSeconds <= 0 {
+		p.cfg.TimeoutSeconds = 15
+	}
+	if p.cfg.MaxBodyBytes <= 0 {
+		p.cfg.MaxBodyBytes = 50000
+	}
+	p.appCfg = ctx.AppConfig
+	p.currentConfig = ctx.CurrentConfig
+	return nil
+}
+
+func (p *Plugin) EnabledForModel(model string) bool {
+	if p.currentConfig != nil {
+		return p.currentConfig().ExtensionEnabled(PluginName, model)
+	}
+	return p.appCfg.ExtensionEnabled(PluginName, model)
+}
+
+// InjectTools implements plugin.ToolInjector.
+func (p *Plugin) InjectTools(ctx *plugin.RequestContext) []format.CoreTool {
+	return []format.CoreTool{{
+		Name:        "web_fetch",
+		Description: "Fetch content from a URL over HTTP/HTTPS. Use this to read web pages, API responses, or documentation. Returns the HTTP status, headers, and body as text.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"url": map[string]any{
+					"type":        "string",
+					"description": "The URL to fetch (must start with http:// or https://)",
+				},
+				"method": map[string]any{
+					"type":        "string",
+					"enum":        []string{"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
+					"description": "HTTP method (default: GET)",
+				},
+			},
+			"required": []string{"url"},
+		},
+	}}
+}
+
+// RewriteMessages implements plugin.MessageRewriter.
+// Scans incoming tool results for web_fetch calls and executes them proxy-side.
+func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.CoreMessage) []format.CoreMessage {
+	for i := range messages {
+		msg := &messages[i]
+		if msg.Role != "tool" {
+			continue
+		}
+		for j := range msg.Content {
+			block := &msg.Content[j]
+			if block.Type != "tool_result" {
+				continue
+			}
+			// Check if the preceding assistant message has a matching tool_use for web_fetch
+			if i > 0 && messages[i-1].Role == "assistant" {
+				for _, ab := range messages[i-1].Content {
+					if ab.Type == "tool_use" && ab.ToolUseID == block.ToolUseID && ab.ToolName == "web_fetch" {
+						// This is a web_fetch call — execute it proxy-side
+						result := p.executeFetch(ab.ToolInput)
+						block.ToolResultContent = []format.CoreContentBlock{{
+							Type: "text",
+							Text: result,
+						}}
+					}
+				}
+			}
+		}
+	}
+	return messages
+}
+
+func (p *Plugin) executeFetch(input json.RawMessage) string {
+	var args struct {
+		URL    string `json:"url"`
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return fmt.Sprintf(`{"error": "invalid arguments: %v"}`, err)
+	}
+	if args.URL == "" {
+		return `{"error": "url is required"}`
+	}
+	if !strings.HasPrefix(args.URL, "http://") && !strings.HasPrefix(args.URL, "https://") {
+		return `{"error": "url must start with http:// or https://"}`
+	}
+	if args.Method == "" {
+		args.Method = "GET"
+	}
+
+	client := &http.Client{Timeout: time.Duration(p.cfg.TimeoutSeconds) * time.Second}
+	req, err := http.NewRequest(args.Method, args.URL, nil)
+	if err != nil {
+		return fmt.Sprintf(`{"error": "failed to create request: %v"}`, err)
+	}
+	req.Header.Set("User-Agent", "MoonBridge-WebFetch/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Sprintf(`{"error": "fetch failed: %v"}`, err)
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, int64(p.cfg.MaxBodyBytes))
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return fmt.Sprintf(`{"error": "read failed: %v", "status": %d}`, err, resp.StatusCode)
+	}
+
+	return fmt.Sprintf(`{"status": %d, "content_type": %q, "body": %s}`,
+		resp.StatusCode,
+		resp.Header.Get("Content-Type"),
+		jsonEscape(string(body)),
+	)
+}
+
+func jsonEscape(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// Compile-time interface checks.
+var (
+	_ plugin.Plugin         = (*Plugin)(nil)
+	_ plugin.ToolInjector   = (*Plugin)(nil)
+	_ plugin.MessageRewriter = (*Plugin)(nil)
+)

--- a/internal/extension/web_fetch/plugin.go
+++ b/internal/extension/web_fetch/plugin.go
@@ -103,6 +103,63 @@ func (p *Plugin) InjectTools(ctx *plugin.RequestContext) []format.CoreTool {
 	}}
 }
 
+// MutateRequest implements plugin.RequestMutator.
+// Scans recent user messages for URLs and injects a hint when found,
+// prompting the model to use the web_fetch tool instead of shell HTTP tools.
+func (p *Plugin) MutateRequest(ctx *plugin.RequestContext, req *format.CoreRequest) {
+	if !hasURLsInMessages(req.Messages) {
+		return
+	}
+	// Check if hint already injected (avoid duplication).
+	for _, sys := range req.System {
+		if sys.Type == "text" && containsString(sys.Text, "web_fetch tool available") {
+			return
+		}
+	}
+	req.System = append(req.System, format.CoreContentBlock{
+		Type: "text",
+		Text: "[System: You have a `web_fetch` tool available for making HTTP requests. Use it instead of curl, wget, or other shell-based HTTP tools. Call web_fetch with {\"url\": \"...\"} to fetch any URL. It returns clean Markdown via Jina Reader.]",
+	})
+}
+
+// hasURLsInMessages checks whether any recent user messages contain URLs.
+func hasURLsInMessages(messages []format.CoreMessage) bool {
+	// Check last 5 messages for URLs.
+	start := len(messages) - 5
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < len(messages); i++ {
+		if messages[i].Role != "user" {
+			continue
+		}
+		for _, block := range messages[i].Content {
+			if block.Type == "text" && containsURL(block.Text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsURL(s string) bool {
+	return len(s) > 10 &&
+		(containsString(s, "http://") || containsString(s, "https://"))
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && indexOfSubstring(s, substr) >= 0
+}
+
+func indexOfSubstring(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
 // RewriteMessages implements plugin.MessageRewriter.
 // Scans incoming tool results for web_fetch calls and executes them proxy-side.
 func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.CoreMessage) []format.CoreMessage {
@@ -228,5 +285,6 @@ func jsonEscape(s string) string {
 var (
 	_ plugin.Plugin          = (*Plugin)(nil)
 	_ plugin.ToolInjector    = (*Plugin)(nil)
+	_ plugin.RequestMutator  = (*Plugin)(nil)
 	_ plugin.MessageRewriter = (*Plugin)(nil)
 )

--- a/internal/extension/web_fetch/plugin.go
+++ b/internal/extension/web_fetch/plugin.go
@@ -1,6 +1,7 @@
 // Package webfetch provides a proxy-side web_fetch tool for Codex.
 // When enabled, it injects a web_fetch tool definition into requests
 // and executes URL fetches on the proxy side (bypassing Codex sandbox).
+// Uses Jina Reader (r.jina.ai) for clean Markdown extraction.
 package webfetch
 
 import (
@@ -84,7 +85,7 @@ func (p *Plugin) EnabledForModel(model string) bool {
 func (p *Plugin) InjectTools(ctx *plugin.RequestContext) []format.CoreTool {
 	return []format.CoreTool{{
 		Name:        "web_fetch",
-		Description: "Fetch content from a URL over HTTP/HTTPS. Use this to read web pages, API responses, or documentation. Returns the HTTP status, headers, and body as text.",
+		Description: "Fetch and extract clean Markdown content from a URL using Jina Reader. Use this to read web pages, documentation, or API responses. Returns clean, readable text suitable for LLM consumption.",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -92,10 +93,9 @@ func (p *Plugin) InjectTools(ctx *plugin.RequestContext) []format.CoreTool {
 					"type":        "string",
 					"description": "The URL to fetch (must start with http:// or https://)",
 				},
-				"method": map[string]any{
-					"type":        "string",
-					"enum":        []string{"GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
-					"description": "HTTP method (default: GET)",
+				"raw": map[string]any{
+					"type":        "boolean",
+					"description": "If true, skip Jina Reader and fetch raw content directly (default: false)",
 				},
 			},
 			"required": []string{"url"},
@@ -120,7 +120,6 @@ func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.C
 			if i > 0 && messages[i-1].Role == "assistant" {
 				for _, ab := range messages[i-1].Content {
 					if ab.Type == "tool_use" && ab.ToolUseID == block.ToolUseID && ab.ToolName == "web_fetch" {
-						// This is a web_fetch call — execute it proxy-side
 						result := p.executeFetch(ab.ToolInput)
 						block.ToolResultContent = []format.CoreContentBlock{{
 							Type: "text",
@@ -136,8 +135,8 @@ func (p *Plugin) RewriteMessages(ctx *plugin.RequestContext, messages []format.C
 
 func (p *Plugin) executeFetch(input json.RawMessage) string {
 	var args struct {
-		URL    string `json:"url"`
-		Method string `json:"method"`
+		URL string `json:"url"`
+		Raw bool   `json:"raw"`
 	}
 	if err := json.Unmarshal(input, &args); err != nil {
 		return fmt.Sprintf(`{"error": "invalid arguments: %v"}`, err)
@@ -148,12 +147,54 @@ func (p *Plugin) executeFetch(input json.RawMessage) string {
 	if !strings.HasPrefix(args.URL, "http://") && !strings.HasPrefix(args.URL, "https://") {
 		return `{"error": "url must start with http:// or https://"}`
 	}
-	if args.Method == "" {
-		args.Method = "GET"
+
+	// Primary: Jina Reader for clean Markdown extraction
+	if !args.Raw {
+		result, err := p.fetchViaJina(args.URL)
+		if err == nil {
+			return fmt.Sprintf(`{"status": 200, "source": "jina", "content": %s}`, jsonEscape(result))
+		}
 	}
 
+	// Fallback: direct HTTP fetch
+	return fetchDirect(args.URL, p.cfg.TimeoutSeconds, p.cfg.MaxBodyBytes)
+}
+
+// fetchViaJina uses Jina Reader (r.jina.ai) to extract clean Markdown from a URL.
+func (p *Plugin) fetchViaJina(url string) (string, error) {
+	jinaURL := "https://r.jina.ai/" + url
+
 	client := &http.Client{Timeout: time.Duration(p.cfg.TimeoutSeconds) * time.Second}
-	req, err := http.NewRequest(args.Method, args.URL, nil)
+	req, err := http.NewRequest("GET", jinaURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("create jina request: %w", err)
+	}
+	req.Header.Set("Accept", "text/markdown")
+	req.Header.Set("User-Agent", "MoonBridge-WebFetch/1.0")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("jina fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("jina returned status %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, int64(p.cfg.MaxBodyBytes))
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return "", fmt.Errorf("jina read: %w", err)
+	}
+
+	return string(body), nil
+}
+
+// fetchDirect does a raw HTTP GET.
+func fetchDirect(url string, timeoutSec, maxBytes int) string {
+	client := &http.Client{Timeout: time.Duration(timeoutSec) * time.Second}
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Sprintf(`{"error": "failed to create request: %v"}`, err)
 	}
@@ -165,7 +206,7 @@ func (p *Plugin) executeFetch(input json.RawMessage) string {
 	}
 	defer resp.Body.Close()
 
-	limited := io.LimitReader(resp.Body, int64(p.cfg.MaxBodyBytes))
+	limited := io.LimitReader(resp.Body, int64(maxBytes))
 	body, err := io.ReadAll(limited)
 	if err != nil {
 		return fmt.Sprintf(`{"error": "read failed: %v", "status": %d}`, err, resp.StatusCode)
@@ -185,7 +226,7 @@ func jsonEscape(s string) string {
 
 // Compile-time interface checks.
 var (
-	_ plugin.Plugin         = (*Plugin)(nil)
-	_ plugin.ToolInjector   = (*Plugin)(nil)
+	_ plugin.Plugin          = (*Plugin)(nil)
+	_ plugin.ToolInjector    = (*Plugin)(nil)
 	_ plugin.MessageRewriter = (*Plugin)(nil)
 )

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -930,6 +930,8 @@ type inputItem struct {
 	Type      string          `json:"type"`
 	Role      string          `json:"role"`
 	Content   json.RawMessage `json:"content"`
+	Text      string          `json:"text"`
+	ImageURL  json.RawMessage `json:"image_url"`
 	Summary   json.RawMessage `json:"summary"`
 	CallID    string          `json:"call_id"`
 	Name      string          `json:"name"`
@@ -1138,7 +1140,33 @@ func convertInput(raw json.RawMessage, model string) ([]format.CoreMessage, []fo
 			}
 
 		default:
+			// Try nested content first (role-based items with content array).
 			blocks := contentBlocksFromRaw(item.Content)
+			// Handle flat-format items: input_text with top-level "text", or
+			// input_image with top-level "image_url".
+			if len(blocks) == 0 {
+				if item.Text != "" {
+					blocks = []format.CoreContentBlock{{Type: "text", Text: item.Text}}
+				} else if src := imageSourceFromRaw(item.ImageURL); src != "" {
+					mediaType := "image/png"
+					if strings.HasPrefix(src, "data:") {
+						if header, _, ok := strings.Cut(src, ","); ok {
+							mt := strings.TrimPrefix(header, "data:")
+							if semicolon := strings.IndexByte(mt, ';'); semicolon >= 0 {
+								mt = mt[:semicolon]
+							}
+							if mt != "" {
+								mediaType = mt
+							}
+						}
+					}
+					blocks = []format.CoreContentBlock{{
+						Type:      "image",
+						ImageData: src,
+						MediaType: mediaType,
+					}}
+				}
+			}
 			if len(blocks) > 0 {
 				messages = append(messages, format.CoreMessage{
 					Role:    "user",

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1555,6 +1555,15 @@ func convertToolWithNamespace(tool Tool, namespace string, disablePatchProxy fun
 	name := namespacedToolName(namespace, tool.Name)
 	ext := make(map[string]any)
 
+	// Defensive: skip tools with empty names to prevent upstream validation
+	// errors (e.g. DeepSeek "Invalid 'tools[N].function.name': empty string").
+	// Namespace-type tools are exempt because their name is used only as prefix
+	// for sub-tools; a namespace with an empty name is unusual but still valid
+	// as long as its sub-tools have proper names.
+	if name == "" && tool.Type != "namespace" {
+		return nil
+	}
+
 	switch tool.Type {
 	case "function":
 		ct := format.CoreTool{

--- a/internal/service/app/extensions.go
+++ b/internal/service/app/extensions.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"log/slog"
 
+	circuitbreaker "moonbridge/internal/extension/circuit_breaker"
 	dbd1 "moonbridge/internal/extension/db/d1"
 	dbsqlite "moonbridge/internal/extension/db/sqlite"
 	deepseekv4 "moonbridge/internal/extension/deepseek_v4"
@@ -11,7 +12,9 @@ import (
 	mbtrics "moonbridge/internal/extension/metrics"
 	codextoolproxy "moonbridge/internal/extension/codex_tool_proxy"
 	"moonbridge/internal/extension/plugin"
+	responsestore "moonbridge/internal/extension/response_store"
 	"moonbridge/internal/extension/visual"
+	webfetch "moonbridge/internal/extension/web_fetch"
 	"moonbridge/internal/config"
 )
 
@@ -38,6 +41,9 @@ func (cat BuiltinExtensionCatalog) ConfigSpecs() []config.ExtensionConfigSpec {
 	specs = append(specs, dbd1.ConfigSpecs()...)
 	specs = append(specs, mbtrics.ConfigSpecs()...)
 	specs = append(specs, codextoolproxy.ConfigSpecs()...)
+	specs = append(specs, webfetch.ConfigSpecs()...)
+	specs = append(specs, circuitbreaker.ConfigSpecs()...)
+	specs = append(specs, responsestore.ConfigSpecs()...)
 	return specs
 }
 
@@ -61,5 +67,8 @@ func (cat BuiltinExtensionCatalog) NewRegistry(logger *slog.Logger, cfg config.C
 
 	registry.Register(mbtrics.NewPlugin())
 	registry.Register(codextoolproxy.NewPlugin())
+	registry.Register(webfetch.NewPlugin())
+	registry.Register(circuitbreaker.NewPlugin())
+	registry.Register(responsestore.NewPlugin())
 	return registry
 }

--- a/internal/service/app/extensions.go
+++ b/internal/service/app/extensions.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	circuitbreaker "moonbridge/internal/extension/circuit_breaker"
+	contextmanager "moonbridge/internal/extension/context_manager"
 	dbd1 "moonbridge/internal/extension/db/d1"
 	dbsqlite "moonbridge/internal/extension/db/sqlite"
 	deepseekv4 "moonbridge/internal/extension/deepseek_v4"
@@ -43,6 +44,7 @@ func (cat BuiltinExtensionCatalog) ConfigSpecs() []config.ExtensionConfigSpec {
 	specs = append(specs, codextoolproxy.ConfigSpecs()...)
 	specs = append(specs, webfetch.ConfigSpecs()...)
 	specs = append(specs, circuitbreaker.ConfigSpecs()...)
+	specs = append(specs, contextmanager.ConfigSpecs()...)
 	specs = append(specs, responsestore.ConfigSpecs()...)
 	return specs
 }
@@ -69,6 +71,7 @@ func (cat BuiltinExtensionCatalog) NewRegistry(logger *slog.Logger, cfg config.C
 	registry.Register(codextoolproxy.NewPlugin())
 	registry.Register(webfetch.NewPlugin())
 	registry.Register(circuitbreaker.NewPlugin())
+	registry.Register(contextmanager.NewPlugin())
 	registry.Register(responsestore.NewPlugin())
 	return registry
 }

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -863,7 +863,7 @@ func (s *Server) handleAdapterStream(
 		s.writeTrace(streamRecord)
 	}()
 
-	if candidate.Protocol == config.ProtocolAnthropic && coreRequestHasImage(coreReq) {
+	if candidate.Protocol == config.ProtocolAnthropic && coreRequestHasNewImage(coreReq) {
 		if providerAdapter := s.adapterRegistryProvider(config.ProtocolAnthropic); providerAdapter != nil {
 			finalizeAnthropicUpstream := func(_ context.Context, upstream any) (any, error) {
 				msgReq, err := normalizeAnthropicRequest(upstream)
@@ -1803,6 +1803,28 @@ func coreBlockHasImage(block format.CoreContentBlock) bool {
 		if coreBlockHasImage(child) {
 			return true
 		}
+	}
+	return false
+}
+
+// coreRequestHasNewImage checks whether the LATEST user message in the
+// request contains image blocks. Unlike coreRequestHasImage, this ignores
+// images in conversation history — preventing the visual fast path from
+// activating on follow-up text messages that only carry old image references.
+func coreRequestHasNewImage(req *format.CoreRequest) bool {
+	if req == nil {
+		return false
+	}
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role != "user" {
+			continue
+		}
+		for _, block := range req.Messages[i].Content {
+			if coreBlockHasImage(block) {
+				return true
+			}
+		}
+		return false
 	}
 	return false
 }

--- a/internal/service/server/dispatch.go
+++ b/internal/service/server/dispatch.go
@@ -521,6 +521,19 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 					logBillingUsageLine(responsesRequest.Model, actualModel, billingUsage, server.stats)
 				}
 			}
+
+			// Call response post-processors (e.g., response_store, tool_call fixup).
+			if !responsesRequest.Stream && server.pluginRegistry != nil {
+				var resp openai.Response
+				if err := json.Unmarshal(captured.Bytes(), &resp); err == nil && resp.ID != "" {
+					sess := server.sessionForRequest(request)
+					reqCtx := &plugin.RequestContext{ModelAlias: responsesRequest.Model}
+					if sess != nil {
+						reqCtx.SessionData = sess.ExtensionData
+					}
+					server.pluginRegistry.PostProcessResponse(reqCtx, &resp)
+				}
+			}
 		}
 		if metricTelemetry.Protocol == "" {
 			metricTelemetry = zeroUsage(config.ProtocolOpenAIResponse, "none")

--- a/internal/service/server/dispatch.go
+++ b/internal/service/server/dispatch.go
@@ -12,6 +12,7 @@ import (
 
 	"moonbridge/internal/config"
 	"moonbridge/internal/extension/plugin"
+	responsestore "moonbridge/internal/extension/response_store"
 	"moonbridge/internal/logger"
 	"moonbridge/internal/protocol/openai"
 	"moonbridge/internal/service/provider"
@@ -373,6 +374,12 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 		// Inject web_search tool if enabled for this model.
 		if pm.ResolvedWebSearchForModel(responsesRequest.Model) == "enabled" {
 			upstreamRequest.Tools = InjectWebSearchTool(upstreamRequest.Tools)
+		}
+
+		// Bridge previous_response_id if supported.
+		if bridged, ok := responsestore.BridgePreviousResponse(&upstreamRequest); ok {
+			bridgedJSON, _ := json.Marshal(bridged)
+			upstreamRequest.Input = bridgedJSON
 		}
 
 		body, err := json.Marshal(upstreamRequest)

--- a/internal/service/server/entry_handlers.go
+++ b/internal/service/server/entry_handlers.go
@@ -1,0 +1,604 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"moonbridge/internal/config"
+	"moonbridge/internal/format"
+	"moonbridge/internal/protocol/anthropic"
+	"moonbridge/internal/protocol/chat"
+	"moonbridge/internal/service/provider"
+)
+
+// handleAnthropicMessages handles POST /v1/messages (Anthropic Messages API).
+// Used by Claude Code, Claude API clients, etc.
+func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
+	log := slog.Default().With("path", r.URL.Path, "method", r.Method, "remote", r.RemoteAddr)
+
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Error("读取请求体失败", "error", err)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	var msgReq anthropic.MessageRequest
+	if err := json.Unmarshal(body, &msgReq); err != nil {
+		log.Warn("无效的 Anthropic 请求", "error", err)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	if msgReq.Model == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "model is required"})
+		return
+	}
+
+	route, resolveErr := s.resolveModelOrFallback(msgReq.Model)
+	if resolveErr != nil {
+		log.Warn("未知模型", "model", msgReq.Model)
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": fmt.Sprintf("unknown model: %q", msgReq.Model)})
+		return
+	}
+
+	coreReq := anthropicMessageToCore(&msgReq)
+	coreResp, dispErr := s.dispatchCoreRequest(r.Context(), coreReq, route)
+	if dispErr != nil {
+		log.Error("Anthropic dispatch 失败", "error", dispErr)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": dispErr.Error()})
+		return
+	}
+	outMsg := coreToAnthropicResponse(coreResp)
+	outMsg.Model = coreResp.Model
+	writeJSON(w, http.StatusOK, outMsg)
+}
+
+// handleChatCompletions handles POST /v1/chat/completions (OpenAI Chat API).
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	log := slog.Default().With("path", r.URL.Path, "method", r.Method, "remote", r.RemoteAddr)
+
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Error("读取请求体失败", "error", err)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	var chatReq chat.ChatRequest
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		log.Warn("无效的 Chat 请求", "error", err)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	if chatReq.Model == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "model is required"})
+		return
+	}
+
+	route, resolveErr := s.resolveModelOrFallback(chatReq.Model)
+	if resolveErr != nil {
+		log.Warn("未知模型", "model", chatReq.Model)
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": fmt.Sprintf("unknown model: %q", chatReq.Model)})
+		return
+	}
+
+	coreReq := chatRequestToCore(&chatReq)
+	coreResp, dispErr := s.dispatchCoreRequest(r.Context(), coreReq, route)
+	if dispErr != nil {
+		log.Error("Chat dispatch 失败", "error", dispErr)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": dispErr.Error()})
+		return
+	}
+	outChat := coreToChatResponse(coreResp)
+	outChat.Model = coreResp.Model
+	writeJSON(w, http.StatusOK, outChat)
+}
+
+// dispatchCoreRequest runs the adapter pipeline and returns a CoreResponse.
+// The caller is responsible for converting to the entry protocol format.
+func (s *Server) dispatchCoreRequest(
+	ctx context.Context,
+	coreReq *format.CoreRequest,
+	route *provider.ResolvedRoute,
+) (*format.CoreResponse, error) {
+	log := slog.Default().With("model", coreReq.Model, "path", "core_dispatch")
+
+	pm := s.activeProviderManager()
+	if pm == nil {
+		return nil, fmt.Errorf("provider manager not available")
+	}
+
+	preferred, ok := route.Preferred()
+	if !ok {
+		log.Error("路由无可用提供商")
+		return nil, fmt.Errorf("no available provider")
+	}
+
+	providerAdapter, ok := s.adapterRegistry.GetProvider(preferred.Protocol)
+	if !ok {
+		log.Error("无可用协议适配器", "protocol", preferred.Protocol)
+		return nil, fmt.Errorf("no adapter for protocol %q", preferred.Protocol)
+	}
+
+	coreReq.Model = preferred.UpstreamModel
+
+	upstreamAny, err := providerAdapter.FromCoreRequest(ctx, coreReq)
+	if err != nil {
+		log.Error("Core → upstream 转换失败", "error", err)
+		return nil, fmt.Errorf("conversion error: %w", err)
+	}
+
+	start := time.Now()
+
+	switch preferred.Protocol {
+	case config.ProtocolAnthropic:
+		return s.dispatchAnthropicCore(ctx, upstreamAny, preferred, providerAdapter, log, start)
+	case config.ProtocolOpenAIChat:
+		return s.dispatchChatCore(ctx, upstreamAny, preferred, providerAdapter, log, start)
+	default:
+		log.Error("不支持的协议", "protocol", preferred.Protocol)
+		return nil, fmt.Errorf("unsupported protocol: %s", preferred.Protocol)
+	}
+}
+
+func (s *Server) dispatchAnthropicCore(
+	ctx context.Context,
+	upstreamAny interface{}, preferred provider.ProviderCandidate,
+	providerAdapter format.ProviderAdapter, log *slog.Logger, start time.Time,
+) (*format.CoreResponse, error) {
+	upstreamReq, ok := upstreamAny.(*anthropic.MessageRequest)
+	if !ok {
+		return nil, fmt.Errorf("unexpected upstream type")
+	}
+
+	client := preferred.Client
+	if client == nil {
+		return nil, fmt.Errorf("no upstream client")
+	}
+
+	rawResp, err := client.CreateMessage(context.Background(), *upstreamReq)
+	if err != nil {
+		log.Error("上游调用失败", "error", err)
+		return nil, fmt.Errorf("upstream error: %w", err)
+	}
+
+	msgResp, ok := rawResp.(anthropic.MessageResponse)
+	if !ok {
+		log.Error("非预期的上游响应类型", "type", fmt.Sprintf("%T", rawResp))
+		return nil, fmt.Errorf("unexpected upstream response type %T", rawResp)
+	}
+
+	coreResp, err := providerAdapter.ToCoreResponse(context.Background(), &msgResp)
+	if err != nil {
+		log.Error("上游响应转换失败", "error", err)
+		return nil, fmt.Errorf("response conversion error: %w", err)
+	}
+
+	log.Info("Anthropic Messages 完成",
+		"model", preferred.UpstreamModel,
+		"input", coreResp.Usage.InputTokens,
+		"output", coreResp.Usage.OutputTokens,
+		"duration", time.Since(start),
+	)
+	return coreResp, nil
+}
+
+func (s *Server) dispatchChatCore(
+	ctx context.Context,
+	upstreamAny interface{}, preferred provider.ProviderCandidate,
+	providerAdapter format.ProviderAdapter, log *slog.Logger, start time.Time,
+) (*format.CoreResponse, error) {
+	chatReq, ok := upstreamAny.(*chat.ChatRequest)
+	if !ok {
+		return nil, fmt.Errorf("unexpected chat upstream type")
+	}
+
+	chatClientRaw := s.activeChatClient(preferred.ProviderKey)
+	if chatClientRaw == nil {
+		return nil, fmt.Errorf("no chat client")
+	}
+	chatClient, ok := chatClientRaw.(*chat.Client)
+	if !ok {
+		return nil, fmt.Errorf("invalid chat client type")
+	}
+
+	rawResp, err := chatClient.CreateChat(context.Background(), chatReq)
+	if err != nil {
+		log.Error("Chat 上游调用失败", "error", err)
+		return nil, fmt.Errorf("upstream error: %w", err)
+	}
+
+	coreResp, err := providerAdapter.ToCoreResponse(context.Background(), rawResp)
+	if err != nil {
+		log.Error("Chat 响应转换失败", "error", err)
+		return nil, fmt.Errorf("response conversion error: %w", err)
+	}
+
+	log.Info("Chat Completions 完成",
+		"model", preferred.UpstreamModel,
+		"input", coreResp.Usage.InputTokens,
+		"output", coreResp.Usage.OutputTokens,
+		"duration", time.Since(start),
+	)
+	return coreResp, nil
+}
+
+// ============================================================================
+// Incoming protocol converters
+// ============================================================================
+
+func anthropicMessageToCore(req *anthropic.MessageRequest) *format.CoreRequest {
+	if req == nil {
+		return nil
+	}
+	coreReq := &format.CoreRequest{
+		Model:         req.Model,
+		MaxTokens:     req.MaxTokens,
+		Messages:      make([]format.CoreMessage, 0, len(req.Messages)),
+		System:        anthropicBlocksToCore(req.System),
+		Temperature:   req.Temperature,
+		TopP:          req.TopP,
+		TopK:          req.TopK,
+		StopSequences: req.StopSequences,
+		Stream:        req.Stream,
+		Metadata:      req.Metadata,
+	}
+	for _, msg := range req.Messages {
+		coreReq.Messages = append(coreReq.Messages, format.CoreMessage{
+			Role:    msg.Role,
+			Content: anthropicBlocksToCore(msg.Content),
+		})
+	}
+	if len(req.Tools) > 0 {
+		coreReq.Tools = make([]format.CoreTool, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			coreReq.Tools = append(coreReq.Tools, format.CoreTool{
+				Name:        t.Name,
+				Description: t.Description,
+				InputSchema: t.InputSchema,
+			})
+		}
+	}
+	if req.ToolChoice != nil {
+		coreReq.ToolChoice = &format.CoreToolChoice{
+			Mode: req.ToolChoice.Type,
+			Name: req.ToolChoice.Name,
+		}
+	}
+	return coreReq
+}
+
+func chatRequestToCore(req *chat.ChatRequest) *format.CoreRequest {
+	if req == nil {
+		return nil
+	}
+	coreReq := &format.CoreRequest{
+		Model:         req.Model,
+		MaxTokens:     req.MaxTokens,
+		Messages:      make([]format.CoreMessage, 0, len(req.Messages)),
+		Temperature:   req.Temperature,
+		TopP:          req.TopP,
+		StopSequences: req.Stop,
+		Stream:        req.Stream,
+	}
+	for _, msg := range req.Messages {
+		if msg.Role == "system" {
+			coreReq.System = append(coreReq.System, format.CoreContentBlock{
+				Type: "text",
+				Text: chatContentToString(msg.Content),
+			})
+			continue
+		}
+		coreMsg := format.CoreMessage{Role: msg.Role}
+		if coreMsg.Role == "tool" {
+			coreMsg.Role = "user"
+		}
+		// Tool call result (tool message).
+		if msg.ToolCallID != "" {
+			coreMsg.Content = []format.CoreContentBlock{{
+				Type:              "tool_result",
+				ToolUseID:         msg.ToolCallID,
+				ToolResultContent: []format.CoreContentBlock{{Type: "text", Text: chatContentToString(msg.Content)}},
+			}}
+			coreReq.Messages = append(coreReq.Messages, coreMsg)
+			continue
+		}
+		// Assistant message with tool calls.
+		if len(msg.ToolCalls) > 0 {
+			for _, tc := range msg.ToolCalls {
+				coreMsg.Content = append(coreMsg.Content, format.CoreContentBlock{
+					Type:      "tool_use",
+					ToolUseID: tc.ID,
+					ToolName:  tc.Function.Name,
+					ToolInput: json.RawMessage(tc.Function.Arguments),
+				})
+			}
+		}
+		// Text content (string or []ContentPart).
+		if text := chatContentToString(msg.Content); text != "" && len(coreMsg.Content) == 0 {
+			coreMsg.Content = []format.CoreContentBlock{{Type: "text", Text: text}}
+		}
+		// Multi-part content (images).
+		if parts, ok := msg.Content.([]interface{}); ok {
+			for _, p := range parts {
+				pm, ok := p.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				ptype, _ := pm["type"].(string)
+				switch ptype {
+				case "text":
+					if t, ok := pm["text"].(string); ok && len(coreMsg.Content) == 0 {
+						coreMsg.Content = append(coreMsg.Content, format.CoreContentBlock{Type: "text", Text: t})
+					}
+				case "image_url":
+					if iu, ok := pm["image_url"].(map[string]interface{}); ok {
+						if url, ok := iu["url"].(string); ok {
+							coreMsg.Content = append(coreMsg.Content, format.CoreContentBlock{
+								Type:      "image",
+								ImageData: url,
+							})
+						}
+					}
+				}
+			}
+		}
+		if len(coreMsg.Content) == 0 {
+			coreMsg.Content = []format.CoreContentBlock{{Type: "text", Text: chatContentToString(msg.Content)}}
+		}
+		coreReq.Messages = append(coreReq.Messages, coreMsg)
+	}
+
+	// Tools
+	if len(req.Tools) > 0 {
+		coreReq.Tools = make([]format.CoreTool, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			switch t.Type {
+			case "function":
+				coreReq.Tools = append(coreReq.Tools, format.CoreTool{
+					Name:        t.Function.Name,
+					Description: t.Function.Description,
+					InputSchema: t.Function.Parameters,
+				})
+			default:
+				coreReq.Tools = append(coreReq.Tools, format.CoreTool{Name: t.Type})
+			}
+		}
+	}
+
+	// ToolChoice
+	if len(req.ToolChoice) > 0 {
+		tc := format.CoreToolChoice{}
+		raw := string(req.ToolChoice)
+		if raw == `"none"` || raw == `"auto"` || raw == `"required"` {
+			tc.Mode = strings.Trim(raw, `"`)
+		} else {
+			var obj map[string]json.RawMessage
+			if json.Unmarshal(req.ToolChoice, &obj) == nil {
+				if fn, ok := obj["function"]; ok {
+					var fobj map[string]string
+					if json.Unmarshal(fn, &fobj) == nil {
+						tc.Mode = "any"
+						tc.Name = fobj["name"]
+					}
+				}
+			}
+		}
+		if tc.Mode != "" {
+			coreReq.ToolChoice = &tc
+		}
+	}
+
+	return coreReq
+}
+
+// ============================================================================
+// Outgoing protocol converters
+// ============================================================================
+
+// coreToAnthropicResponse converts a CoreResponse to Anthropic Messages API format.
+func coreToAnthropicResponse(coreResp *format.CoreResponse) anthropic.MessageResponse {
+	out := anthropic.MessageResponse{
+		ID:         coreResp.ID,
+		Model:      coreResp.Model,
+		StopReason: coreStatusToAnthropicStop(coreResp.Status),
+		Usage: anthropic.Usage{
+			InputTokens:  coreResp.Usage.InputTokens,
+			OutputTokens: coreResp.Usage.OutputTokens,
+		},
+	}
+	for _, msg := range coreResp.Messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		for _, block := range msg.Content {
+			switch block.Type {
+			case "text":
+				out.Content = append(out.Content, anthropic.ContentBlock{Type: "text", Text: block.Text})
+			case "reasoning":
+				out.Content = append(out.Content, anthropic.ContentBlock{
+					Type:      "thinking",
+					Thinking:  block.ReasoningText,
+					Signature: block.ReasoningSignature,
+				})
+			case "tool_use":
+				out.Content = append(out.Content, anthropic.ContentBlock{
+					Type:  "tool_use",
+					ID:    block.ToolUseID,
+					Name:  block.ToolName,
+					Input: block.ToolInput,
+				})
+			}
+		}
+	}
+	return out
+}
+
+func coreToChatResponse(coreResp *format.CoreResponse) chat.ChatResponse {
+	out := chat.ChatResponse{
+		ID:      coreResp.ID,
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   coreResp.Model,
+		Usage: &chat.Usage{
+			PromptTokens:     coreResp.Usage.InputTokens,
+			CompletionTokens: coreResp.Usage.OutputTokens,
+			TotalTokens:      coreResp.Usage.TotalTokens,
+		},
+	}
+	for _, msg := range coreResp.Messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		choice := chat.Choice{
+			Index:        len(out.Choices),
+			FinishReason: "stop",
+		}
+		choice.Message.Role = "assistant"
+
+		for _, block := range msg.Content {
+			switch block.Type {
+			case "text":
+				choice.Message.Content = strings.TrimSpace(chatContentToString(choice.Message.Content) + block.Text)
+			case "tool_use":
+				choice.Message.ToolCalls = append(choice.Message.ToolCalls, chat.ToolCall{
+					ID:   block.ToolUseID,
+					Type: "function",
+					Function: chat.ToolCallFunc{
+						Name:      block.ToolName,
+						Arguments: block.ToolInput,
+					},
+				})
+				choice.FinishReason = "tool_calls"
+			}
+		}
+
+		if choice.Message.Content == "" && len(choice.Message.ToolCalls) == 0 {
+			continue
+		}
+		out.Choices = append(out.Choices, choice)
+	}
+	return out
+}
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+func anthropicBlocksToCore(blocks []anthropic.ContentBlock) []format.CoreContentBlock {
+	out := make([]format.CoreContentBlock, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			out = append(out, format.CoreContentBlock{Type: "text", Text: b.Text})
+		case "image":
+			src := ""
+			mediaType := "image/png"
+			if b.Source != nil {
+				src = b.Source.Data
+				if b.Source.MediaType != "" {
+					mediaType = b.Source.MediaType
+				}
+			}
+			out = append(out, format.CoreContentBlock{Type: "image", ImageData: src, MediaType: mediaType})
+		case "tool_use":
+			out = append(out, format.CoreContentBlock{
+				Type:      "tool_use",
+				ToolUseID: b.ID,
+				ToolName:  b.Name,
+				ToolInput: b.Input,
+			})
+		case "tool_result":
+			out = append(out, format.CoreContentBlock{
+				Type:              "tool_result",
+				ToolUseID:         b.ToolUseID,
+				ToolResultContent: anthropicBlocksToCore(toolResultToBlocks(b.Content)),
+			})
+		}
+	}
+	return out
+}
+
+func toolResultToBlocks(content any) []anthropic.ContentBlock {
+	if content == nil {
+		return nil
+	}
+	switch v := content.(type) {
+	case string:
+		return []anthropic.ContentBlock{{Type: "text", Text: v}}
+	case []any:
+		var blocks []anthropic.ContentBlock
+		for _, item := range v {
+			if m, ok := item.(map[string]any); ok {
+				block := anthropic.ContentBlock{}
+				if t, _ := m["type"].(string); t != "" {
+					block.Type = t
+				}
+				if text, _ := m["text"].(string); text != "" {
+					block.Text = text
+				}
+				blocks = append(blocks, block)
+			}
+		}
+		return blocks
+	}
+	return nil
+}
+
+func chatContentToString(content any) string {
+	if content == nil {
+		return ""
+	}
+	switch v := content.(type) {
+	case string:
+		return v
+	case []interface{}:
+		var texts []string
+		for _, p := range v {
+			if pm, ok := p.(map[string]interface{}); ok {
+				if t, _ := pm["type"].(string); t == "text" {
+					if text, _ := pm["text"].(string); text != "" {
+						texts = append(texts, text)
+					}
+				}
+			}
+		}
+		return strings.Join(texts, "")
+	}
+	return ""
+}
+
+
+
+func coreStatusToAnthropicStop(status string) string {
+	switch status {
+	case "completed":
+		return "end_turn"
+	case "tool_use":
+		return "tool_use"
+	default:
+		return "end_turn"
+	}
+}
+
+func writeErrorJSON(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/service/server/server.go
+++ b/internal/service/server/server.go
@@ -151,6 +151,9 @@ func New(cfg Config) *Server {
 	}
 	s.mux.HandleFunc("/v1/responses", s.handleResponses)
 	s.mux.HandleFunc("/responses", s.handleResponses)
+	s.mux.HandleFunc("/v1/messages", s.handleAnthropicMessages)
+	s.mux.HandleFunc("/messages", s.handleAnthropicMessages)
+	s.mux.HandleFunc("/v1/chat/completions", s.handleChatCompletions)
 	s.mux.HandleFunc("/v1/models", s.handleModels)
 	s.mux.HandleFunc("/models", s.handleModels)
 	s.registerPluginRoutes()


### PR DESCRIPTION
## Summary

4 new features:

### web_fetch
- Proxy-side HTTP fetching tool, bypasses Codex sandbox HTTP restrictions
- Auto-detects URLs in tool responses

### circuit_breaker
- Monitors consecutive tool_use calls, prevents loop death
- Default: warn at 20, force-stop at 30

### response_store
- Caches upstream responses, bridges previous_response_id
- Configurable TTL (default 1h, 500 entries)

### context_manager + tool-call dedup
- Deduplicates sequential identical tool calls

All configurable via extensions in config.yml.