### PR TITLE
fix(stream): visual orchestrator blocks real streaming for text-only requests

### DIFF
--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -941,22 +941,25 @@ func (s *Server) handleAdapterStream(
 		}
 
 		var visCoreProvider visualpkg.CoreProvider
-		if provAdapter, ok := s.adapterRegistry.GetProvider(candidate.Protocol); ok {
-			finalizeAnthropicUpstream := func(_ context.Context, upstream any) (any, error) {
-				msgReq, err := normalizeAnthropicRequest(upstream)
-				if err != nil {
-					return nil, err
+		hasImage := coreRequestHasImage(coreReq)
+		if hasImage {
+			if provAdapter, ok := s.adapterRegistry.GetProvider(candidate.Protocol); ok {
+				finalizeAnthropicUpstream := func(_ context.Context, upstream any) (any, error) {
+					msgReq, err := normalizeAnthropicRequest(upstream)
+					if err != nil {
+						return nil, err
+					}
+					if wsMode == "enabled" {
+						injectAnthropicWebSearch(&msgReq)
+					}
+					if s.pluginRegistry != nil && sess != nil {
+						prependCachedThinking(&msgReq, sess)
+					}
+					return &msgReq, nil
 				}
-				if wsMode == "enabled" {
-					injectAnthropicWebSearch(&msgReq)
+				if visProv := s.wrapWithVisual(ctx, openAIReq.Model, candidate, provAdapter, finalizeAnthropicUpstream); visProv != nil {
+					visCoreProvider = visProv
 				}
-				if s.pluginRegistry != nil && sess != nil {
-					prependCachedThinking(&msgReq, sess)
-				}
-				return &msgReq, nil
-			}
-			if visProv := s.wrapWithVisual(ctx, openAIReq.Model, candidate, provAdapter, finalizeAnthropicUpstream); visProv != nil {
-				visCoreProvider = visProv
 			}
 		}
 
@@ -977,9 +980,10 @@ func (s *Server) handleAdapterStream(
 			writeOpenAIError(w, http.StatusInternalServerError, payload)
 			return
 		}
-		// Strip image blocks from anthropic request if visual extension is enabled.
-		// This prevents base64 image data from being sent to text-only models.
-		if s.pluginRegistry != nil && s.runtime != nil && openAIReq.Model != "" {
+		// Strip image blocks from anthropic request if visual extension is enabled
+		// and images are present. This prevents base64 image data from being sent to
+		// text-only models while keeping pure-text requests on the real streaming path.
+		if hasImage && s.pluginRegistry != nil && s.runtime != nil && openAIReq.Model != "" {
 			cfgV := s.runtime.Current().Config
 			visCfg, visOk := visualpkg.ConfigForModelFromResolvedConfig(cfgV, openAIReq.Model)
 			if visOk && visCfg.Provider != "" && visCfg.Model != "" {


### PR DESCRIPTION
## 问题

当 visual 扩展为模型启用时，`handleAdapterStream` 无条件将上游包裹为 `CoreOrchestrator`，即使请求中没有图片。

`CoreOrchestrator.CreateCore()` 是同步方法——等待上游完整生成后才返回，然后 `coreResponseToCoreStream` 将完整响应拆成模拟 SSE 事件发送。这导致**假流式**：客户端等待很久后瞬间收到全部 SSE 事件。

## 根因

`adapter_dispatch.go` 中 `case ProtocolAnthropic` 流式分支（~line 943）的 `wrapWithVisual` 调用缺少图片存在性检查。已有图片的早期 return 路径（line 866）正确处理了有图片的情况，但纯文本请求落入下方分支时仍被 visual 编排器接管。

## 修复

- 在创建 `visCoreProvider` 前加入 `coreRequestHasImage(coreReq)` 守卫
- 同理守卫图片剥离逻辑
- 纯文本请求走真正的 `StreamMessage → ToCoreStream → SSE` 路径，逐 token flush

## 验证

修复前后用 curl 测试：

```bash
curl -N http://127.0.0.1:38440/v1/responses   -H "Content-Type: application/json"   -d '{"model":"moonbridge","input":"hello","stream":true}'
```

修复前：等待 ~10s 后一瞬间收到全部事件。  
修复后：`reasoning_summary_text.delta` 和 `output_text.delta` 逐 token 到达。