### PR TITLE
fix: only set tool_choice when tools are defined

### DIFF
--- a/internal/protocol/anthropic/adapter.go
+++ b/internal/protocol/anthropic/adapter.go
@@ -326,7 +326,9 @@ func (a *AnthropicProviderAdapter) FromCoreRequest(ctx context.Context, req *for
 	if req.ToolChoice != nil {
 		tc := a.toAnthropicToolChoice(*req.ToolChoice)
 		anthropicReq.ToolChoice = &tc
-	} else {
+	} else if len(anthropicReq.Tools) > 0 {
+		// Only set tool_choice to auto if there are tools defined.
+		// Otherwise, upstream providers like DashScope will reject the request.
 		anthropicReq.ToolChoice = &ToolChoice{Type: "auto"}
 	}
 


### PR DESCRIPTION
## Problem

When a request contains no tools, the Anthropic adapter was unconditionally setting `tool_choice` to `"auto"`. This causes upstream providers like **DashScope/Alibaba Bailian** to reject the request with the error:

```
InvalidParameter: When using `tool_choice`, `tools` must be set.
```

## Root Cause

In `internal/protocol/anthropic/adapter.go`, the `FromCoreRequest` function always set `tool_choice = "auto"` as a fallback:

```go
if req.ToolChoice != nil {
    tc := a.toAnthropicToolChoice(*req.ToolChoice)
    anthropicReq.ToolChoice = &tc
} else {
    anthropicReq.ToolChoice = &ToolChoice{Type: "auto"}
}
```

While the official Anthropic API may tolerate `tool_choice` without `tools`, stricter Anthropic-compatible providers like DashScope reject it.

## Fix

Only set `tool_choice` when tools are actually present:

```go
if req.ToolChoice != nil {
    tc := a.toAnthropicToolChoice(*req.ToolChoice)
    anthropicReq.ToolChoice = &tc
} else if len(anthropicReq.Tools) > 0 {
    anthropicReq.ToolChoice = &ToolChoice{Type: "auto"}
}
```

## Testing

Tested with DashScope (Alibaba Bailian) Anthropic-compatible endpoint:
- ✅ `qwen3.7-plus` requests without tools now succeed
- ✅ `qwen3.7-max` requests without tools now succeed
- ✅ `deepseek-v4-flash` requests without tools now succeed
- ✅ `qwen3.6-flash` requests without tools now succeed
- ✅ Requests with tools still work as before (tool_choice correctly set to auto)

## Impact

Minimal. This is a defensive fix that only affects behavior when no tools are defined — previously these requests would fail on strict providers; now they work correctly. Requests with tools are unaffected.