### PR TITLE
fix(protocol): skip tools with empty names to avoid upstream rejection

### DIFF
--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -310,6 +310,9 @@ func (a *AnthropicProviderAdapter) FromCoreRequest(ctx context.Context, req *for
 	if len(req.Tools) > 0 {
 		anthropicReq.Tools = make([]Tool, 0, len(req.Tools))
 		for _, t := range req.Tools {
+			if t.Name == "" {
+				continue // skip tools with empty names — upstream providers reject them
+			}
 			schema := cleanSchema(t.InputSchema)
 			if schema == nil {
 				schema = map[string]any{"type": "object"}

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1630,6 +1630,11 @@ func convertToolWithNamespace(tool Tool, namespace string, disablePatchProxy fun
 func flattenToolsWithNamespace(openaiTools []Tool, namespace string, disablePatchProxy func(string) bool) []format.CoreTool {
 	var result []format.CoreTool
 	for _, t := range openaiTools {
+		// Skip tools with empty function names — upstream providers
+		// (e.g. DeepSeek) reject them with a 400/validation error.
+		if t.Name == "" {
+			continue
+		}
 		converted := convertToolWithNamespace(t, namespace, disablePatchProxy)
 		result = append(result, converted...)
 	}


### PR DESCRIPTION
DeepSeek and other providers reject tools with empty names (400/validation). Add guard in both Anthropic and OpenAI adapters to skip such tools silently.