### PR TITLE
Fix MiniMax chat tool compatibility

### DIFF
--- a/internal/protocol/chat/adapter.go
+++ b/internal/protocol/chat/adapter.go
@@ -33,6 +33,20 @@ type ChatProviderAdapter struct {
 	streamEvents []ChatStreamChunk
 }
 
+type chatStreamChoiceState struct {
+	started          bool
+	blockIndex       int          // monotonically increasing content block index
+	textStarted      bool         // whether a text block is active
+	hasReasoning     bool         // whether a reasoning block is active
+	reasonIndex      int          // block index for the reasoning content block
+	toolCallIdx      int          // next tool call content block index
+	callStarted      map[int]bool // tracks which tool call indices have been started
+	toolCallSlot     map[int]int  // tool_call delta index -> content block index
+	reasoningContent string       // accumulated reasoning content for the current reasoning block
+	thinkActive      bool         // whether a <think>...</think> text tag is open
+	thinkBuffer      string       // buffered text for split tag detection
+}
+
 // NewChatProviderAdapter creates a new ChatProviderAdapter.
 //
 // client is the HTTP client for Chat API calls. May be nil if the adapter
@@ -123,7 +137,7 @@ func (a *ChatProviderAdapter) FromCoreRequest(ctx context.Context, req *format.C
 				Function: FunctionDef{
 					Name:        t.Name,
 					Description: t.Description,
-					Parameters:  t.InputSchema,
+					Parameters:  defaultToolParameters(t.InputSchema),
 				},
 			})
 		}
@@ -176,6 +190,7 @@ func (a *ChatProviderAdapter) ToCoreResponse(ctx context.Context, resp any) (*fo
 
 	coreResp := &format.CoreResponse{
 		ID:         chatResp.ID,
+		Model:      chatResp.Model,
 		Status:     status,
 		Messages:   messages,
 		StopReason: stopReason,
@@ -241,17 +256,7 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 		defer close(events)
 
 		// Per-choice state for streaming.
-		type choiceState struct {
-			started          bool
-			blockIndex       int          // monotonically increasing content block index
-			hasReasoning     bool         // whether a reasoning block is active
-			reasonIndex      int          // block index for the reasoning content block
-			toolCallIdx      int          // next tool call content block index (starts after text block)
-			callStarted      map[int]bool // tracks which tool call indices have been started
-			toolCallSlot     map[int]int  // tool_call delta index -> content block index
-			reasoningContent string       // accumulated reasoning content for the current reasoning block
-		}
-		choices := make(map[int]*choiceState)
+		choices := make(map[int]*chatStreamChoiceState)
 		var seqNum int64
 		var finalUsage *format.CoreUsage
 		var lastModel string
@@ -301,69 +306,67 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 				for _, sc := range chunk.Choices {
 					state := choices[sc.Index]
 					if state == nil {
-						state = &choiceState{blockIndex: sc.Index * 2}
+						state = &chatStreamChoiceState{blockIndex: sc.Index * 2}
 						choices[sc.Index] = state
 					}
 
 					ci := sc.Index
 
-					// Emit content_block.started on first appearance with role.
+					// Mark the assistant turn on first appearance with role. The
+					// concrete block is started lazily when text/reasoning/tool
+					// content arrives, which avoids emitting empty text items for
+					// tool-only or reasoning-only turns.
 					if !state.started && sc.Delta.Role == "assistant" {
 						state.started = true
-						blockType := "text"
-						if sc.Delta.ReasoningContent != "" {
-							blockType = "reasoning"
-							state.hasReasoning = true
-							state.reasonIndex = state.blockIndex
+					}
+
+					startText := func() {
+						if state.textStarted {
+							return
+						}
+						state.textStarted = true
+						emit(format.CoreStreamEvent{
+							Type:         format.CoreContentBlockStarted,
+							Index:        state.blockIndex,
+							ChoiceIndex:  &ci,
+							ContentBlock: &format.CoreContentBlock{Type: "text"},
+						})
+					}
+					closeText := func(stopReason string) {
+						if !state.textStarted {
+							return
 						}
 						emit(format.CoreStreamEvent{
-							Type:        format.CoreContentBlockStarted,
+							Type:        format.CoreContentBlockDone,
 							Index:       state.blockIndex,
+							StopReason:  stopReason,
 							ChoiceIndex: &ci,
-							ContentBlock: &format.CoreContentBlock{
-								Type: blockType,
-							},
 						})
+						state.textStarted = false
+						state.blockIndex++
 					}
-
-					// Emit text delta.
-					// Emit reasoning content as text delta.
-					// Note: reasoning_content may appear AFTER the text block has started
-					// (DeepSeek first sends role=assistant, then reasoning_content in subsequent chunks).
-					if sc.Delta.ReasoningContent != "" {
-						if !state.hasReasoning {
-							// Transition from premature text block to reasoning block.
-							state.hasReasoning = true
-							state.reasonIndex = state.blockIndex + 1
-							state.blockIndex = state.reasonIndex
-							emit(format.CoreStreamEvent{
-								Type:        format.CoreContentBlockDone,
-								Index:       state.blockIndex,
-								ChoiceIndex: &ci,
-							})
-							emit(format.CoreStreamEvent{
-								Type:        format.CoreContentBlockStarted,
-								Index:       state.reasonIndex,
-								ChoiceIndex: &ci,
-								ContentBlock: &format.CoreContentBlock{
-									Type: "reasoning",
-								},
-							})
+					startReasoning := func() {
+						if state.hasReasoning {
+							return
 						}
-						state.reasoningContent += sc.Delta.ReasoningContent
+						closeText("")
+						state.hasReasoning = true
+						state.reasonIndex = state.blockIndex
 						emit(format.CoreStreamEvent{
-							Type:        format.CoreTextDelta,
-							Index:       state.reasonIndex,
-							Delta:       sc.Delta.ReasoningContent,
-							ChoiceIndex: &ci,
+							Type:         format.CoreContentBlockStarted,
+							Index:        state.reasonIndex,
+							ChoiceIndex:  &ci,
+							ContentBlock: &format.CoreContentBlock{Type: "reasoning"},
 						})
 					}
-
-					// Transition from reasoning block to text block.
-					if sc.Delta.Content != "" && state.hasReasoning {
+					closeReasoning := func(stopReason string) {
+						if !state.hasReasoning {
+							return
+						}
 						emit(format.CoreStreamEvent{
 							Type:        format.CoreContentBlockDone,
 							Index:       state.reasonIndex,
+							StopReason:  stopReason,
 							ChoiceIndex: &ci,
 							ContentBlock: &format.CoreContentBlock{
 								Type:          "reasoning",
@@ -373,22 +376,46 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 						state.reasoningContent = ""
 						state.hasReasoning = false
 						state.blockIndex = state.reasonIndex + 1
-						emit(format.CoreStreamEvent{
-							Type:        format.CoreContentBlockStarted,
-							Index:       state.blockIndex,
-							ChoiceIndex: &ci,
-							ContentBlock: &format.CoreContentBlock{
-								Type: "text",
-							},
-						})
 					}
-					if sc.Delta.Content != "" {
+					emitTextDelta := func(delta string) {
+						if delta == "" {
+							return
+						}
+						startText()
 						emit(format.CoreStreamEvent{
 							Type:        format.CoreTextDelta,
 							Index:       state.blockIndex,
-							Delta:       sc.Delta.Content,
+							Delta:       delta,
 							ChoiceIndex: &ci,
 						})
+					}
+					emitReasoningDelta := func(delta string) {
+						if delta == "" {
+							return
+						}
+						startReasoning()
+						state.reasoningContent += delta
+						emit(format.CoreStreamEvent{
+							Type:        format.CoreTextDelta,
+							Index:       state.reasonIndex,
+							Delta:       delta,
+							ChoiceIndex: &ci,
+						})
+					}
+
+					// Emit provider-native reasoning_content as reasoning deltas.
+					// Note: reasoning_content may appear AFTER the text block has started
+					// (DeepSeek first sends role=assistant, then reasoning_content in subsequent chunks).
+					if sc.Delta.ReasoningContent != "" {
+						emitReasoningDelta(sc.Delta.ReasoningContent)
+					}
+
+					// Transition from reasoning block to text block.
+					if sc.Delta.Content != "" && state.hasReasoning && !state.thinkActive && state.thinkBuffer == "" {
+						closeReasoning("")
+					}
+					if sc.Delta.Content != "" {
+						state.consumeThinkTaggedDelta(sc.Delta.Content, emitTextDelta, emitReasoningDelta, closeReasoning)
 					}
 
 					// Emit tool call content blocks and args deltas.
@@ -399,8 +426,12 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 						}
 						if state.callStarted == nil {
 							state.callStarted = make(map[int]bool)
-							// Start tool call indices after the current text/reasoning block.
-							state.toolCallIdx = state.blockIndex + 1
+							// Start tool call indices after any active text/reasoning block.
+							if state.textStarted || state.hasReasoning {
+								state.toolCallIdx = state.blockIndex + 1
+							} else {
+								state.toolCallIdx = state.blockIndex
+							}
 						}
 						if state.toolCallSlot == nil {
 							state.toolCallSlot = make(map[int]int)
@@ -456,28 +487,14 @@ func (a *ChatProviderAdapter) ToCoreStream(ctx context.Context, src any) (<-chan
 					// Emit content_block.done when finish_reason is set.
 					if sc.FinishReason != "" {
 						stopReason := a.mapFinishReason(sc.FinishReason)
+						state.flushThinkTaggedContent(emitTextDelta, emitReasoningDelta, closeReasoning)
 						if state.hasReasoning {
-							emit(format.CoreStreamEvent{
-								Type:        format.CoreContentBlockDone,
-								Index:       state.blockIndex,
-								StopReason:  stopReason,
-								ChoiceIndex: &ci,
-								ContentBlock: &format.CoreContentBlock{
-									Type:          "reasoning",
-									ReasoningText: state.reasoningContent,
-								},
-							})
-							state.reasoningContent = ""
-						} else {
-							emit(format.CoreStreamEvent{
-								Type:        format.CoreContentBlockDone,
-								Index:       state.blockIndex,
-								StopReason:  stopReason,
-								ChoiceIndex: &ci,
-							})
+							closeReasoning(stopReason)
+						} else if state.textStarted {
+							closeText(stopReason)
 						}
 						// Complete tool call blocks.
-						for idx := state.blockIndex + 1; idx < state.toolCallIdx; idx++ {
+						for idx := 0; idx < state.toolCallIdx; idx++ {
 							if !state.callStarted[idx] {
 								continue
 							}
@@ -805,14 +822,17 @@ func (a *ChatProviderAdapter) fromChatContent(content any) []format.CoreContentB
 		if v == "" {
 			return nil
 		}
-		return []format.CoreContentBlock{
-			{Type: "text", Text: v},
-		}
+		return splitThinkTaggedText(v)
 	case []any:
 		blocks := make([]format.CoreContentBlock, 0, len(v))
 		for _, item := range v {
 			if m, ok := item.(map[string]any); ok {
-				blocks = append(blocks, a.fromContentPartMap(m))
+				block := a.fromContentPartMap(m)
+				if block.Type == "text" && block.Text != "" {
+					blocks = append(blocks, splitThinkTaggedText(block.Text)...)
+				} else {
+					blocks = append(blocks, block)
+				}
 			}
 		}
 		return blocks
@@ -877,4 +897,145 @@ func unquoteArguments(raw json.RawMessage) json.RawMessage {
 		return raw
 	}
 	return json.RawMessage(s)
+}
+
+func defaultToolParameters(schema map[string]any) map[string]any {
+	if len(schema) > 0 {
+		return schema
+	}
+	return map[string]any{"type": "object"}
+}
+
+const (
+	thinkOpenTag  = "<think>"
+	thinkCloseTag = "</think>"
+)
+
+func splitThinkTaggedText(text string) []format.CoreContentBlock {
+	var blocks []format.CoreContentBlock
+	remaining := text
+	for remaining != "" {
+		open := indexFold(remaining, thinkOpenTag)
+		if open < 0 {
+			appendTextBlock(&blocks, remaining)
+			break
+		}
+		appendTextBlock(&blocks, remaining[:open])
+		remaining = remaining[open+len(thinkOpenTag):]
+		close := indexFold(remaining, thinkCloseTag)
+		if close < 0 {
+			appendReasoningBlock(&blocks, remaining)
+			break
+		}
+		appendReasoningBlock(&blocks, remaining[:close])
+		remaining = trimOneLeadingLineBreak(remaining[close+len(thinkCloseTag):])
+	}
+	return blocks
+}
+
+func appendTextBlock(blocks *[]format.CoreContentBlock, text string) {
+	if text == "" {
+		return
+	}
+	*blocks = append(*blocks, format.CoreContentBlock{Type: "text", Text: text})
+}
+
+func appendReasoningBlock(blocks *[]format.CoreContentBlock, text string) {
+	if text == "" {
+		return
+	}
+	*blocks = append(*blocks, format.CoreContentBlock{
+		Type:          "reasoning",
+		ReasoningText: text,
+	})
+}
+
+func (state *chatStreamChoiceState) consumeThinkTaggedDelta(
+	delta string,
+	emitText func(string),
+	emitReasoning func(string),
+	closeReasoning func(string),
+) {
+	state.thinkBuffer += delta
+	for state.thinkBuffer != "" {
+		if state.thinkActive {
+			close := indexFold(state.thinkBuffer, thinkCloseTag)
+			if close >= 0 {
+				emitReasoning(state.thinkBuffer[:close])
+				state.thinkBuffer = trimOneLeadingLineBreak(state.thinkBuffer[close+len(thinkCloseTag):])
+				state.thinkActive = false
+				closeReasoning("")
+				continue
+			}
+			emit, keep := splitSafeForTag(state.thinkBuffer, thinkCloseTag)
+			emitReasoning(emit)
+			state.thinkBuffer = keep
+			return
+		}
+
+		open := indexFold(state.thinkBuffer, thinkOpenTag)
+		if open >= 0 {
+			emitText(state.thinkBuffer[:open])
+			state.thinkBuffer = state.thinkBuffer[open+len(thinkOpenTag):]
+			state.thinkActive = true
+			continue
+		}
+		emit, keep := splitSafeForTag(state.thinkBuffer, thinkOpenTag)
+		emitText(emit)
+		state.thinkBuffer = keep
+		return
+	}
+}
+
+func (state *chatStreamChoiceState) flushThinkTaggedContent(
+	emitText func(string),
+	emitReasoning func(string),
+	closeReasoning func(string),
+) {
+	if state.thinkBuffer == "" {
+		return
+	}
+	if state.thinkActive {
+		emitReasoning(state.thinkBuffer)
+		state.thinkBuffer = ""
+		state.thinkActive = false
+		closeReasoning("")
+		return
+	}
+	emitText(state.thinkBuffer)
+	state.thinkBuffer = ""
+}
+
+func splitSafeForTag(text string, tag string) (emit string, keep string) {
+	keepLen := longestTagPrefixSuffix(text, tag)
+	if keepLen == 0 {
+		return text, ""
+	}
+	return text[:len(text)-keepLen], text[len(text)-keepLen:]
+}
+
+func longestTagPrefixSuffix(text string, tag string) int {
+	maxLen := min(len(text), len(tag)-1)
+	lowerText := strings.ToLower(text)
+	lowerTag := strings.ToLower(tag)
+	for n := maxLen; n > 0; n-- {
+		if strings.HasSuffix(lowerText, lowerTag[:n]) {
+			return n
+		}
+	}
+	return 0
+}
+
+func indexFold(s string, substr string) int {
+	return strings.Index(strings.ToLower(s), strings.ToLower(substr))
+}
+
+func trimOneLeadingLineBreak(s string) string {
+	if strings.HasPrefix(s, "\r\n") {
+		return s[2:]
+	}
+	if strings.HasPrefix(s, "\n") || strings.HasPrefix(s, "\r") {
+		return s[1:]
+	}
+	return s
 }

--- a/internal/protocol/chat/chat_test.go
+++ b/internal/protocol/chat/chat_test.go
@@ -1127,6 +1127,25 @@ func TestFromCoreRequest_Tools(t *testing.T) {
 	}
 }
 
+func TestFromCoreRequest_ToolsDefaultEmptyParameters(t *testing.T) {
+	adapter := newTestAdapter()
+	result, err := adapter.FromCoreRequest(context.Background(), &format.CoreRequest{
+		Model: "gpt-4o",
+		Messages: []format.CoreMessage{
+			{Role: "user", Content: []format.CoreContentBlock{{Type: "text", Text: "call tool"}}},
+		},
+		Tools: []format.CoreTool{{Name: "ping"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chatReq := result.(*chat.ChatRequest)
+	params := chatReq.Tools[0].Function.Parameters
+	if got := params["type"]; got != "object" {
+		t.Fatalf("default parameters type = %v, want object; params=%+v", got, params)
+	}
+}
+
 func TestFromCoreRequest_ToolChoice(t *testing.T) {
 	adapter := newTestAdapter()
 	tests := []struct {
@@ -1505,6 +1524,43 @@ func TestToCoreResponse_ToolCalls(t *testing.T) {
 	}
 }
 
+func TestToCoreResponse_SplitsThinkTaggedText(t *testing.T) {
+	adapter := newTestAdapter()
+	chatResp := &chat.ChatResponse{
+		ID:    "chatcmpl-think",
+		Model: "MiniMax-M3",
+		Choices: []chat.Choice{{
+			Index: 0,
+			Message: chat.ChatMessage{
+				Role:    "assistant",
+				Content: "<think>\nplan privately\n</think>\npong",
+			},
+			FinishReason: "stop",
+		}},
+	}
+
+	result, err := adapter.ToCoreResponse(context.Background(), chatResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Model != "MiniMax-M3" {
+		t.Fatalf("Model = %q, want MiniMax-M3", result.Model)
+	}
+	if len(result.Messages) != 1 {
+		t.Fatalf("Messages: got %d, want 1", len(result.Messages))
+	}
+	content := result.Messages[0].Content
+	if len(content) != 2 {
+		t.Fatalf("content len = %d, want 2: %+v", len(content), content)
+	}
+	if content[0].Type != "reasoning" || content[0].ReasoningText != "\nplan privately\n" {
+		t.Fatalf("reasoning block = %+v", content[0])
+	}
+	if content[1].Type != "text" || content[1].Text != "pong" {
+		t.Fatalf("text block = %+v", content[1])
+	}
+}
+
 func TestToCoreResponse_FinishReasonVariants(t *testing.T) {
 	adapter := newTestAdapter()
 	tests := []struct {
@@ -1746,6 +1802,83 @@ func TestToCoreStream_ToolCallArgsDelta(t *testing.T) {
 	}
 	if toolCallDeltaCount != 1 {
 		t.Errorf("tool_call_args.delta count = %d, want 1", toolCallDeltaCount)
+	}
+}
+
+func TestToCoreStream_SplitsThinkTaggedTextAcrossChunks(t *testing.T) {
+	adapter := newTestAdapter()
+	src := make(chan chat.ChatStreamChunk, 6)
+	src <- chat.ChatStreamChunk{
+		Model: "MiniMax-M3",
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{Role: "assistant", Content: "<thi"},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{Content: "nk>\nplan"},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{Content: "\n</thi"},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{
+			Index: 0,
+			Delta: chat.Delta{Content: "nk>\npong"},
+		}},
+	}
+	src <- chat.ChatStreamChunk{
+		Choices: []chat.StreamChoice{{Index: 0, FinishReason: "stop"}},
+	}
+	close(src)
+
+	events, err := adapter.ToCoreStream(context.Background(), (<-chan chat.ChatStreamChunk)(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var reasoningStarted bool
+	var reasoningDone *format.CoreStreamEvent
+	var text string
+	var completed *format.CoreStreamEvent
+	for e := range events {
+		if e.Type == format.CoreContentBlockStarted && e.ContentBlock != nil && e.ContentBlock.Type == "reasoning" {
+			reasoningStarted = true
+		}
+		if e.Type == format.CoreTextDelta {
+			if strings.Contains(e.Delta, "<think") || strings.Contains(e.Delta, "</think") {
+				t.Fatalf("think tag leaked in text delta: %+v", e)
+			}
+			if e.Index == 1 {
+				text += e.Delta
+			}
+		}
+		if e.Type == format.CoreContentBlockDone && e.ContentBlock != nil && e.ContentBlock.Type == "reasoning" {
+			ev := e
+			reasoningDone = &ev
+		}
+		if e.Type == format.CoreEventCompleted {
+			ev := e
+			completed = &ev
+		}
+	}
+	if !reasoningStarted {
+		t.Fatal("reasoning block was not started")
+	}
+	if reasoningDone == nil || reasoningDone.ContentBlock.ReasoningText != "\nplan\n" {
+		t.Fatalf("reasoning done = %+v", reasoningDone)
+	}
+	if text != "pong" {
+		t.Fatalf("text = %q, want pong", text)
+	}
+	if completed == nil || completed.Model != "MiniMax-M3" {
+		t.Fatalf("completed = %+v, want model MiniMax-M3", completed)
 	}
 }
 

--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -34,14 +34,14 @@ type OpenAIAdapter struct {
 	hooks format.CorePluginHooks
 
 	disablePatchProxy func(string) bool
-	streamMu     sync.Mutex
-	streamEvents []StreamEvent
+	streamMu          sync.Mutex
+	streamEvents      []StreamEvent
 }
 
 // NewOpenAIAdapter creates a new OpenAIAdapter with the given config and hooks.
 func NewOpenAIAdapter(hooks format.CorePluginHooks) *OpenAIAdapter {
 	return &OpenAIAdapter{
-		hooks: hooks.WithDefaults(),
+		hooks:             hooks.WithDefaults(),
 		disablePatchProxy: hooks.DisablePatchProxy,
 	}
 }
@@ -676,6 +676,9 @@ func (a *OpenAIAdapter) streamLoop(ctx context.Context, coreReq *format.CoreRequ
 		// Lifecycle: completed
 		// ==================================================================
 		case format.CoreEventCompleted:
+			if event.Model != "" {
+				response.Model = event.Model
+			}
 			// Build output_text from message items, same as FromCoreResponse.
 			var texts []string
 			for _, item := range response.Output {

--- a/internal/protocol/openai/adapter_test.go
+++ b/internal/protocol/openai/adapter_test.go
@@ -294,8 +294,8 @@ func TestToCoreRequest_BatchesCustomToolCallsAndOutputsIntoSingleRound(t *testin
 	for i, want := range []struct {
 		assistantTextIdx int
 		msgIdx           int
-		callID  string
-		outcome string
+		callID           string
+		outcome          string
 	}{
 		{0, 1, "call_a", "ok a"},
 		{3, 4, "call_b", "ok b"},
@@ -363,5 +363,32 @@ func TestFromCoreStream_NoDuplicateDoneForToolUse(t *testing.T) {
 	}
 	if itemDone != 1 {
 		t.Fatalf("output_item.done (tool) count=%d, want 1", itemDone)
+	}
+}
+
+func TestFromCoreStream_CompletedCarriesModel(t *testing.T) {
+	adapter := openai.NewOpenAIAdapter(format.CorePluginHooks{})
+	coreReq := &format.CoreRequest{Model: "minimax-test"}
+	evCh := make(chan format.CoreStreamEvent, 1)
+	evCh <- format.CoreStreamEvent{Type: format.CoreEventCompleted, Status: "completed", Model: "MiniMax-M3"}
+	close(evCh)
+
+	streamAny, err := adapter.FromCoreStream(context.Background(), coreReq, evCh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := streamAny.(<-chan openai.StreamEvent)
+	var completed *openai.ResponseLifecycleEvent
+	for ev := range stream {
+		if ev.Event == "response.completed" {
+			data := ev.Data.(openai.ResponseLifecycleEvent)
+			completed = &data
+		}
+	}
+	if completed == nil {
+		t.Fatal("response.completed not found")
+	}
+	if completed.Response.Model != "MiniMax-M3" {
+		t.Fatalf("completed model = %q, want MiniMax-M3", completed.Response.Model)
 	}
 }

--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -2143,7 +2143,6 @@ func normalizeAnthropicRequest(upstream any) (anthropic.MessageRequest, error) {
 	}
 }
 
-
 // injectCoreWebSearch replaces web_search tools in coreReq.Tools with injected
 // tavily_search/firecrawl_fetch tools when the resolved web search mode is "injected".
 // Returns true if injection was applied.

--- a/internal/service/server/dispatch.go
+++ b/internal/service/server/dispatch.go
@@ -368,6 +368,7 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 
 		upstreamRequest := responsesRequest
 		upstreamRequest.Model = candidate.UpstreamModel
+		upstreamRequest.Tools = expandResponseNamespaceTools(upstreamRequest.Tools)
 		actualModel = candidate.UpstreamModel
 
 		// Inject web_search tool if enabled for this model.
@@ -487,14 +488,28 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 		shouldCapture := traceEnabled || usageEnabled
 
 		var captured bytes.Buffer
-		target := io.Writer(writer)
+		var monitor *openAIStreamMonitor
+		writers := []io.Writer{writer}
 		if shouldCapture {
-			target = io.MultiWriter(writer, &captured)
+			writers = append(writers, &captured)
 		}
-		if _, err := io.Copy(target, upstreamResp.Body); err != nil {
+		if responsesRequest.Stream {
+			monitor = &openAIStreamMonitor{}
+			writers = append(writers, monitor)
+		}
+		target := io.MultiWriter(writers...)
+		if _, err := copyUpstreamResponseBody(target, upstreamResp.Body, writer); err != nil {
 			hookErr = "copy upstream response"
 			log.Error("复制上游响应失败", "error", err)
 			return
+		}
+		if monitor != nil {
+			monitor.Finish()
+			if monitor.Terminal == "response.completed" {
+				log.Info("OpenAI Responses 直通流结束", "status", upstreamResp.StatusCode, "content_type", upstreamResp.Header.Get("Content-Type"), "terminal", monitor.Terminal, "bytes", monitor.Bytes)
+			} else {
+				log.Warn("OpenAI Responses 直通流未以 completed 结束", "status", upstreamResp.StatusCode, "content_type", upstreamResp.Header.Get("Content-Type"), "terminal", monitor.Terminal, "error_type", monitor.ErrorType, "error_code", monitor.ErrorCode, "error_message", monitor.ErrorMessage, "bytes", monitor.Bytes, "body_preview", monitor.Preview())
+			}
 		}
 
 		if traceEnabled {
@@ -550,5 +565,177 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 	)
 	if hookErr == "" {
 		hookErr = fmt.Sprintf("all %d candidates failed: %v", len(openaiCandidates), lastErr)
+	}
+}
+
+func expandResponseNamespaceTools(tools []openai.Tool) []openai.Tool {
+	if len(tools) == 0 {
+		return tools
+	}
+	expanded := make([]openai.Tool, 0, len(tools))
+	for _, tool := range tools {
+		if tool.Type == "namespace" && len(tool.Tools) > 0 {
+			expanded = append(expanded, expandResponseNamespaceTools(tool.Tools)...)
+			continue
+		}
+		if len(tool.Tools) > 0 {
+			tool.Tools = expandResponseNamespaceTools(tool.Tools)
+		}
+		expanded = append(expanded, tool)
+	}
+	return expanded
+}
+
+func copyUpstreamResponseBody(target io.Writer, source io.Reader, responseWriter http.ResponseWriter) (int64, error) {
+	buffer := make([]byte, 32*1024)
+	flusher, _ := responseWriter.(http.Flusher)
+	var written int64
+	for {
+		n, readErr := source.Read(buffer)
+		if n > 0 {
+			chunk := buffer[:n]
+			writeN, writeErr := target.Write(chunk)
+			written += int64(writeN)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if writeN != n {
+				return written, io.ErrShortWrite
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if readErr == io.EOF {
+			return written, nil
+		}
+		if readErr != nil {
+			return written, readErr
+		}
+	}
+}
+
+type openAIStreamMonitor struct {
+	Bytes        int64
+	Terminal     string
+	ErrorType    string
+	ErrorCode    string
+	ErrorMessage string
+	preview      []byte
+
+	lineBuf   []byte
+	eventName string
+	dataLines []string
+}
+
+func (m *openAIStreamMonitor) Write(p []byte) (int, error) {
+	m.Bytes += int64(len(p))
+	if len(m.preview) < 2048 {
+		remaining := 2048 - len(m.preview)
+		if len(p) < remaining {
+			remaining = len(p)
+		}
+		m.preview = append(m.preview, p[:remaining]...)
+	}
+	for _, b := range p {
+		if b == '\n' {
+			m.processLine(string(m.lineBuf))
+			m.lineBuf = m.lineBuf[:0]
+			continue
+		}
+		m.lineBuf = append(m.lineBuf, b)
+	}
+	return len(p), nil
+}
+
+func (m *openAIStreamMonitor) Preview() string {
+	return strings.TrimSpace(string(m.preview))
+}
+
+func (m *openAIStreamMonitor) Finish() {
+	if len(m.lineBuf) > 0 {
+		m.processLine(string(m.lineBuf))
+		m.lineBuf = nil
+	}
+	m.finishEvent()
+}
+
+func (m *openAIStreamMonitor) processLine(line string) {
+	line = strings.TrimSuffix(line, "\r")
+	if strings.TrimSpace(line) == "" {
+		m.finishEvent()
+		return
+	}
+	if strings.HasPrefix(line, "event:") {
+		m.eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		return
+	}
+	if strings.HasPrefix(line, "data:") {
+		m.dataLines = append(m.dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+	}
+}
+
+func (m *openAIStreamMonitor) finishEvent() {
+	if m.eventName == "" && len(m.dataLines) == 0 {
+		return
+	}
+	data := strings.Join(m.dataLines, "\n")
+	if data == "[DONE]" {
+		m.Terminal = "[DONE]"
+	} else if m.eventName == "response.completed" || m.eventName == "response.failed" || m.eventName == "error" {
+		m.Terminal = m.eventName
+		m.captureError(data)
+	} else if data != "" {
+		m.captureTerminalFromData(data)
+	}
+	m.eventName = ""
+	m.dataLines = nil
+}
+
+func (m *openAIStreamMonitor) captureTerminalFromData(data string) {
+	var payload struct {
+		Type     string             `json:"type"`
+		Error    openai.ErrorObject `json:"error"`
+		Response struct {
+			Status string              `json:"status"`
+			Error  *openai.ErrorObject `json:"error"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		return
+	}
+	switch payload.Type {
+	case "response.completed", "response.failed", "error":
+		m.Terminal = payload.Type
+		m.captureErrorFromPayload(payload.Error, payload.Response.Error)
+	}
+}
+
+func (m *openAIStreamMonitor) captureError(data string) {
+	if data == "" || data == "[DONE]" {
+		return
+	}
+	var payload struct {
+		Error    openai.ErrorObject `json:"error"`
+		Response struct {
+			Error *openai.ErrorObject `json:"error"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		return
+	}
+	m.captureErrorFromPayload(payload.Error, payload.Response.Error)
+}
+
+func (m *openAIStreamMonitor) captureErrorFromPayload(eventErr openai.ErrorObject, responseErr *openai.ErrorObject) {
+	if eventErr.Message != "" || eventErr.Type != "" || eventErr.Code != "" {
+		m.ErrorType = eventErr.Type
+		m.ErrorCode = eventErr.Code
+		m.ErrorMessage = eventErr.Message
+	}
+	if responseErr != nil && (m.ErrorMessage == "" && m.ErrorType == "" && m.ErrorCode == "") {
+		m.ErrorType = responseErr.Type
+		m.ErrorCode = responseErr.Code
+		m.ErrorMessage = responseErr.Message
 	}
 }

--- a/internal/service/server/dispatch.go
+++ b/internal/service/server/dispatch.go
@@ -506,9 +506,9 @@ func (server *Server) handleOpenAIResponse(writer http.ResponseWriter, request *
 		if monitor != nil {
 			monitor.Finish()
 			if monitor.Terminal == "response.completed" {
-				log.Info("OpenAI Responses 直通流结束", "status", upstreamResp.StatusCode, "content_type", upstreamResp.Header.Get("Content-Type"), "terminal", monitor.Terminal, "bytes", monitor.Bytes)
+				log.Info("OpenAI Responses stream completed", "status", upstreamResp.StatusCode, "content_type", upstreamResp.Header.Get("Content-Type"), "terminal", monitor.Terminal, "bytes", monitor.Bytes, "monitor_truncated", monitor.Truncated)
 			} else {
-				log.Warn("OpenAI Responses 直通流未以 completed 结束", "status", upstreamResp.StatusCode, "content_type", upstreamResp.Header.Get("Content-Type"), "terminal", monitor.Terminal, "error_type", monitor.ErrorType, "error_code", monitor.ErrorCode, "error_message", monitor.ErrorMessage, "bytes", monitor.Bytes, "body_preview", monitor.Preview())
+				log.Warn("OpenAI Responses stream ended without response.completed", "status", upstreamResp.StatusCode, "content_type", upstreamResp.Header.Get("Content-Type"), "terminal", monitor.Terminal, "error_type", monitor.ErrorType, "error_code", monitor.ErrorCode, "error_message", monitor.ErrorMessage, "bytes", monitor.Bytes, "monitor_truncated", monitor.Truncated)
 			}
 		}
 
@@ -615,29 +615,33 @@ func copyUpstreamResponseBody(target io.Writer, source io.Reader, responseWriter
 	}
 }
 
+const openAIStreamMonitorMaxParseBytes = 64 * 1024
+
 type openAIStreamMonitor struct {
 	Bytes        int64
 	Terminal     string
 	ErrorType    string
 	ErrorCode    string
 	ErrorMessage string
-	preview      []byte
+	Truncated    bool
 
-	lineBuf   []byte
-	eventName string
-	dataLines []string
+	parsedBytes int
+	lineBuf     []byte
+	eventName   string
+	dataLines   []string
 }
 
 func (m *openAIStreamMonitor) Write(p []byte) (int, error) {
 	m.Bytes += int64(len(p))
-	if len(m.preview) < 2048 {
-		remaining := 2048 - len(m.preview)
-		if len(p) < remaining {
-			remaining = len(p)
-		}
-		m.preview = append(m.preview, p[:remaining]...)
-	}
 	for _, b := range p {
+		if m.Truncated {
+			continue
+		}
+		if m.parsedBytes >= openAIStreamMonitorMaxParseBytes {
+			m.truncateParsing()
+			continue
+		}
+		m.parsedBytes++
 		if b == '\n' {
 			m.processLine(string(m.lineBuf))
 			m.lineBuf = m.lineBuf[:0]
@@ -648,16 +652,22 @@ func (m *openAIStreamMonitor) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (m *openAIStreamMonitor) Preview() string {
-	return strings.TrimSpace(string(m.preview))
-}
-
 func (m *openAIStreamMonitor) Finish() {
+	if m.Truncated {
+		return
+	}
 	if len(m.lineBuf) > 0 {
 		m.processLine(string(m.lineBuf))
 		m.lineBuf = nil
 	}
 	m.finishEvent()
+}
+
+func (m *openAIStreamMonitor) truncateParsing() {
+	m.Truncated = true
+	m.lineBuf = nil
+	m.eventName = ""
+	m.dataLines = nil
 }
 
 func (m *openAIStreamMonitor) processLine(line string) {

--- a/internal/service/server/dispatch_internal_test.go
+++ b/internal/service/server/dispatch_internal_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpenAIStreamMonitorTruncatesParsingWithoutBlockingWrites(t *testing.T) {
+	monitor := &openAIStreamMonitor{}
+	payload := strings.Repeat("x", openAIStreamMonitorMaxParseBytes+1024)
+
+	n, err := monitor.Write([]byte(payload))
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("Write() bytes = %d, want %d", n, len(payload))
+	}
+	if monitor.Bytes != int64(len(payload)) {
+		t.Fatalf("Bytes = %d, want %d", monitor.Bytes, len(payload))
+	}
+	if !monitor.Truncated {
+		t.Fatal("Truncated = false, want true")
+	}
+	if len(monitor.lineBuf) != 0 || len(monitor.dataLines) != 0 || monitor.eventName != "" {
+		t.Fatalf("monitor buffers were not cleared: line=%d data=%d event=%q", len(monitor.lineBuf), len(monitor.dataLines), monitor.eventName)
+	}
+
+	monitor.Finish()
+	if monitor.Terminal != "" || monitor.ErrorMessage != "" {
+		t.Fatalf("Finish() parsed truncated data: terminal=%q error=%q", monitor.Terminal, monitor.ErrorMessage)
+	}
+}

--- a/internal/service/server/server_test.go
+++ b/internal/service/server/server_test.go
@@ -10,16 +10,17 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"moonbridge/internal/config"
 	"moonbridge/internal/extension/codex"
 	deepseekv4 "moonbridge/internal/extension/deepseek_v4"
 	"moonbridge/internal/extension/plugin"
-	"moonbridge/internal/config"
+	"moonbridge/internal/format"
 	"moonbridge/internal/logger"
 	"moonbridge/internal/protocol/openai"
-	"moonbridge/internal/format"
 	"moonbridge/internal/service/provider"
 	"moonbridge/internal/service/server"
 	"moonbridge/internal/service/stats"
@@ -82,7 +83,6 @@ func (provider providerFunc) StreamMessage(ctx context.Context, req any) (<-chan
 	return provider.stream(ctx, req)
 }
 
-
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -93,6 +93,22 @@ type captureCompletionPlugin struct {
 	plugin.BasePlugin
 	result plugin.RequestResult
 	called bool
+}
+
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushes int
+}
+
+func newFlushRecorder() *flushRecorder {
+	return &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *flushRecorder) Flush() {
+	r.flushes++
+	if r.Code == 0 {
+		r.WriteHeader(http.StatusOK)
+	}
 }
 
 func (p *captureCompletionPlugin) Name() string { return "capture_completion" }
@@ -753,6 +769,125 @@ func TestResponsesHandlerPassesOpenAIStreamUsageToMetrics(t *testing.T) {
 	}
 	if usage.NormalizedInputTokens != 90 || capture.result.InputTokens != 90 || usage.NormalizedCacheCreation != 0 {
 		t.Fatalf("normalized usage = %+v result=%+v", usage, capture.result)
+	}
+}
+
+func TestResponsesHandlerFlushesOpenAIStreamPassthrough(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+				`event: response.created`,
+				`data: {"type":"response.created","response":{"id":"resp_1","status":"in_progress"}}`,
+				``,
+				`event: response.completed`,
+				`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}`,
+				``,
+			}, "\n"))),
+		}, nil
+	})}
+
+	providerMgr, err := provider.NewProviderManager(map[string]provider.ProviderConfig{
+		"openai": {
+			BaseURL:  "https://openai.example.test",
+			APIKey:   "openai-key",
+			Protocol: config.ProtocolOpenAIResponse,
+		},
+	}, map[string]provider.ModelRoute{
+		"gpt-direct": {Provider: "openai", Name: "gpt-upstream"},
+	})
+	if err != nil {
+		t.Fatalf("NewProviderManager() error = %v", err)
+	}
+	handler := server.New(server.Config{
+		ProviderMgr:      providerMgr,
+		OpenAIHTTPClient: httpClient,
+	})
+
+	recorder := newFlushRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(`{"model":"gpt-direct","input":"hello","stream":true}`))
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if recorder.flushes == 0 {
+		t.Fatalf("expected stream passthrough to flush writes")
+	}
+	if !strings.Contains(recorder.Body.String(), "event: response.completed") {
+		t.Fatalf("stream response missing response.completed: %s", recorder.Body.String())
+	}
+}
+
+func TestResponsesHandlerExpandsNamespaceToolsForOpenAIStreamPassthrough(t *testing.T) {
+	var upstreamRequest openai.ResponsesRequest
+	httpClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(request.Body).Decode(&upstreamRequest); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+				`event: response.completed`,
+				`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}`,
+				``,
+			}, "\n"))),
+		}, nil
+	})}
+
+	providerMgr, err := provider.NewProviderManager(map[string]provider.ProviderConfig{
+		"openai": {
+			BaseURL:  "https://openai.example.test",
+			APIKey:   "openai-key",
+			Protocol: config.ProtocolOpenAIResponse,
+		},
+	}, map[string]provider.ModelRoute{
+		"gpt-direct": {Provider: "openai", Name: "gpt-upstream"},
+	})
+	if err != nil {
+		t.Fatalf("NewProviderManager() error = %v", err)
+	}
+	handler := server.New(server.Config{
+		ProviderMgr:      providerMgr,
+		OpenAIHTTPClient: httpClient,
+	})
+
+	body := `{
+		"model":"gpt-direct",
+		"input":"hello",
+		"stream":true,
+		"tools":[
+			{"type":"function","name":"top_level","parameters":{"type":"object"}},
+			{"type":"namespace","name":"multi_agent_v1","tools":[
+				{"type":"function","name":"spawn_agent","parameters":{"type":"object"}},
+				{"type":"function","name":"wait_agent","parameters":{"type":"object"}}
+			]}
+		]
+	}`
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if upstreamRequest.Model != "gpt-upstream" {
+		t.Fatalf("upstream model = %q", upstreamRequest.Model)
+	}
+	if len(upstreamRequest.Tools) != 3 {
+		t.Fatalf("tools len = %d, tools = %+v", len(upstreamRequest.Tools), upstreamRequest.Tools)
+	}
+	for _, tool := range upstreamRequest.Tools {
+		if tool.Type == "namespace" {
+			t.Fatalf("namespace tool was not expanded: %+v", tool)
+		}
+	}
+	gotNames := []string{upstreamRequest.Tools[0].Name, upstreamRequest.Tools[1].Name, upstreamRequest.Tools[2].Name}
+	wantNames := []string{"top_level", "spawn_agent", "wait_agent"}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("tool names = %+v, want %+v", gotNames, wantNames)
 	}
 }
 


### PR DESCRIPTION
## 变更内容

对于MiniMax这样的大模型而言，有些API兼容性问题需要解决，否则codex无法使用：

1. 将 Chat 函数工具中默认缺省的 parameters 补为 { "type": "object" }，这样即使某些 provider 拒绝缺失 parameters，也仍然可以接受工具定义。
2. 将 MiniMax 风格的 <think>...</think> 内容拆分为 reasoning blocks，同时支持非流式和流式 Chat 响应，确保 Codex 看到的最终 output_text 保持干净。
3. 在非流式以及已完成的流式 Responses 输出中，保留上游 Chat 模型名称。

MiniMax 当前在函数工具省略 parameters 时会拒绝请求，返回 invalid params, 400 (2013)。此外，它会把 reasoning 内容放在 <think> 标签中，并作为普通 Chat content 输出；如果不处理，这些内容会泄漏到 Codex 可见的输出文本中。

我也直接针对 /v1/chat/completions 验证了原始 MiniMax 的 stream=true + tools 请求；当前它会返回 HTTP 200，并通过流式 tool_calls delta 输出工具调用。因此，这个 PR 没有为该路径增加非流式 fallback。

## 验证
```bash
go test ./internal/protocol/chat ./internal/protocol/openai ./internal/service/server ./internal/config
```

原始 MiniMax 端点验证：
* stream=true + tools 返回 HTTP 200，并输出了 tool_calls
* 未显式设置 parameters 的 function tool 返回 HTTP 400，错误为 invalid params, 400 (2013)

通过临时本地实例验证 Moon Bridge：
* 未显式设置 parameters 的 function tool 返回 HTTP 200，并生成了 function_call 参数 {}
* <think> 内容被作为 reasoning summary events 输出，而不是作为 output_text

