### PR TITLE
fix(openai/adapter): handle tool_search type to avoid empty tool name

### DIFF
--- a/internal/protocol/openai/adapter.go
+++ b/internal/protocol/openai/adapter.go
@@ -1869,6 +1869,13 @@ func convertToolWithNamespace(tool Tool, namespace string, disablePatchProxy fun
 			Description: "Search the web for up-to-date information.",
 			Extensions:  ext,
 		}}
+	case "tool_search":
+		ext["source_type"] = tool.Type
+		return []format.CoreTool{{
+			Name:        tool.Type,
+			Description: "Search over deferred tool metadata and expose matching tools for the next model call.",
+			Extensions:  ext,
+		}}
 	case "file_search":
 		ext["source_type"] = tool.Type
 		ext["max_num_results"] = tool.MaxNumResults


### PR DESCRIPTION
Codex（Version 26.616.81150 •  @ 2026\6\24） sends tools with type "tool_search" but no name field. Previously this fell through to the default case and produced an empty tool name, which upstream providers (e.g. DeepSeek) reject.

Assign the synthetic name "tool_search" like web_search/file_search.

Fixes: Invalid 'tools[15].function.name': empty string

It appears when using the router. eg gpt-5.4 to deepseek-v4-pro