### PR TITLE
fix: use max_tokens instead of max_completion_tokens for DeepSeek com…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,17 @@ module moonbridge
 
 go 1.25.0
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/invopop/jsonschema v0.14.0
+	gopkg.in/yaml.v3 v3.0.1
+	modernc.org/sqlite v1.50.0
+)
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
@@ -20,5 +23,4 @@ require (
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
-	modernc.org/sqlite v1.50.0 // indirect
 )

--- a/internal/protocol/chat/types.go
+++ b/internal/protocol/chat/types.go
@@ -14,7 +14,7 @@ type ChatRequest struct {
 	Messages          []ChatMessage   `json:"messages"`
 	Temperature       *float64        `json:"temperature,omitempty"`
 	TopP              *float64        `json:"top_p,omitempty"`
-	MaxTokens         int             `json:"max_completion_tokens,omitempty"`
+	MaxTokens         int             `json:"max_tokens,omitempty"`
 	Stop              []string        `json:"stop,omitempty"`
 	Stream            bool            `json:"stream,omitempty"`
 	Tools             []ChatTool      `json:"tools,omitempty"`


### PR DESCRIPTION
…patibility

DeepSeek API expects max_tokens in the request body, but ChatRequest.MaxTokens was serialized as max_completion_tokens (the OpenAI o-series field name). This caused DeepSeek to ignore or reject the token limit, leading to cryptic errors during long conversations with heavy tool use.