### PR TITLE
fix: handle nested function tool names

### DIFF
--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -310,6 +310,9 @@ func (a *AnthropicProviderAdapter) FromCoreRequest(ctx context.Context, req *for
 	if len(req.Tools) > 0 {
 		anthropicReq.Tools = make([]Tool, 0, len(req.Tools))
 		for _, t := range req.Tools {
+			if strings.TrimSpace(t.Name) == "" {
+				continue
+			}
 			schema := cleanSchema(t.InputSchema)
 			if schema == nil {
 				schema = map[string]any{"type": "object"}

--- a/internal/protocol/anthropic/adapter_test.go
+++ b/internal/protocol/anthropic/adapter_test.go
@@ -177,6 +177,34 @@ func TestFromCoreRequest_Tools(t *testing.T) {
 		t.Errorf("tool type = %q, want empty (Anthropic custom tools have no type field)", msgReq.Tools[0].Type)
 	}
 }
+
+func TestFromCoreRequest_FiltersEmptyToolNames(t *testing.T) {
+	adapter := newTestAdapter()
+
+	coreReq := &format.CoreRequest{
+		Model: "claude-sonnet-4",
+		Messages: []format.CoreMessage{
+			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "call a tool"}}},
+		},
+		Tools: []format.CoreTool{
+			{Name: "", Description: "invalid", InputSchema: map[string]any{"type": "object"}},
+			{Name: "get_weather", Description: "Get the weather", InputSchema: map[string]any{"type": "object"}},
+		},
+	}
+
+	result, err := adapter.FromCoreRequest(context.Background(), coreReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgReq := result.(*anthropic.MessageRequest)
+	if len(msgReq.Tools) != 1 {
+		t.Fatalf("got %d tools, want 1: %+v", len(msgReq.Tools), msgReq.Tools)
+	}
+	if msgReq.Tools[0].Name != "get_weather" {
+		t.Errorf("tool name = %q", msgReq.Tools[0].Name)
+	}
+}
+
 func TestFromCoreRequest_ImageMessage(t *testing.T) {
 	adapter := newTestAdapter()
 

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -34,14 +34,14 @@ type OpenAIAdapter struct {
 	hooks format.CorePluginHooks
 
 	disablePatchProxy func(string) bool
-	streamMu     sync.Mutex
-	streamEvents []StreamEvent
+	streamMu          sync.Mutex
+	streamEvents      []StreamEvent
 }
 
 // NewOpenAIAdapter creates a new OpenAIAdapter with the given config and hooks.
 func NewOpenAIAdapter(hooks format.CorePluginHooks) *OpenAIAdapter {
 	return &OpenAIAdapter{
-		hooks: hooks.WithDefaults(),
+		hooks:             hooks.WithDefaults(),
 		disablePatchProxy: hooks.DisablePatchProxy,
 	}
 }
@@ -1524,6 +1524,7 @@ func buildToolOutputItemStreaming(block *format.CoreContentBlock, extensions map
 // Custom tools are expanded using codex package helpers.
 // Namespace tools are recursively flattened.
 func convertToolWithNamespace(tool Tool, namespace string, disablePatchProxy func(string) bool) []format.CoreTool {
+	tool = normalizeToolFunction(tool)
 	name := namespacedToolName(namespace, tool.Name)
 	ext := make(map[string]any)
 
@@ -1639,6 +1640,9 @@ func flattenToolsWithNamespace(openaiTools []Tool, namespace string, disablePatc
 	seen := make(map[string]bool, len(result))
 	deduped := make([]format.CoreTool, 0, len(result))
 	for _, t := range result {
+		if strings.TrimSpace(t.Name) == "" {
+			continue
+		}
 		if seen[t.Name] {
 			continue
 		}
@@ -1647,6 +1651,27 @@ func flattenToolsWithNamespace(openaiTools []Tool, namespace string, disablePatc
 	}
 	result = deduped
 	return result
+}
+
+// normalizeToolFunction accepts Chat Completions-style function tools inside
+// Responses requests, where name/schema live under tool.function.
+func normalizeToolFunction(tool Tool) Tool {
+	if tool.Function == nil {
+		return tool
+	}
+	if strings.TrimSpace(tool.Name) == "" {
+		tool.Name = tool.Function.Name
+	}
+	if strings.TrimSpace(tool.Description) == "" {
+		tool.Description = tool.Function.Description
+	}
+	if tool.Parameters == nil {
+		tool.Parameters = tool.Function.Parameters
+	}
+	if tool.Strict == nil {
+		tool.Strict = tool.Function.Strict
+	}
+	return tool
 }
 
 // namespacedToolName joins namespace and name.

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -89,6 +89,69 @@ func TestToCoreRequest_AppendsInjectedTools(t *testing.T) {
 	}
 }
 
+func TestToCoreRequest_ChatCompletionsFunctionTool(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+
+	strict := true
+	req := &openai.ResponsesRequest{
+		Model: "gpt-4o",
+		Input: json.RawMessage(`"call a tool"`),
+		Tools: []openai.Tool{{
+			Type: "function",
+			Function: &openai.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get the weather",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"city": map[string]any{"type": "string"},
+					},
+				},
+				Strict: &strict,
+			},
+		}},
+	}
+
+	result, err := adapter.ToCoreRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Tools) != 1 {
+		t.Fatalf("got %d tools, want 1: %+v", len(result.Tools), result.Tools)
+	}
+	if result.Tools[0].Name != "get_weather" {
+		t.Fatalf("tool name = %q, want get_weather", result.Tools[0].Name)
+	}
+	if result.Tools[0].Description != "Get the weather" {
+		t.Fatalf("tool description = %q", result.Tools[0].Description)
+	}
+	if result.Tools[0].InputSchema["type"] != "object" {
+		t.Fatalf("tool schema = %+v", result.Tools[0].InputSchema)
+	}
+}
+
+func TestToCoreRequest_FiltersEmptyToolNames(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+
+	req := &openai.ResponsesRequest{
+		Model: "gpt-4o",
+		Input: json.RawMessage(`"call a tool"`),
+		Tools: []openai.Tool{{
+			Type:        "function",
+			Description: "missing name",
+			Parameters:  map[string]any{"type": "object"},
+		}},
+	}
+
+	result, err := adapter.ToCoreRequest(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Tools) != 0 {
+		t.Fatalf("got tools %+v, want none", result.Tools)
+	}
+}
+
 func TestToCoreRequest_FunctionCallOutputImage(t *testing.T) {
 	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
 
@@ -294,8 +357,8 @@ func TestToCoreRequest_BatchesCustomToolCallsAndOutputsIntoSingleRound(t *testin
 	for i, want := range []struct {
 		assistantTextIdx int
 		msgIdx           int
-		callID  string
-		outcome string
+		callID           string
+		outcome          string
 	}{
 		{0, 1, "call_a", "ok a"},
 		{3, 4, "call_b", "ok b"},

--- a/internal/protocol/openai/types.go
+++ b/internal/protocol/openai/types.go
@@ -47,6 +47,7 @@ type Tool struct {
 	Description        string         `json:"description,omitempty"`
 	Parameters         map[string]any `json:"parameters,omitempty"`
 	Strict             *bool          `json:"strict,omitempty"`
+	Function           *ToolFunction  `json:"function,omitempty"`
 	Format             map[string]any `json:"format,omitempty"`
 	Tools              []Tool         `json:"tools,omitempty"`
 	ExternalWebAccess  *bool          `json:"external_web_access,omitempty"`
@@ -54,6 +55,14 @@ type Tool struct {
 	MaxNumResults      int            `json:"max_num_results,omitempty"`
 	DisplayWidth       int            `json:"display_width,omitempty"`
 	DisplayHeight      int            `json:"display_height,omitempty"`
+}
+
+// ToolFunction represents a Chat Completions-style nested function tool payload.
+type ToolFunction struct {
+	Name        string         `json:"name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+	Strict      *bool          `json:"strict,omitempty"`
 }
 
 // ============================================================================
@@ -116,10 +125,10 @@ type ContentPart struct {
 
 // Usage represents token usage statistics.
 type Usage struct {
-	InputTokens        int                `json:"input_tokens,omitempty"`
-	OutputTokens       int                `json:"output_tokens,omitempty"`
-	TotalTokens        int                `json:"total_tokens"`
-	InputTokensDetails InputTokensDetails `json:"input_tokens_details,omitempty"`
+	InputTokens         int                 `json:"input_tokens,omitempty"`
+	OutputTokens        int                 `json:"output_tokens,omitempty"`
+	TotalTokens         int                 `json:"total_tokens"`
+	InputTokensDetails  InputTokensDetails  `json:"input_tokens_details,omitempty"`
 	OutputTokensDetails OutputTokensDetails `json:"output_tokens_details,omitempty"`
 }
 


### PR DESCRIPTION
## 背景

在 Codex -> sub2api -> Moon Bridge -> DeepSeek 的调用链路中，DeepSeek 返回 400：

```text
Invalid 'tools[73].function.name': empty string. Expected a string with minimum length 1
```

排查发现，Moon Bridge 在处理 OpenAI Responses 请求里的 tools 时，只读取了 Responses 风格的顶层字段：
```json
{
  "type": "function",
  "name": "get_weather",
  "parameters": {}
}
```

但实际链路里可能会收到 Chat Completions 风格的嵌套 function 工具定义：
```json
{
  "type": "function",
  "function": {
    "name": "get_weather",
    "description": "Get the weather",
    "parameters": {}
  }
}
```

由于原 DTO 没有 function 字段，转换到 CoreTool 时 Name 会变成空字符串，随后 Anthropic adapter 会把这个空工具名继续转发给 DeepSeek，最终触发上游 400。

## 修改内容
* 为 OpenAI Tool DTO 增加 function 嵌套结构支持。
* 在 OpenAI adapter 转换工具前，兼容 Chat Completions 风格的 tool.function：
  * function.name -> tool.Name
  * function.description -> tool.Description
  * function.parameters -> tool.Parameters
  * function.strict -> tool.Strict
* 在 OpenAI tool flatten/dedup 阶段过滤空名称工具，避免非法 CoreTool 进入后续流程。
* 在 Anthropic provider adapter 发起上游请求前再次过滤空名称工具，作为防御性兜底。
* 补充单元测试覆盖：
  * 嵌套 function.name 能正确转换为 CoreTool name。
  * 空名称工具会在 OpenAI adapter 阶段被过滤。
  * Anthropic adapter 不会发送空名称工具给上游。


## 影响范围
该修改主要提升 OpenAI Responses 入站兼容性，允许 Moon Bridge 接收 Chat Completions 风格的嵌套 function tool 定义。

对原有顶层 name / description / parameters 的 Responses 风格工具定义保持兼容；如果工具名称为空，会被过滤，不再传递给 Anthropic/DeepSeek 上游。