### PR TITLE
fix: filter empty tool names in responses API path

### DIFF
--- a/internal/service/server/adapter_dispatch.go
+++ b/internal/service/server/adapter_dispatch.go
@@ -126,6 +126,10 @@ func (s *Server) handleWithAdapters(
 		writeOpenAIError(w, http.StatusInternalServerError, payload)
 		return
 	}
+	// Filter out tools with empty names — Codex desktop sometimes sends
+	// tools with empty names that upstream APIs (DeepSeek, Qwen) reject
+	// with a 400 error.
+	coreReq.Tools = filterEmptyCoreToolNames(coreReq.Tools)
 
 	// ------------------------------------------------------------------
 	// 3. Pick upstream provider candidate, resolve ProviderAdapter.

--- a/internal/service/server/filter_empty_tools.go
+++ b/internal/service/server/filter_empty_tools.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"moonbridge/internal/format"
+)
+
+// filterEmptyCoreToolNames removes tools whose name is empty.
+// Codex desktop sometimes sends tools with empty names that
+// upstream APIs (DeepSeek, Qwen) reject with a 400 error.
+func filterEmptyCoreToolNames(tools []format.CoreTool) []format.CoreTool {
+	if len(tools) == 0 {
+		return tools
+	}
+	filtered := make([]format.CoreTool, 0, len(tools))
+	for _, t := range tools {
+		if t.Name != "" {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}

--- a/internal/service/server/filter_empty_tools_test.go
+++ b/internal/service/server/filter_empty_tools_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"moonbridge/internal/format"
+	"testing"
+)
+
+func TestFilterEmptyCoreToolNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		tools    []format.CoreTool
+		expected int
+	}{
+		{
+			name:     "empty tools",
+			tools:    []format.CoreTool{},
+			expected: 0,
+		},
+		{
+			name: "no empty names",
+			tools: []format.CoreTool{
+				{Name: "tool1"},
+				{Name: "tool2"},
+			},
+			expected: 2,
+		},
+		{
+			name: "one empty name at end",
+			tools: []format.CoreTool{
+				{Name: "tool1"},
+				{Name: "tool2"},
+				{Name: ""},
+			},
+			expected: 2,
+		},
+		{
+			name: "one empty name in middle",
+			tools: []format.CoreTool{
+				{Name: "tool1"},
+				{Name: ""},
+				{Name: "tool3"},
+			},
+			expected: 2,
+		},
+		{
+			name: "all empty names",
+			tools: []format.CoreTool{
+				{Name: ""},
+				{Name: ""},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterEmptyCoreToolNames(tt.tools)
+			if len(result) != tt.expected {
+				t.Errorf("filterEmptyCoreToolNames() returned %d tools, want %d", len(result), tt.expected)
+			}
+			// Verify no empty names remain
+			for _, tool := range result {
+				if tool.Name == "" {
+					t.Errorf("filtered result still contains tool with empty name")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 问题

Codex desktop 有时会发送包含空名称工具的工具列表，上游 API（DeepSeek、Qwen）严格校验会拒绝，导致 502 错误：

```
Invalid 'tools[36].function.name': empty string. Expected a string with minimum length 1
```

## 根因

现有的 `filterEmptyToolNames()` 只在 chat completions 路径（处理 `ChatTool` 类型）生效，但 responses API 路径（`handleWithAdapters`）使用 `CoreTool` 类型，没有过滤空名称工具。

## 修复

- 新增 `filterEmptyCoreToolNames()` 函数，在 `ToCoreRequest` 转换后过滤 `CoreTool` 列表中的空名称工具
- 添加完整的单元测试覆盖各种边界情况

## 变更文件

- `internal/service/server/adapter_dispatch.go`: 在 responses API 路径调用过滤函数
- `internal/service/server/filter_empty_tools.go`: 新增过滤函数实现
- `internal/service/server/filter_empty_tools_test.go`: 新增单元测试

## 测试

```bash
go test ./internal/service/server -run TestFilterEmptyCoreToolNames -v
```

所有测试用例通过：
- empty_tools
- no_empty_names
- one_empty_name_at_end
- one_empty_name_in_middle
- all_empty_names