### PR TITLE
Ignore local runtime logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ build/
 .dev.vars
 /moonbridge
 logs/
+*.log


### PR DESCRIPTION
Stabilization PR from the atimics fork.\n\nAdds a narrow ignore rule for local runtime log files so  does not dirty the worktree. No source behavior changes.