### PR TITLE
fix: 修复 README 中火山引擎 logo 空链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Moon Bridge 是一个用 Go 编写的协议转换与模型路由代理。对外�
 
   <tr>
     <td align="center" width="160">
-      <a href=" "><img src="./Images/volcano.png" alt="火山引擎" height="32"></a ><br>
+      <a href="https://www.volcengine.com/"><img src="./Images/volcano.png" alt="火山引擎" height="32"></a><br>
       <a href="https://dis.chatdesks.cn/chatdesk/hsyqmoon-bridge.html"><strong>方舟 Agent Plan</strong></a >
     </td>
     <td align="left">


### PR DESCRIPTION
## 改动内容

修复 [README.md](https://github.com/ZhiYi-R/moon-bridge/blob/main/README.md) 赞助商表格中火山引擎 logo 的无效链接：

```diff
- <a href=" "><img src="./Images/volcano.png" alt="火山引擎" height="32"></a ><br>
+ <a href="https://www.volcengine.com/"><img src="./Images/volcano.png" alt="火山引擎" height="32"></a><br>
```

## 背景

该空链接（`href=" "`）由最近一次提交 c9ae8a8 引入，导致点击火山引擎 logo 无响应。此 PR 将其指向火山引擎官网，并顺带清理了 `</a >` 中的多余空格。

## 验证

- `git blame` 确认该问题由 HEAD 提交引入
- 纯文档改动，不影响任何代码，无需运行测试

> 注：CONTRIBUTING.md 提到 PR 合入 dev 分支，但远端目前没有 dev 分支（HEAD 指向 main），故 base 暂选 main，如有需要可改。